### PR TITLE
Do not wipe out context.data, breaking @key, @index, etc in partials

### DIFF
--- a/tasks/assemble.js
+++ b/tasks/assemble.js
@@ -541,7 +541,6 @@ module.exports = function(grunt) {
       }
 
       // extend again
-      options.data = undefined;
       options.pages = undefined;
       options.layout = undefined;
       options.collections = undefined;


### PR DESCRIPTION
This fixes the problems addressed in #22 and #41. 

In the code without my patch, `options.data` is set to `undefined`, and then a few lines later we're merging all these objects, which causes the newly undefined `options.data` to wipe out any good object that we might have. As far as I can tell by tracing where options.data comes from and is used again, setting it to undefined again serves no useful purpose.

Big thanks to @yongtw123 for pointing me in the right direction in #22.