### PR TITLE
collection.sort: fix sorting

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -46,6 +46,27 @@ collection.update = function(col, page, context) {
   return col;
 };
 
+function compare (a, b) {
+
+  if(a && b) {
+    if(a < b) {
+      return -1;
+    } else if (a > b) {
+      return 1;
+    } else {
+      return 0;
+    }
+  } else {
+    // pages without {sortby} field will at the end of collection
+    if (!a && !b) { 
+      return 0; 
+    }
+    if (!a) { 
+      return 1; 
+    }
+    return -1;
+  }
+}
 
 collection.sort = function(col) {
   'use strict';
@@ -60,15 +81,7 @@ collection.sort = function(col) {
 
     // sort items by the actual item
     col.items.sort(function(a, b) {
-      if(a[col.inflection] && b[col.inflection]) {
-        if(a[col.inflection] < b[col.inflection]) {
-          return -1;
-        } else if (a[col.inflection] > b[col.inflection]) {
-          return 1;
-        } else {
-          return 0;
-        }
-      }
+      return compare(a[col.inflection], b[col.inflection]);
     });
 
     if(sortorder !== 'ASC') {
@@ -81,17 +94,7 @@ collection.sort = function(col) {
     col.items.forEach(function(item) {
 
       item.pages.sort(function(a, b) {
-        if(a.data[sortby] && b.data[sortby]) {
-          if(a.data[sortby] < b.data[sortby]) {
-            return -1;
-          } else if (a.data[sortby] > b.data[sortby]) {
-            return 1;
-          } else {
-            return 0;
-          }
-        } else {
-          return 0;
-        }
+        return compare(a.data[sortby], b.data[sortby]);
       });
 
       if(sortorder !== 'ASC') {


### PR DESCRIPTION
Pages w/o name (or 'orderby' collection's field) were at random order, now they will be at the end of collection.
Common comparing logic was extracted into `compare` method.