### PR TITLE
BUG-FIX: grunt.config.data were extended for every call

### DIFF
--- a/tasks/assemble.js
+++ b/tasks/assemble.js
@@ -598,8 +598,13 @@ module.exports = function(grunt) {
    * @return {[type]}         [description]
    */
   var processContext = function(grunt, context, data) {
+    var currentGruntConfigData = grunt.config.data;
+
     grunt.config.data = _.extend({}, grunt.config.data, context, data);
-    return grunt.config.process(data || context);
+    var processed = grunt.config.process(data || context);
+
+    grunt.config.data = currentGruntConfigData;
+    return processed;
   };
 
 


### PR DESCRIPTION
Context was added to `grunt.config.data` and it was becoming available for all pages unless overwritten in YFM. As `grunt.config.process` requires `grunt.config.data`, so moved `grunt.config.data` to a *temp*, then extended, called process and get back the original from *temp*.