### PR TITLE
Identation fix for body into layout

### DIFF
--- a/tasks/assemble.js
+++ b/tasks/assemble.js
@@ -719,7 +719,19 @@ module.exports = function(grunt) {
    * @return {String}         The raw, assembled, uncompiled and unprocessed page
    */
   var injectBody = function(layout, body) {
-    return layout.replace(assemble.engine.bodyRegex, function () { return body; });
+    var indentation = getIndentation(layout);
+    var bodyWithIndentation = _.map(body.split('\n'), function (line){
+      return line.replace(/^/, indentation);
+    }).join('\n');
+    return layout.replace(assemble.engine.bodyRegex, function () { return bodyWithIndentation; });
+  };
+
+  var getIndentation = function(layout) {
+    var bodyRegex = assemble.engine.bodyRegex;
+    var bodyRegexWithIndentation = new RegExp(/\s*/.source + bodyRegex.source);
+
+    return layout.match(bodyRegexWithIndentation)[0]
+      .replace(bodyRegex, '');
   };
 
 };


### PR DESCRIPTION
when the body tag is inserted into a layout, the insertion point is
maintained which is important for identation based template languages,
like jade.