### PR TITLE
BUG-FIX Passing an object to options.data causes an error

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,7 +56,11 @@ module.exports = function(grunt) {
         helpers: ['test/helpers/*.js'],
         layoutdir: 'test/fixtures/layouts',
         layout: 'default.hbs',
-        flatten: true
+        flatten: true,
+        data: {
+          global1: "globalData1",
+          global2: "globalData2"
+        }
       },
       // Should render pages with `layout: false` or `layout: none` defined
       no_layout: {
@@ -332,6 +336,29 @@ module.exports = function(grunt) {
         },
         files: {
           'test/actual/globlayout/multi': ['test/fixtures/pages/globlayout/globlayout.hbs']
+        }
+      },
+      // Should process pages no YAML front matter defined
+      noyfmdata: {
+        options: {
+          data: {
+            one: "1-one",
+            two: "2-two",
+            three: "3-three",
+            global1: "override global1 data via task option"
+          }
+        },
+        files: {
+          'test/actual/noyfm/no-yfm-data.html': ['test/fixtures/pages/no-yfm-data.hbs']
+        }
+      },
+      // Should process pages no YAML front matter defined
+      noyfmdatafile: {
+        options: {
+          data: 'test/fixtures/data/data.yml'
+        },
+        files: {
+          'test/actual/noyfm/no-yfm-datafile.html': ['test/fixtures/pages/no-yfm-data.hbs']
         }
       }
     },

--- a/lib/assemble.js
+++ b/lib/assemble.js
@@ -40,7 +40,8 @@ var Assemble = function() {
     this.options.originalAssets = this.options.assets;
     this.options.originalLayout = this.options.layout;
 
-    this.options.data = mergeOptionsArrays.apply(this, [task.target, 'data']);
+    this.options.data = mergeOptionsObjects.apply(this, [task.target, 'data']);
+    this.options.dataFiles = mergeGlobArrays.apply(this, [task.target, 'data']);
     this.options.partials = mergeOptionsArrays.apply(this, [task.target, 'partials']);
     this.options.collections = mergeOptionsArrays.apply(this, [task.target, 'collections']);
 
@@ -104,6 +105,25 @@ var Assemble = function() {
         return true;
       }
     });
+  };
+
+  var mergeOptionsObjects = function(target, name) {
+    var global = this.grunt.config(['assemble', 'options', name]);
+    var targetData = this.grunt.config(['assemble', target, 'options', name]);
+    return _.extend(
+      {},
+      _.isPlainObject(global) ? global : {},
+      _.isPlainObject(targetData) ? targetData : {}
+    );
+  };
+
+  var mergeGlobArrays = function(target, name) {
+    var globalArray = this.grunt.config(['assemble', 'options', name]) || [];
+    var targetArray = this.grunt.config(['assemble', target, 'options', name]) || [];
+    // skip plain objects -> contains JSON data
+    globalArray = _.isPlainObject(globalArray) ? [] : utils.arrayify(globalArray);
+    targetArray = _.isPlainObject(targetArray) ? [] : utils.arrayify(targetArray);
+    return _.flatten(globalArray.concat(targetArray));
   };
 
   var mergeOptionsArrays = function(target, name) {

--- a/tasks/assemble.js
+++ b/tasks/assemble.js
@@ -52,9 +52,9 @@ module.exports = function(grunt) {
 
       assemble.partials = file.expand(assemble.options.partials);
 
-      if(_.isArray(assemble.options.data)) {
-        assemble.dataFiles = file.expand(assemble.options.data);
-        assemble.options.data = {};
+      if(_.isArray(assemble.options.dataFiles) && assemble.options.dataFiles.length > 0) {
+        assemble.dataFiles = file.expand(assemble.options.dataFiles);
+        //assemble.options.data = {};
       }
 
       // Expand layout into layoutFiles if a glob pattern is specified

--- a/test/actual/assets_base.html
+++ b/test/actual/assets_base.html
@@ -20,33 +20,25 @@
 
       <ul class="pager">
 
-  
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">First</a>
     </li>
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">&larr; Previous</a>
     </li>
-  
 
-  
 
-  
     <li class="active pager-middle">
       <a href="assets_base.html">1</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
-  
 
 </ul><style>
 .unselectable {
@@ -66,33 +58,25 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
     <li class="prev disabled">
       <a unselectable="on" class="unselectable">First</a>
     </li>
     <li class="prev disabled">
       <a unselectable="on" class="unselectable">&larr; Previous</a>
     </li>
-  
 
-  
 
-  
     <li class="active">
       <a href="assets_base.html">1</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
-  
 
 </ul>
           </div>
@@ -113,18 +97,14 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
               </div>
               <div class="col-md-6">
-                
               </div>
             </div>
 
             <hr>
 
             <p>Examples to test the "relative" and "assets" variables, and to show how they work</p>
-
-
 
 
 
@@ -143,17 +123,11 @@ assets_base: {
 
 
 
-
-
-
-
             <div class="docs-header" id="content">
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="assets_base.html">assets_base.html</a></li>
-            
             </ul>
 
             <hr>
@@ -228,7 +202,6 @@ assets_base: {
                   basename:      assets
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>

--- a/test/actual/assets_blank_path.html
+++ b/test/actual/assets_blank_path.html
@@ -20,33 +20,25 @@
 
       <ul class="pager">
 
-  
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">First</a>
     </li>
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">&larr; Previous</a>
     </li>
-  
 
-  
 
-  
     <li class="active pager-middle">
       <a href="assets_blank_path.html">1</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
-  
 
 </ul><style>
 .unselectable {
@@ -66,33 +58,25 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
     <li class="prev disabled">
       <a unselectable="on" class="unselectable">First</a>
     </li>
     <li class="prev disabled">
       <a unselectable="on" class="unselectable">&larr; Previous</a>
     </li>
-  
 
-  
 
-  
     <li class="active">
       <a href="assets_blank_path.html">1</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
-  
 
 </ul>
           </div>
@@ -113,21 +97,14 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
               </div>
               <div class="col-md-6">
-                
               </div>
             </div>
 
             <hr>
 
             <p>Examples to test the "relative" and "assets" variables, and to show how they work</p>
-
-
-
-
-
 
 
 
@@ -146,14 +123,11 @@ assets_blank_path: {
 }
 </pre>
 
-
             <div class="docs-header" id="content">
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="assets_blank_path.html">assets_blank_path.html</a></li>
-            
             </ul>
 
             <hr>
@@ -228,7 +202,6 @@ assets_blank_path: {
                   basename:      assets
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>

--- a/test/actual/assets_dot_slash.html
+++ b/test/actual/assets_dot_slash.html
@@ -20,33 +20,25 @@
 
       <ul class="pager">
 
-  
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">First</a>
     </li>
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">&larr; Previous</a>
     </li>
-  
 
-  
 
-  
     <li class="active pager-middle">
       <a href="assets_dot_slash.html">1</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
-  
 
 </ul><style>
 .unselectable {
@@ -66,33 +58,25 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
     <li class="prev disabled">
       <a unselectable="on" class="unselectable">First</a>
     </li>
     <li class="prev disabled">
       <a unselectable="on" class="unselectable">&larr; Previous</a>
     </li>
-  
 
-  
 
-  
     <li class="active">
       <a href="assets_dot_slash.html">1</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
-  
 
 </ul>
           </div>
@@ -113,20 +97,14 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
               </div>
               <div class="col-md-6">
-                
               </div>
             </div>
 
             <hr>
 
             <p>Examples to test the "relative" and "assets" variables, and to show how they work</p>
-
-
-
-
 
 
 
@@ -145,15 +123,11 @@ assets_dot_slash: {
 
 
 
-
-
             <div class="docs-header" id="content">
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="assets_dot_slash.html">assets_dot_slash.html</a></li>
-            
             </ul>
 
             <hr>
@@ -228,7 +202,6 @@ assets_dot_slash: {
                   basename:      assets
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>

--- a/test/actual/assets_nested.html
+++ b/test/actual/assets_nested.html
@@ -20,33 +20,25 @@
 
       <ul class="pager">
 
-  
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">First</a>
     </li>
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">&larr; Previous</a>
     </li>
-  
 
-  
 
-  
     <li class="active pager-middle">
       <a href="assets_nested.html">1</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
-  
 
 </ul><style>
 .unselectable {
@@ -66,33 +58,25 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
     <li class="prev disabled">
       <a unselectable="on" class="unselectable">First</a>
     </li>
     <li class="prev disabled">
       <a unselectable="on" class="unselectable">&larr; Previous</a>
     </li>
-  
 
-  
 
-  
     <li class="active">
       <a href="assets_nested.html">1</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
-  
 
 </ul>
           </div>
@@ -113,17 +97,14 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
               </div>
               <div class="col-md-6">
-                
               </div>
             </div>
 
             <hr>
 
             <p>Examples to test the "relative" and "assets" variables, and to show how they work</p>
-
 
 <h1>"Public" Folder</h1>
 <p>Public (assets) folder is in the project root</p>
@@ -146,18 +127,11 @@ assets_nested: {
 
 
 
-
-
-
-
-
             <div class="docs-header" id="content">
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="assets_nested.html">assets_nested.html</a></li>
-            
             </ul>
 
             <hr>
@@ -232,7 +206,6 @@ assets_nested: {
                   basename:      assets
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>

--- a/test/actual/assets_trailing_slash.html
+++ b/test/actual/assets_trailing_slash.html
@@ -20,33 +20,25 @@
 
       <ul class="pager">
 
-  
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">First</a>
     </li>
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">&larr; Previous</a>
     </li>
-  
 
-  
 
-  
     <li class="active pager-middle">
       <a href="assets_trailing_slash.html">1</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
-  
 
 </ul><style>
 .unselectable {
@@ -66,33 +58,25 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
     <li class="prev disabled">
       <a unselectable="on" class="unselectable">First</a>
     </li>
     <li class="prev disabled">
       <a unselectable="on" class="unselectable">&larr; Previous</a>
     </li>
-  
 
-  
 
-  
     <li class="active">
       <a href="assets_trailing_slash.html">1</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
-  
 
 </ul>
           </div>
@@ -113,19 +97,14 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
               </div>
               <div class="col-md-6">
-                
               </div>
             </div>
 
             <hr>
 
             <p>Examples to test the "relative" and "assets" variables, and to show how they work</p>
-
-
-
 
 
 
@@ -144,16 +123,11 @@ assets_trailing_slash: {
 
 
 
-
-
-
             <div class="docs-header" id="content">
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="assets_trailing_slash.html">assets_trailing_slash.html</a></li>
-            
             </ul>
 
             <hr>
@@ -228,7 +202,6 @@ assets_trailing_slash: {
                   basename:      assets
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>

--- a/test/actual/collections/asc/alert.html
+++ b/test/actual/collections/asc/alert.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
-      <a href="debug-helpers.html">&larr; Previous</a>
+      <a href="example.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="collections-pages.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
-      <a href="debug-helpers.html">&larr; Previous</a>
+      <a href="example.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="active">
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="collections-pages.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,286 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">components</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">components</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">2</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">2</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -718,37 +482,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -791,262 +540,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/asc/debug-helpers.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/asc/alert.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/asc/debug-helpers.html
-                  dirname:       test/actual/collections/asc
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/asc/alert.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/asc/alert.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/asc/alert.html
-                  dirname:       test/actual/collections/asc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/asc/collections-pages.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/asc/alert.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/asc/collections-pages.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/asc/collections-tags.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/asc/alert.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/asc/collections-tags.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/asc/collections.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/asc/alert.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/asc/collections.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/asc/complex.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/asc/alert.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/asc/complex.html
-                  dirname:       test/actual/collections/asc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/asc/context.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/asc/alert.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/asc/context.html
-                  dirname:       test/actual/collections/asc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/asc/collections-categories.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/asc/alert.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/asc/collections-categories.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1079,7 +572,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/asc/alert.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/asc/alert.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/asc/alert.html
+                  dirname:       test/actual/collections/asc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/asc/collections-pages.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/asc/alert.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/asc/collections-pages.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/asc/collections-tags.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/asc/alert.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/asc/collections-tags.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/asc/collections.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/asc/alert.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/asc/collections.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/asc/complex.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/asc/alert.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/asc/complex.html
+                  dirname:       test/actual/collections/asc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/asc/context.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/asc/alert.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/asc/context.html
+                  dirname:       test/actual/collections/asc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/asc/debug-helpers.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/asc/alert.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/asc/debug-helpers.html
+                  dirname:       test/actual/collections/asc
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/asc/collections-categories.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/asc/alert.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/asc/collections-categories.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1111,7 +860,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1143,7 +892,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1175,7 +924,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/asc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/asc/alert.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/asc/no-yfm-data.html
+                  dirname:       test/actual/collections/asc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1207,7 +988,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1239,7 +1020,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1271,7 +1052,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1318,6 +1098,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/asc/collections-categories.html
+++ b/test/actual/collections/asc/collections-categories.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
-      <a href="context.html">&larr; Previous</a>
+      <a href="debug-helpers.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
-    <li class="active pager-middle">
-      <a href="collections-categories.html">8</a>
-    </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
+    <li class="active pager-middle">
+      <a href="collections-categories.html">9</a>
+    </li>
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="example.html">Next &rarr;</a>
+      <a href="gist-helper.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
-      <a href="context.html">&larr; Previous</a>
+      <a href="debug-helpers.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
-    <li class="active">
-      <a href="collections-categories.html">8</a>
-    </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
+    <li class="active">
+      <a href="collections-categories.html">9</a>
+    </li>
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="example.html">Next &rarr;</a>
+      <a href="gist-helper.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,488 +187,289 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">5</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">three</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">5</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">three</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -718,33 +481,19 @@
     <h4>Categories</h4>
   </div>
   <div class="panel-body">
-  
     <span class="label label-info">categories</span>
-  
     <span class="label label-info">collections</span>
-  
     <span class="label label-info">components</span>
-  
     <span class="label label-info">context</span>
-  
     <span class="label label-info">fixtures</span>
-  
     <span class="label label-info">helper</span>
-  
     <span class="label label-info">markdown</span>
-  
     <span class="label label-info">one</span>
-  
     <span class="label label-info">pages</span>
-  
     <span class="label label-info">three</span>
-  
     <span class="label label-info">two</span>
-  
     <span class="label label-info">yaml</span>
-  
     <span class="label label-info">yfm</span>
-  
   </div>
 </div>
 
@@ -752,37 +501,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -825,262 +559,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/asc/debug-helpers.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/asc/collections-categories.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/asc/debug-helpers.html
-                  dirname:       test/actual/collections/asc
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/asc/alert.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/asc/collections-categories.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/asc/alert.html
-                  dirname:       test/actual/collections/asc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/asc/collections-pages.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/asc/collections-categories.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/asc/collections-pages.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/asc/collections-tags.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/asc/collections-categories.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/asc/collections-tags.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/asc/collections.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/asc/collections-categories.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/asc/collections.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/asc/complex.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/asc/collections-categories.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/asc/complex.html
-                  dirname:       test/actual/collections/asc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/asc/context.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/asc/collections-categories.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/asc/context.html
-                  dirname:       test/actual/collections/asc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/asc/collections-categories.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/asc/collections-categories.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/asc/collections-categories.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1113,7 +591,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/asc/alert.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/asc/collections-categories.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/asc/alert.html
+                  dirname:       test/actual/collections/asc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/asc/collections-pages.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/asc/collections-categories.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/asc/collections-pages.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/asc/collections-tags.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/asc/collections-categories.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/asc/collections-tags.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/asc/collections.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/asc/collections-categories.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/asc/collections.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/asc/complex.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/asc/collections-categories.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/asc/complex.html
+                  dirname:       test/actual/collections/asc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/asc/context.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/asc/collections-categories.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/asc/context.html
+                  dirname:       test/actual/collections/asc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/asc/debug-helpers.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/asc/collections-categories.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/asc/debug-helpers.html
+                  dirname:       test/actual/collections/asc
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/asc/collections-categories.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/asc/collections-categories.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/asc/collections-categories.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1145,7 +879,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1177,7 +911,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1209,7 +943,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/asc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/asc/collections-categories.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/asc/no-yfm-data.html
+                  dirname:       test/actual/collections/asc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1241,7 +1007,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1273,7 +1039,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1305,7 +1071,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1349,6 +1114,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1363,16 +1129,16 @@
   },
   "filename": "collections-categories.html",
   "first": false,
-  "index": 7,
+  "index": 8,
   "isCurrentPage": false,
   "last": false,
   "middle": true,
-  "next": 8,
-  "number": 8,
+  "next": 9,
+  "number": 9,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n<div class=\"panel panel-info\">\n  <div class=\"panel-heading\">\n    <h4>Categories</h4>\n  </div>\n  <div class=\"panel-body\">\n  {{#categories}}\n    <span class=\"label label-info\">{{category}}</span>\n  {{/categories}}\n  </div>\n</div>\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "collections-categories.html",
   "pagename": "collections-categories.html",
-  "prev": 6,
+  "prev": 7,
   "relativeLink": "collections-categories.html",
   "src": "test/fixtures/pages/collections-categories.hbs",
   "title": "Collections Categories"

--- a/test/actual/collections/asc/collections-pages.html
+++ b/test/actual/collections/asc/collections-pages.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="alert.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="collections-tags.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="alert.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li class="active">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="collections-tags.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,480 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">pages</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">pages</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -710,37 +477,22 @@
     <h4>Pages Collection</h4>
   </div>
   <div class="panel-body">
-    
-      <a href="#">Debug Helper</a>
-    
-      <a href="#">Title for "alert.hbs"</a>
-    
-      <a href="#">Pages Collection</a>
-    
-      <a href="#">Tags Test</a>
-    
-      <a href="#">Collections</a>
-    
-      <a href="#">Complex YFM</a>
-    
-      <a href="#">Context</a>
-    
-      <a href="#">Collections Categories</a>
-    
       <a href="#">Title from YFM of "example.hbs"</a>
-    
+      <a href="#">Title for "alert.hbs"</a>
+      <a href="#">Pages Collection</a>
+      <a href="#">Tags Test</a>
+      <a href="#">Collections</a>
+      <a href="#">Complex YFM</a>
+      <a href="#">Context</a>
+      <a href="#">Debug Helper</a>
+      <a href="#">Collections Categories</a>
       <a href="#">Gist Helper</a>
-    
       <a href="#"><%= site.title %></a>
-    
       <a href="#">md helper</a>
-    
       <a href="#"></a>
-    
+      <a href="#"></a>
       <a href="#">This title is from the YFM of the current page</a>
-    
       <a href="#">YFM</a>
-    
   </div>
 </div>
 
@@ -748,37 +500,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -821,262 +558,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/asc/debug-helpers.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/asc/collections-pages.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/asc/debug-helpers.html
-                  dirname:       test/actual/collections/asc
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/asc/alert.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/asc/collections-pages.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/asc/alert.html
-                  dirname:       test/actual/collections/asc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/asc/collections-pages.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/asc/collections-pages.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/asc/collections-pages.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/asc/collections-tags.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/asc/collections-pages.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/asc/collections-tags.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/asc/collections.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/asc/collections-pages.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/asc/collections.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/asc/complex.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/asc/collections-pages.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/asc/complex.html
-                  dirname:       test/actual/collections/asc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/asc/context.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/asc/collections-pages.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/asc/context.html
-                  dirname:       test/actual/collections/asc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/asc/collections-categories.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/asc/collections-pages.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/asc/collections-categories.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1109,7 +590,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/asc/alert.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/asc/collections-pages.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/asc/alert.html
+                  dirname:       test/actual/collections/asc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/asc/collections-pages.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/asc/collections-pages.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/asc/collections-pages.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/asc/collections-tags.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/asc/collections-pages.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/asc/collections-tags.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/asc/collections.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/asc/collections-pages.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/asc/collections.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/asc/complex.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/asc/collections-pages.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/asc/complex.html
+                  dirname:       test/actual/collections/asc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/asc/context.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/asc/collections-pages.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/asc/context.html
+                  dirname:       test/actual/collections/asc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/asc/debug-helpers.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/asc/collections-pages.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/asc/debug-helpers.html
+                  dirname:       test/actual/collections/asc
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/asc/collections-categories.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/asc/collections-pages.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/asc/collections-categories.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1141,7 +878,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1173,7 +910,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1205,7 +942,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/asc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/asc/collections-pages.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/asc/no-yfm-data.html
+                  dirname:       test/actual/collections/asc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1237,7 +1006,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1269,7 +1038,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1301,7 +1070,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1334,6 +1102,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/asc/collections-tags.html
+++ b/test/actual/collections/asc/collections-tags.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="collections-pages.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="collections.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="collections-pages.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="active">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="collections.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,488 +187,289 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">5</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">two</span>
-    
-      <span class="label label-success">three</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">5</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">two</span>
+                        <span class="label label-success">three</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -718,37 +481,21 @@
     <h4>Tags</h4>
   </div>
   <div class="panel-body">
-  
     <span class="label label-success">alert</span>
-  
     <span class="label label-success">bootstrap</span>
-  
     <span class="label label-success">collections</span>
-  
     <span class="label label-success">complex</span>
-  
     <span class="label label-success">example</span>
-  
     <span class="label label-success">examples</span>
-  
     <span class="label label-success">markdown</span>
-  
     <span class="label label-success">md</span>
-  
     <span class="label label-success">one</span>
-  
     <span class="label label-success">pages</span>
-  
     <span class="label label-success">tags</span>
-  
     <span class="label label-success">test</span>
-  
     <span class="label label-success">tests</span>
-  
     <span class="label label-success">three</span>
-  
     <span class="label label-success">two</span>
-  
   </div>
 </div>
 
@@ -756,37 +503,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -829,262 +561,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/asc/debug-helpers.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/asc/collections-tags.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/asc/debug-helpers.html
-                  dirname:       test/actual/collections/asc
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/asc/alert.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/asc/collections-tags.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/asc/alert.html
-                  dirname:       test/actual/collections/asc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/asc/collections-pages.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/asc/collections-tags.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/asc/collections-pages.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/asc/collections-tags.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/asc/collections-tags.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/asc/collections-tags.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/asc/collections.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/asc/collections-tags.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/asc/collections.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/asc/complex.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/asc/collections-tags.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/asc/complex.html
-                  dirname:       test/actual/collections/asc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/asc/context.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/asc/collections-tags.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/asc/context.html
-                  dirname:       test/actual/collections/asc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/asc/collections-categories.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/asc/collections-tags.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/asc/collections-categories.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1117,7 +593,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/asc/alert.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/asc/collections-tags.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/asc/alert.html
+                  dirname:       test/actual/collections/asc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/asc/collections-pages.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/asc/collections-tags.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/asc/collections-pages.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/asc/collections-tags.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/asc/collections-tags.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/asc/collections-tags.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/asc/collections.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/asc/collections-tags.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/asc/collections.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/asc/complex.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/asc/collections-tags.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/asc/complex.html
+                  dirname:       test/actual/collections/asc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/asc/context.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/asc/collections-tags.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/asc/context.html
+                  dirname:       test/actual/collections/asc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/asc/debug-helpers.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/asc/collections-tags.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/asc/debug-helpers.html
+                  dirname:       test/actual/collections/asc
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/asc/collections-categories.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/asc/collections-tags.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/asc/collections-categories.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1149,7 +881,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1181,7 +913,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1213,7 +945,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/asc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/asc/collections-tags.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/asc/no-yfm-data.html
+                  dirname:       test/actual/collections/asc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1245,7 +1009,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1277,7 +1041,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1309,7 +1073,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1346,6 +1109,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/asc/collections.html
+++ b/test/actual/collections/asc/collections.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="collections-tags.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="complex.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="collections-tags.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="active">
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="complex.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">one</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li class="active">
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li class="active">
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li class="active">
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">one</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li class="active">
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li class="active">
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li class="active">
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -711,101 +476,56 @@
             
 Collections
 <ul class="tags">
-
   <li>alert</li>
-
   <li>bootstrap</li>
-
   <li>collections</li>
-
   <li>complex</li>
-
   <li>example</li>
-
   <li>examples</li>
-
   <li>markdown</li>
-
   <li>md</li>
-
   <li>one</li>
-
   <li>pages</li>
-
   <li>tags</li>
-
   <li>test</li>
-
   <li>tests</li>
-
   <li>three</li>
-
   <li>two</li>
-
 </ul>
 
 <ul class="categories">
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
 </ul>
 
 <ul class="pages">
-
-	<li>debug-helpers</li>
-
-	<li>alert</li>
-
-	<li>collections-pages</li>
-
-	<li>collections-tags</li>
-
-	<li>collections</li>
-
-	<li>complex</li>
-
-	<li>context</li>
-
-	<li>collections-categories</li>
-
 	<li>example</li>
-
+	<li>alert</li>
+	<li>collections-pages</li>
+	<li>collections-tags</li>
+	<li>collections</li>
+	<li>complex</li>
+	<li>context</li>
+	<li>debug-helpers</li>
+	<li>collections-categories</li>
 	<li>gist-helper</li>
-
 	<li>lodash</li>
-
 	<li>md-helper</li>
-
+	<li>no-yfm-data</li>
 	<li>no-yfm</li>
-
 	<li>yfm-context</li>
-
 	<li>yfm</li>
-
 </ul>
 
 
@@ -813,37 +533,22 @@ Collections
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -886,262 +591,6 @@ Collections
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/asc/debug-helpers.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/asc/collections.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/asc/debug-helpers.html
-                  dirname:       test/actual/collections/asc
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/asc/alert.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/asc/collections.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/asc/alert.html
-                  dirname:       test/actual/collections/asc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/asc/collections-pages.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/asc/collections.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/asc/collections-pages.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/asc/collections-tags.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/asc/collections.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/asc/collections-tags.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/asc/collections.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/asc/collections.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/asc/collections.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/asc/complex.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/asc/collections.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/asc/complex.html
-                  dirname:       test/actual/collections/asc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/asc/context.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/asc/collections.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/asc/context.html
-                  dirname:       test/actual/collections/asc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/asc/collections-categories.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/asc/collections.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/asc/collections-categories.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1174,7 +623,263 @@ Collections
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/asc/alert.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/asc/collections.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/asc/alert.html
+                  dirname:       test/actual/collections/asc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/asc/collections-pages.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/asc/collections.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/asc/collections-pages.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/asc/collections-tags.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/asc/collections.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/asc/collections-tags.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/asc/collections.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/asc/collections.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/asc/collections.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/asc/complex.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/asc/collections.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/asc/complex.html
+                  dirname:       test/actual/collections/asc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/asc/context.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/asc/collections.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/asc/context.html
+                  dirname:       test/actual/collections/asc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/asc/debug-helpers.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/asc/collections.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/asc/debug-helpers.html
+                  dirname:       test/actual/collections/asc
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/asc/collections-categories.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/asc/collections.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/asc/collections-categories.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1206,7 +911,7 @@ Collections
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1238,7 +943,7 @@ Collections
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1270,7 +975,39 @@ Collections
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/asc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/asc/collections.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/asc/no-yfm-data.html
+                  dirname:       test/actual/collections/asc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1302,7 +1039,7 @@ Collections
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1334,7 +1071,7 @@ Collections
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1366,7 +1103,6 @@ Collections
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1405,6 +1141,7 @@ Collections
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/asc/complex.html
+++ b/test/actual/collections/asc/complex.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="collections.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="context.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="collections.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li class="active">
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="context.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,486 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">pages</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">pages</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">complex</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">complex</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -719,37 +482,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -792,262 +540,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/asc/debug-helpers.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/asc/complex.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/asc/debug-helpers.html
-                  dirname:       test/actual/collections/asc
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/asc/alert.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/asc/complex.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/asc/alert.html
-                  dirname:       test/actual/collections/asc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/asc/collections-pages.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/asc/complex.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/asc/collections-pages.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/asc/collections-tags.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/asc/complex.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/asc/collections-tags.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/asc/collections.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/asc/complex.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/asc/collections.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/asc/complex.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/asc/complex.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/asc/complex.html
-                  dirname:       test/actual/collections/asc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/asc/context.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/asc/complex.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/asc/context.html
-                  dirname:       test/actual/collections/asc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/asc/collections-categories.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/asc/complex.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/asc/collections-categories.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1080,7 +572,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/asc/alert.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/asc/complex.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/asc/alert.html
+                  dirname:       test/actual/collections/asc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/asc/collections-pages.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/asc/complex.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/asc/collections-pages.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/asc/collections-tags.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/asc/complex.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/asc/collections-tags.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/asc/collections.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/asc/complex.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/asc/collections.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/asc/complex.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/asc/complex.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/asc/complex.html
+                  dirname:       test/actual/collections/asc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/asc/context.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/asc/complex.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/asc/context.html
+                  dirname:       test/actual/collections/asc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/asc/debug-helpers.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/asc/complex.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/asc/debug-helpers.html
+                  dirname:       test/actual/collections/asc
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/asc/collections-categories.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/asc/complex.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/asc/collections-categories.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1112,7 +860,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1144,7 +892,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1176,7 +924,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/asc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/asc/complex.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/asc/no-yfm-data.html
+                  dirname:       test/actual/collections/asc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1208,7 +988,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1240,7 +1020,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1272,7 +1052,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1319,6 +1098,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/asc/context.html
+++ b/test/actual/collections/asc/context.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="complex.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="collections-categories.html">Next &rarr;</a>
+      <a href="debug-helpers.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="complex.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li class="active">
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="collections-categories.html">Next &rarr;</a>
+      <a href="debug-helpers.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">fixtures</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -753,193 +518,171 @@
 <hr>
 
 <ul class="context-test">
-
-  <li><a href="#" data-context="basename">debug-helpers</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">debug-helpers</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">alert</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">alert</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections-pages</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections-pages</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections-tags</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections-tags</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">complex</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">complex</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">context</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">context</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections-categories</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections-categories</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">example</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">example</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
+  <li><a href="#" data-context="basename">alert</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">alert</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections-pages</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections-pages</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections-tags</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections-tags</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">complex</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">complex</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">context</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">context</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">debug-helpers</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">debug-helpers</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections-categories</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections-categories</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
   <li><a href="#" data-context="basename">gist-helper</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">gist-helper</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">lodash</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">lodash</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">md-helper</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">md-helper</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
+  <li><a href="#" data-context="basename">no-yfm-data</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">no-yfm-data</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
   <li><a href="#" data-context="basename">no-yfm</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">no-yfm</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">yfm-context</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">yfm-context</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">yfm</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">yfm</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
 </ul>
 
 <hr>
 
 <ul class="context-test">
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Debug Helper</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Title for &quot;alert.hbs&quot;</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Pages Collection</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Tags Test</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Collections</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Complex YFM</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Context</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Collections Categories</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">Title from YFM of &quot;example.hbs&quot;</a></li>
-
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Title for &quot;alert.hbs&quot;</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Pages Collection</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Tags Test</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Collections</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Complex YFM</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Context</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Debug Helper</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Collections Categories</a></li>
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">Gist Helper</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">&lt;%= site.title %&gt;</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">md helper</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title"></a></li>
-
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title"></a></li>
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">This title is from the YFM of the current page</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">YFM</a></li>
-
 </ul>
 
 
@@ -947,37 +690,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -1020,262 +748,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/asc/debug-helpers.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/asc/context.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/asc/debug-helpers.html
-                  dirname:       test/actual/collections/asc
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/asc/alert.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/asc/context.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/asc/alert.html
-                  dirname:       test/actual/collections/asc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/asc/collections-pages.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/asc/context.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/asc/collections-pages.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/asc/collections-tags.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/asc/context.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/asc/collections-tags.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/asc/collections.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/asc/context.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/asc/collections.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/asc/complex.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/asc/context.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/asc/complex.html
-                  dirname:       test/actual/collections/asc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/asc/context.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/asc/context.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/asc/context.html
-                  dirname:       test/actual/collections/asc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/asc/collections-categories.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/asc/context.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/asc/collections-categories.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1308,7 +780,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/asc/alert.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/asc/context.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/asc/alert.html
+                  dirname:       test/actual/collections/asc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/asc/collections-pages.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/asc/context.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/asc/collections-pages.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/asc/collections-tags.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/asc/context.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/asc/collections-tags.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/asc/collections.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/asc/context.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/asc/collections.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/asc/complex.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/asc/context.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/asc/complex.html
+                  dirname:       test/actual/collections/asc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/asc/context.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/asc/context.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/asc/context.html
+                  dirname:       test/actual/collections/asc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/asc/debug-helpers.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/asc/context.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/asc/debug-helpers.html
+                  dirname:       test/actual/collections/asc
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/asc/collections-categories.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/asc/context.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/asc/collections-categories.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1340,7 +1068,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1372,7 +1100,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1404,7 +1132,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/asc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/asc/context.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/asc/no-yfm-data.html
+                  dirname:       test/actual/collections/asc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1436,7 +1196,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1468,7 +1228,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1500,7 +1260,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1546,6 +1305,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/asc/debug-helpers.html
+++ b/test/actual/collections/asc/debug-helpers.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
-    <li class="previous disabled">
-      <a unselectable="on" class="unselectable">First</a>
-    </li>
-    <li class="previous disabled">
-      <a unselectable="on" class="unselectable">&larr; Previous</a>
-    </li>
-  
 
-  
-
-  
-    <li class="active pager-middle">
-      <a href="debug-helpers.html">1</a>
+    <li class="previous">
+      <a href="example.html">First</a>
     </li>
-  
+    <li class="previous">
+      <a href="context.html">&larr; Previous</a>
+    </li>
+
+    <li class="pager-middle">
+      <a href="example.html">1</a>
+    </li>
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
-    <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+    <li class="active pager-middle">
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="alert.html">Next &rarr;</a>
+      <a href="collections-categories.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
-    <li class="prev disabled">
-      <a unselectable="on" class="unselectable">First</a>
-    </li>
-    <li class="prev disabled">
-      <a unselectable="on" class="unselectable">&larr; Previous</a>
-    </li>
-  
 
-  
-
-  
-    <li class="active">
-      <a href="debug-helpers.html">1</a>
+    <li class="prev">
+      <a href="example.html">First</a>
     </li>
-  
+    <li class="prev">
+      <a href="context.html">&larr; Previous</a>
+    </li>
+
+    <li>
+      <a href="example.html">1</a>
+    </li>
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
-    <li>
-      <a href="collections-categories.html">8</a>
+    <li class="active">
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="alert.html">Next &rarr;</a>
+      <a href="collections-categories.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -707,42 +476,26 @@
 <p>Uncomment the <code>debug</code> helper below, run <code>grunt assemble</code>, and watch the output in the command line to see how it works.</p>
 
 
-
             <div class="docs-header" id="content">
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -785,262 +538,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/asc/debug-helpers.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/asc/debug-helpers.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/asc/debug-helpers.html
-                  dirname:       test/actual/collections/asc
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/asc/alert.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/asc/debug-helpers.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/asc/alert.html
-                  dirname:       test/actual/collections/asc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/asc/collections-pages.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/asc/debug-helpers.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/asc/collections-pages.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/asc/collections-tags.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/asc/debug-helpers.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/asc/collections-tags.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/asc/collections.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/asc/debug-helpers.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/asc/collections.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/asc/complex.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/asc/debug-helpers.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/asc/complex.html
-                  dirname:       test/actual/collections/asc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/asc/context.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/asc/debug-helpers.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/asc/context.html
-                  dirname:       test/actual/collections/asc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/asc/collections-categories.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/asc/debug-helpers.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/asc/collections-categories.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1073,7 +570,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/asc/alert.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/asc/debug-helpers.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/asc/alert.html
+                  dirname:       test/actual/collections/asc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/asc/collections-pages.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/asc/debug-helpers.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/asc/collections-pages.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/asc/collections-tags.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/asc/debug-helpers.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/asc/collections-tags.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/asc/collections.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/asc/debug-helpers.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/asc/collections.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/asc/complex.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/asc/debug-helpers.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/asc/complex.html
+                  dirname:       test/actual/collections/asc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/asc/context.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/asc/debug-helpers.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/asc/context.html
+                  dirname:       test/actual/collections/asc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/asc/debug-helpers.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/asc/debug-helpers.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/asc/debug-helpers.html
+                  dirname:       test/actual/collections/asc
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/asc/collections-categories.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/asc/debug-helpers.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/asc/collections-categories.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1105,7 +858,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1137,7 +890,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1169,7 +922,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/asc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/asc/debug-helpers.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/asc/no-yfm-data.html
+                  dirname:       test/actual/collections/asc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1201,7 +986,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1233,7 +1018,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1265,7 +1050,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1295,6 +1079,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1308,15 +1093,18 @@
     }
   },
   "filename": "debug-helpers.html",
-  "first": true,
-  "index": 0,
+  "first": false,
+  "index": 7,
+  "isCurrentPage": false,
   "last": false,
-  "middle": false,
-  "next": 1,
-  "number": 1,
+  "middle": true,
+  "next": 8,
+  "number": 8,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n{{#markdown}}\n\n### \\{{debug}} helper\nUncomment the `debug` helper below, run `grunt assemble`, and watch the output in the command line to see how it works.\n{{!debug text}}\n\n{{/markdown}}\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "debug-helpers.html",
   "pagename": "debug-helpers.html",
+  "prev": 6,
+  "relativeLink": "debug-helpers.html",
   "src": "test/fixtures/pages/debug-helpers.hbs",
   "title": "Debug Helper"
 }

--- a/test/actual/collections/asc/example.html
+++ b/test/actual/collections/asc/example.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
+    <li class="previous disabled">
+      <a unselectable="on" class="unselectable">First</a>
+    </li>
+    <li class="previous disabled">
+      <a unselectable="on" class="unselectable">&larr; Previous</a>
+    </li>
 
-  
-    <li class="previous">
-      <a href="debug-helpers.html">First</a>
-    </li>
-    <li class="previous">
-      <a href="collections-categories.html">&larr; Previous</a>
-    </li>
-  
 
-  
-    <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+    <li class="active pager-middle">
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
-    <li class="active pager-middle">
-      <a href="example.html">9</a>
+    <li class="pager-middle">
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="gist-helper.html">Next &rarr;</a>
+      <a href="alert.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
+    <li class="prev disabled">
+      <a unselectable="on" class="unselectable">First</a>
+    </li>
+    <li class="prev disabled">
+      <a unselectable="on" class="unselectable">&larr; Previous</a>
+    </li>
 
-  
-    <li class="prev">
-      <a href="debug-helpers.html">First</a>
-    </li>
-    <li class="prev">
-      <a href="collections-categories.html">&larr; Previous</a>
-    </li>
-  
 
-  
-    <li>
-      <a href="debug-helpers.html">1</a>
+    <li class="active">
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
-    <li class="active">
-      <a href="example.html">9</a>
+    <li>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="gist-helper.html">Next &rarr;</a>
+      <a href="alert.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,286 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">2</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">2</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">example</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">example</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -715,7 +479,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
 <hr>
 
 <div>Title from YFM of &quot;example.hbs&quot;</div>
-<div></div>
+<div>This is text from example.json.</div>
 
 <hr>
 
@@ -726,37 +490,22 @@ This example shows that the properties from "example.json" and "example.hbs" are
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -799,262 +548,6 @@ This example shows that the properties from "example.json" and "example.hbs" are
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/asc/debug-helpers.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/asc/example.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/asc/debug-helpers.html
-                  dirname:       test/actual/collections/asc
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/asc/alert.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/asc/example.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/asc/alert.html
-                  dirname:       test/actual/collections/asc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/asc/collections-pages.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/asc/example.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/asc/collections-pages.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/asc/collections-tags.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/asc/example.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/asc/collections-tags.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/asc/collections.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/asc/example.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/asc/collections.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/asc/complex.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/asc/example.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/asc/complex.html
-                  dirname:       test/actual/collections/asc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/asc/context.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/asc/example.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/asc/context.html
-                  dirname:       test/actual/collections/asc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/asc/collections-categories.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/asc/example.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/asc/collections-categories.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1087,7 +580,263 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/asc/alert.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/asc/example.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/asc/alert.html
+                  dirname:       test/actual/collections/asc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/asc/collections-pages.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/asc/example.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/asc/collections-pages.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/asc/collections-tags.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/asc/example.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/asc/collections-tags.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/asc/collections.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/asc/example.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/asc/collections.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/asc/complex.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/asc/example.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/asc/complex.html
+                  dirname:       test/actual/collections/asc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/asc/context.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/asc/example.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/asc/context.html
+                  dirname:       test/actual/collections/asc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/asc/debug-helpers.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/asc/example.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/asc/debug-helpers.html
+                  dirname:       test/actual/collections/asc
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/asc/collections-categories.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/asc/example.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/asc/collections-categories.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1119,7 +868,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1151,7 +900,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1183,7 +932,39 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/asc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/asc/example.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/asc/no-yfm-data.html
+                  dirname:       test/actual/collections/asc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1215,7 +996,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1247,7 +1028,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1279,7 +1060,6 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1324,6 +1104,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1337,26 +1118,25 @@ This example shows that the properties from "example.json" and "example.hbs" are
     }
   },
   "filename": "example.html",
-  "first": false,
-  "index": 8,
-  "isCurrentPage": false,
+  "first": true,
+  "index": 0,
+  "info": "Congratulations! This is data from example.yml.",
   "items": [
     "omega",
     "gamma"
   ],
   "last": false,
-  "middle": true,
-  "next": 9,
-  "number": 9,
+  "middle": false,
+  "next": 1,
+  "number": 1,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n\nThis example shows that the properties from \"example.json\" and \"example.hbs\" are on the page object.\n\n<hr>\n\n<div>{{page.title}}</div>\n<div>{{page.text}}</div>\n\n<hr>\n\n<div>{{title}}</div>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "example.html",
   "pagename": "example.html",
-  "prev": 7,
-  "relativeLink": "example.html",
   "src": "test/fixtures/pages/example.hbs",
   "tags": [
     "example"
   ],
+  "text": "This is text from example.json.",
   "title": "Title from YFM of \"example.hbs\""
 }
 </code></pre>

--- a/test/actual/collections/asc/gist-helper.html
+++ b/test/actual/collections/asc/gist-helper.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
-      <a href="example.html">&larr; Previous</a>
+      <a href="collections-categories.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="lodash.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
-      <a href="example.html">&larr; Previous</a>
+      <a href="collections-categories.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="active">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="lodash.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -704,45 +473,28 @@
 
             
 <h1 id="-gist-helper">{{gist}} helper</h1>
-<script src="https://gist.github.com/5193239.js"></script>
-
-
+<p>&lt;script src=&quot;<a href="https://gist.github.com/5193239.js&quot;&gt;&lt;/script&amp;gt">https://gist.github.com/5193239.js&quot;&gt;&lt;/script&amp;gt</a>;</p>
 
             <div class="docs-header" id="content">
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -785,262 +537,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/asc/debug-helpers.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/asc/gist-helper.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/asc/debug-helpers.html
-                  dirname:       test/actual/collections/asc
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/asc/alert.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/asc/gist-helper.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/asc/alert.html
-                  dirname:       test/actual/collections/asc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/asc/collections-pages.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/asc/gist-helper.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/asc/collections-pages.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/asc/collections-tags.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/asc/gist-helper.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/asc/collections-tags.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/asc/collections.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/asc/gist-helper.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/asc/collections.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/asc/complex.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/asc/gist-helper.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/asc/complex.html
-                  dirname:       test/actual/collections/asc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/asc/context.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/asc/gist-helper.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/asc/context.html
-                  dirname:       test/actual/collections/asc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/asc/collections-categories.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/asc/gist-helper.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/asc/collections-categories.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1073,7 +569,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/asc/alert.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/asc/gist-helper.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/asc/alert.html
+                  dirname:       test/actual/collections/asc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/asc/collections-pages.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/asc/gist-helper.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/asc/collections-pages.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/asc/collections-tags.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/asc/gist-helper.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/asc/collections-tags.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/asc/collections.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/asc/gist-helper.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/asc/collections.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/asc/complex.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/asc/gist-helper.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/asc/complex.html
+                  dirname:       test/actual/collections/asc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/asc/context.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/asc/gist-helper.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/asc/context.html
+                  dirname:       test/actual/collections/asc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/asc/debug-helpers.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/asc/gist-helper.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/asc/debug-helpers.html
+                  dirname:       test/actual/collections/asc
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/asc/collections-categories.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/asc/gist-helper.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/asc/collections-categories.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1105,7 +857,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1137,7 +889,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1169,7 +921,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/asc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/asc/gist-helper.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/asc/no-yfm-data.html
+                  dirname:       test/actual/collections/asc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1201,7 +985,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1233,7 +1017,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1265,7 +1049,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1295,6 +1078,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/asc/lodash.html
+++ b/test/actual/collections/asc/lodash.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="gist-helper.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="md-helper.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="gist-helper.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="active">
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="md-helper.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -711,37 +480,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -784,262 +538,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/asc/debug-helpers.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/asc/lodash.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/asc/debug-helpers.html
-                  dirname:       test/actual/collections/asc
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/asc/alert.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/asc/lodash.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/asc/alert.html
-                  dirname:       test/actual/collections/asc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/asc/collections-pages.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/asc/lodash.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/asc/collections-pages.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/asc/collections-tags.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/asc/lodash.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/asc/collections-tags.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/asc/collections.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/asc/lodash.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/asc/collections.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/asc/complex.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/asc/lodash.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/asc/complex.html
-                  dirname:       test/actual/collections/asc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/asc/context.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/asc/lodash.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/asc/context.html
-                  dirname:       test/actual/collections/asc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/asc/collections-categories.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/asc/lodash.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/asc/collections-categories.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1072,7 +570,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/asc/alert.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/asc/lodash.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/asc/alert.html
+                  dirname:       test/actual/collections/asc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/asc/collections-pages.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/asc/lodash.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/asc/collections-pages.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/asc/collections-tags.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/asc/lodash.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/asc/collections-tags.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/asc/collections.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/asc/lodash.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/asc/collections.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/asc/complex.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/asc/lodash.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/asc/complex.html
+                  dirname:       test/actual/collections/asc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/asc/context.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/asc/lodash.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/asc/context.html
+                  dirname:       test/actual/collections/asc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/asc/debug-helpers.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/asc/lodash.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/asc/debug-helpers.html
+                  dirname:       test/actual/collections/asc
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/asc/collections-categories.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/asc/lodash.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/asc/collections-categories.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1104,7 +858,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1136,7 +890,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1168,7 +922,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/asc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/asc/lodash.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/asc/no-yfm-data.html
+                  dirname:       test/actual/collections/asc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1200,7 +986,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1232,7 +1018,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1264,7 +1050,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1296,6 +1081,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/asc/md-helper.html
+++ b/test/actual/collections/asc/md-helper.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="lodash.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="no-yfm.html">Next &rarr;</a>
+      <a href="no-yfm-data.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="lodash.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="active">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="no-yfm.html">Next &rarr;</a>
+      <a href="no-yfm-data.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,488 +187,288 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">2</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">helper</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">2</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">helper</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">markdown</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">markdown</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -738,37 +500,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -811,262 +558,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/asc/debug-helpers.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/asc/md-helper.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/asc/debug-helpers.html
-                  dirname:       test/actual/collections/asc
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/asc/alert.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/asc/md-helper.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/asc/alert.html
-                  dirname:       test/actual/collections/asc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/asc/collections-pages.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/asc/md-helper.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/asc/collections-pages.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/asc/collections-tags.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/asc/md-helper.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/asc/collections-tags.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/asc/collections.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/asc/md-helper.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/asc/collections.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/asc/complex.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/asc/md-helper.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/asc/complex.html
-                  dirname:       test/actual/collections/asc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/asc/context.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/asc/md-helper.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/asc/context.html
-                  dirname:       test/actual/collections/asc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/asc/collections-categories.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/asc/md-helper.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/asc/collections-categories.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1099,7 +590,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/asc/alert.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/asc/md-helper.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/asc/alert.html
+                  dirname:       test/actual/collections/asc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/asc/collections-pages.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/asc/md-helper.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/asc/collections-pages.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/asc/collections-tags.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/asc/md-helper.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/asc/collections-tags.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/asc/collections.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/asc/md-helper.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/asc/collections.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/asc/complex.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/asc/md-helper.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/asc/complex.html
+                  dirname:       test/actual/collections/asc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/asc/context.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/asc/md-helper.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/asc/context.html
+                  dirname:       test/actual/collections/asc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/asc/debug-helpers.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/asc/md-helper.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/asc/debug-helpers.html
+                  dirname:       test/actual/collections/asc
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/asc/collections-categories.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/asc/md-helper.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/asc/collections-categories.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1131,7 +878,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1163,7 +910,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1195,7 +942,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/asc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/asc/md-helper.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/asc/no-yfm-data.html
+                  dirname:       test/actual/collections/asc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1227,7 +1006,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1259,7 +1038,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1291,7 +1070,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1340,6 +1118,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/asc/no-yfm-data.html
+++ b/test/actual/collections/asc/no-yfm-data.html
@@ -1,0 +1,1121 @@
+<!DOCTYPE html>
+  <html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Layout filename: ''</title>
+    <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../../assets/validation.css">
+  </head>
+  <body style="padding-top: 60px;">
+    <div class="container">
+
+      <!-- validate assets path -->
+      <section id="validate"></section>
+      <div class="docs-section">
+        <div class="docs-header" id="content">
+          <h4><strong class="text-muted">test/fixtures/pages/no-yfm-data.hbs</strong> &#x2192; <strong class="text-success">test/actual/collections/asc/no-yfm-data.html</strong></h4>
+        </div>
+        <hr>
+      </div>
+
+      <ul class="pager">
+
+
+    <li class="previous">
+      <a href="example.html">First</a>
+    </li>
+    <li class="previous">
+      <a href="md-helper.html">&larr; Previous</a>
+    </li>
+
+    <li class="pager-middle">
+      <a href="example.html">1</a>
+    </li>
+    <li class="pager-middle">
+      <a href="alert.html">2</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections-pages.html">3</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections-tags.html">4</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections.html">5</a>
+    </li>
+    <li class="pager-middle">
+      <a href="complex.html">6</a>
+    </li>
+    <li class="pager-middle">
+      <a href="context.html">7</a>
+    </li>
+    <li class="pager-middle">
+      <a href="debug-helpers.html">8</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections-categories.html">9</a>
+    </li>
+    <li class="pager-middle">
+      <a href="gist-helper.html">10</a>
+    </li>
+    <li class="pager-middle">
+      <a href="lodash.html">11</a>
+    </li>
+    <li class="pager-middle">
+      <a href="md-helper.html">12</a>
+    </li>
+    <li class="active pager-middle">
+      <a href="no-yfm-data.html">13</a>
+    </li>
+    <li class="pager-middle">
+      <a href="no-yfm.html">14</a>
+    </li>
+    <li class="pager-middle">
+      <a href="yfm-context.html">15</a>
+    </li>
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
+
+    <li class="next">
+      <a href="yfm.html">Last</a>
+    </li>
+    <li class="next">
+      <a href="no-yfm.html">Next &rarr;</a>
+    </li>
+
+
+</ul><style>
+.unselectable {
+  -webkit-touch-callout: none;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+}
+</style>
+      <hr>
+
+      <div class="row">
+        <!-- Column: sidebar -->
+        <div class="col-md-3">
+          <div class="bs-sidebar hidden-print" role="complementary">
+            <!-- pagination -->
+            <ul class="nav nav-pills nav-stacked">
+
+
+    <li class="prev">
+      <a href="example.html">First</a>
+    </li>
+    <li class="prev">
+      <a href="md-helper.html">&larr; Previous</a>
+    </li>
+
+    <li>
+      <a href="example.html">1</a>
+    </li>
+    <li>
+      <a href="alert.html">2</a>
+    </li>
+    <li>
+      <a href="collections-pages.html">3</a>
+    </li>
+    <li>
+      <a href="collections-tags.html">4</a>
+    </li>
+    <li>
+      <a href="collections.html">5</a>
+    </li>
+    <li>
+      <a href="complex.html">6</a>
+    </li>
+    <li>
+      <a href="context.html">7</a>
+    </li>
+    <li>
+      <a href="debug-helpers.html">8</a>
+    </li>
+    <li>
+      <a href="collections-categories.html">9</a>
+    </li>
+    <li>
+      <a href="gist-helper.html">10</a>
+    </li>
+    <li>
+      <a href="lodash.html">11</a>
+    </li>
+    <li>
+      <a href="md-helper.html">12</a>
+    </li>
+    <li class="active">
+      <a href="no-yfm-data.html">13</a>
+    </li>
+    <li>
+      <a href="no-yfm.html">14</a>
+    </li>
+    <li>
+      <a href="yfm-context.html">15</a>
+    </li>
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
+
+    <li class="next">
+      <a href="no-yfm.html">Next &rarr;</a>
+    </li>
+    <li class="next">
+      <a href="yfm.html">Last</a>
+    </li>
+
+
+</ul>
+          </div>
+        </div>
+        <!-- Column: content -->
+        <div class="col-md-9" role="main">
+          <div class="docs-section">
+            <div class="docs-header" id="content">
+              <h4><strong>Page layout:</strong> default.hbs</h4>
+              <h4><strong>Page src:</strong> test/fixtures/pages/no-yfm-data.hbs</h4>
+              <h4><strong>Page dest:</strong> test/actual/collections/asc/no-yfm-data.html</h4>
+              <h4><strong>Dest filename:</strong> no-yfm-data.html</h4>
+              <h4><strong>Dest basename:</strong> no-yfm-data</h4>
+              <h4><strong>Page title:</strong> (no title defined)</h4>
+            </div>
+
+            <hr>
+            <div class="row">
+              <div class="col-md-6">
+                <!-- Categories Collection -->
+                  
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
+              </div>
+              <div class="col-md-6">
+                  
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
+              </div>
+            </div>
+
+            <hr>
+
+            There is no YAML front matter in this page.
+
+<ul>
+  <li>first</li>
+  <li>second</li>
+  <li>third</li>
+  <li>globalData1</li>
+</ul>
+
+
+            <div class="docs-header" id="content">
+              <h1>Content</h1>
+            </div>
+            <ul>
+              <li><a href="example.html">example.html</a></li>
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
+              <li><a href="gist-helper.html">gist-helper.html</a></li>
+              <li><a href="lodash.html">lodash.html</a></li>
+              <li><a href="md-helper.html">md-helper.html</a></li>
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+              <li><a href="no-yfm.html">no-yfm.html</a></li>
+              <li><a href="yfm-context.html">yfm-context.html</a></li>
+              <li><a href="yfm.html">yfm.html</a></li>
+            </ul>
+
+            <hr>
+            <div style="display: none">
+
+              <h1>Page</h1>
+              <!--
+              "this"
+              ===============================
+              this.src:      
+              this.dest:     
+              this.layout:   
+              this.dirname:  test/actual/collections/asc
+              this.filename: no-yfm-data.html
+              this.pagename: no-yfm-data.html
+              this.basename: no-yfm-data
+              this.ext:      .html
+
+              "page"
+              ===============================
+              page.src:        test/fixtures/pages/no-yfm-data.hbs
+              page.dest:       test/actual/collections/asc/no-yfm-data.html
+              page.layout:     
+              page.dirname:    test/actual/collections/asc
+              page.filename:   no-yfm-data.html
+              page.pagename:   no-yfm-data.html
+              page.basename:   no-yfm-data
+              page.ext:        .html
+
+              "root"
+              ===============================
+              src:           
+              dest:          
+              layout:        
+              dirname:       test/actual/collections/asc
+              filename:      no-yfm-data.html
+              pagename:      no-yfm-data.html
+              basename:      no-yfm-data
+              ext:           .html
+              -->
+              <h1>Each pages</h1>
+              <ul>
+                <li><a href="example.html">example.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/example.hbs
+                  this.dest:     test/actual/collections/asc/example.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: example.html
+                  this.pagename: example.html
+                  this.basename: example
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/example.hbs
+                  dest:          test/actual/collections/asc/example.html
+                  dirname:       test/actual/collections/asc
+                  filename:      example.html
+                  pagename:      example.html
+                  basename:      example
+                  ext:           .html
+                  -->
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/asc/alert.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/asc/alert.html
+                  dirname:       test/actual/collections/asc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/asc/collections-pages.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/asc/collections-pages.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/asc/collections-tags.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/asc/collections-tags.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/asc/collections.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/asc/collections.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/asc/complex.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/asc/complex.html
+                  dirname:       test/actual/collections/asc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/asc/context.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/asc/context.html
+                  dirname:       test/actual/collections/asc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/asc/debug-helpers.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/asc/debug-helpers.html
+                  dirname:       test/actual/collections/asc
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/asc/collections-categories.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/asc/collections-categories.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/gist-helper.hbs
+                  this.dest:     test/actual/collections/asc/gist-helper.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: gist-helper.html
+                  this.pagename: gist-helper.html
+                  this.basename: gist-helper
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/gist-helper.hbs
+                  dest:          test/actual/collections/asc/gist-helper.html
+                  dirname:       test/actual/collections/asc
+                  filename:      gist-helper.html
+                  pagename:      gist-helper.html
+                  basename:      gist-helper
+                  ext:           .html
+                  -->
+<li><a href="lodash.html">lodash.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/lodash.hbs
+                  this.dest:     test/actual/collections/asc/lodash.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: lodash.html
+                  this.pagename: lodash.html
+                  this.basename: lodash
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/lodash.hbs
+                  dest:          test/actual/collections/asc/lodash.html
+                  dirname:       test/actual/collections/asc
+                  filename:      lodash.html
+                  pagename:      lodash.html
+                  basename:      lodash
+                  ext:           .html
+                  -->
+<li><a href="md-helper.html">md-helper.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/md-helper.hbs
+                  this.dest:     test/actual/collections/asc/md-helper.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: md-helper.html
+                  this.pagename: md-helper.html
+                  this.basename: md-helper
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/md-helper.hbs
+                  dest:          test/actual/collections/asc/md-helper.html
+                  dirname:       test/actual/collections/asc
+                  filename:      md-helper.html
+                  pagename:      md-helper.html
+                  basename:      md-helper
+                  ext:           .html
+                  -->
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/asc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/asc/no-yfm-data.html
+                  dirname:       test/actual/collections/asc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm.hbs
+                  this.dest:     test/actual/collections/asc/no-yfm.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: no-yfm.html
+                  this.pagename: no-yfm.html
+                  this.basename: no-yfm
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm.hbs
+                  dest:          test/actual/collections/asc/no-yfm.html
+                  dirname:       test/actual/collections/asc
+                  filename:      no-yfm.html
+                  pagename:      no-yfm.html
+                  basename:      no-yfm
+                  ext:           .html
+                  -->
+<li><a href="yfm-context.html">yfm-context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/yfm-context.hbs
+                  this.dest:     test/actual/collections/asc/yfm-context.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: yfm-context.html
+                  this.pagename: yfm-context.html
+                  this.basename: yfm-context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/yfm-context.hbs
+                  dest:          test/actual/collections/asc/yfm-context.html
+                  dirname:       test/actual/collections/asc
+                  filename:      yfm-context.html
+                  pagename:      yfm-context.html
+                  basename:      yfm-context
+                  ext:           .html
+                  -->
+<li><a href="yfm.html">yfm.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/yfm.hbs
+                  this.dest:     test/actual/collections/asc/yfm.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: yfm.html
+                  this.pagename: yfm.html
+                  this.basename: yfm
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/yfm.hbs
+                  dest:          test/actual/collections/asc/yfm.html
+                  dirname:       test/actual/collections/asc
+                  filename:      yfm.html
+                  pagename:      yfm.html
+                  basename:      yfm
+                  ext:           .html
+                  -->
+              </ul>
+
+              <h1>Debug Info</h1>
+              <pre><code class="json">
+{
+  "_page": "all",
+  "assets": "../../../assets",
+  "basename": "no-yfm-data",
+  "data": {},
+  "dest": "test/actual/collections/asc/no-yfm-data.html",
+  "dirname": "test/actual/collections/asc",
+  "ext": ".html",
+  "extname": ".html",
+  "filePair": {
+    "src": [
+      "test/fixtures/pages/alert.hbs",
+      "test/fixtures/pages/collections-categories.hbs",
+      "test/fixtures/pages/collections-pages.hbs",
+      "test/fixtures/pages/collections-tags.hbs",
+      "test/fixtures/pages/collections.hbs",
+      "test/fixtures/pages/complex.hbs",
+      "test/fixtures/pages/context.hbs",
+      "test/fixtures/pages/debug-helpers.hbs",
+      "test/fixtures/pages/example.hbs",
+      "test/fixtures/pages/gist-helper.hbs",
+      "test/fixtures/pages/lodash.hbs",
+      "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
+      "test/fixtures/pages/no-yfm.hbs",
+      "test/fixtures/pages/yfm-context.hbs",
+      "test/fixtures/pages/yfm.hbs"
+    ],
+    "dest": "test/actual/collections/asc/",
+    "orig": {
+      "src": [
+        "test/fixtures/pages/*.hbs"
+      ],
+      "dest": "test/actual/collections/asc/"
+    }
+  },
+  "filename": "no-yfm-data.html",
+  "first": false,
+  "index": 12,
+  "isCurrentPage": false,
+  "last": false,
+  "middle": true,
+  "next": 13,
+  "number": 13,
+  "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            There is no YAML front matter in this page.\n\n<ul>\n  <li>{{one}}</li>\n  <li>{{two}}</li>\n  <li>{{three}}</li>\n  <li>{{global1}}</li>\n</ul>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
+  "pageName": "no-yfm-data.html",
+  "pagename": "no-yfm-data.html",
+  "prev": 11,
+  "relativeLink": "no-yfm-data.html",
+  "src": "test/fixtures/pages/no-yfm-data.hbs"
+}
+</code></pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script src="../../../assets/validation.js"></script>
+  </body>
+</html>

--- a/test/actual/collections/asc/no-yfm.html
+++ b/test/actual/collections/asc/no-yfm.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
-      <a href="md-helper.html">&larr; Previous</a>
+      <a href="no-yfm-data.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="no-yfm-data.html">13</a>
+    </li>
     <li class="active pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="yfm-context.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
-      <a href="md-helper.html">&larr; Previous</a>
+      <a href="no-yfm-data.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
+    <li>
+      <a href="no-yfm-data.html">13</a>
+    </li>
     <li class="active">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="yfm-context.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -704,8 +473,8 @@
 
             There is no YAML front matter in this page.
 
-<div></div>
-<div></div>
+<div>Variable number one</div>
+<div>Variable number two</div>
 
 
 
@@ -714,37 +483,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -787,262 +541,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/asc/debug-helpers.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/asc/no-yfm.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/asc/debug-helpers.html
-                  dirname:       test/actual/collections/asc
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/asc/alert.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/asc/no-yfm.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/asc/alert.html
-                  dirname:       test/actual/collections/asc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/asc/collections-pages.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/asc/no-yfm.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/asc/collections-pages.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/asc/collections-tags.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/asc/no-yfm.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/asc/collections-tags.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/asc/collections.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/asc/no-yfm.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/asc/collections.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/asc/complex.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/asc/no-yfm.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/asc/complex.html
-                  dirname:       test/actual/collections/asc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/asc/context.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/asc/no-yfm.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/asc/context.html
-                  dirname:       test/actual/collections/asc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/asc/collections-categories.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/asc/no-yfm.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/asc/collections-categories.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1075,7 +573,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/asc/alert.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/asc/alert.html
+                  dirname:       test/actual/collections/asc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/asc/collections-pages.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/asc/collections-pages.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/asc/collections-tags.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/asc/collections-tags.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/asc/collections.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/asc/collections.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/asc/complex.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/asc/complex.html
+                  dirname:       test/actual/collections/asc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/asc/context.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/asc/context.html
+                  dirname:       test/actual/collections/asc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/asc/debug-helpers.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/asc/debug-helpers.html
+                  dirname:       test/actual/collections/asc
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/asc/collections-categories.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/asc/collections-categories.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1107,7 +861,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1139,7 +893,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1171,7 +925,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/asc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/asc/no-yfm.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/asc/no-yfm-data.html
+                  dirname:       test/actual/collections/asc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1203,7 +989,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1235,7 +1021,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1267,7 +1053,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1295,6 +1080,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1309,16 +1095,16 @@
   },
   "filename": "no-yfm.html",
   "first": false,
-  "index": 12,
+  "index": 13,
   "isCurrentPage": false,
   "last": false,
   "middle": true,
-  "next": 13,
-  "number": 13,
+  "next": 14,
+  "number": 14,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            There is no YAML front matter in this page.\n\n<div>{{noyfm.one}}</div>\n<div>{{noyfm.two}}</div>\n\n\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "no-yfm.html",
   "pagename": "no-yfm.html",
-  "prev": 11,
+  "prev": 12,
   "relativeLink": "no-yfm.html",
   "src": "test/fixtures/pages/no-yfm.hbs"
 }

--- a/test/actual/collections/asc/yfm-context.html
+++ b/test/actual/collections/asc/yfm-context.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="no-yfm.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="no-yfm.html">14</a>
+    </li>
     <li class="active pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="yfm.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="no-yfm.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
+    <li>
+      <a href="no-yfm.html">14</a>
+    </li>
     <li class="active">
-      <a href="yfm-context.html">14</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="yfm.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yfm</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">context</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yfm</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">context</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -711,8 +476,8 @@
             
 
 <div class="page-header">
-  <h1>Title from home.json didn't render.</h1>
-  <p class="lead">Description from home.json didn't render.</p>
+  <h1>This title is from a JSON file.</h1>
+  <p class="lead">This description is from a JSON file.</p>
 </div>
 
 <hr>
@@ -736,37 +501,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -809,262 +559,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/asc/debug-helpers.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/asc/yfm-context.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/asc/debug-helpers.html
-                  dirname:       test/actual/collections/asc
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/asc/alert.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/asc/yfm-context.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/asc/alert.html
-                  dirname:       test/actual/collections/asc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/asc/collections-pages.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/asc/yfm-context.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/asc/collections-pages.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/asc/collections-tags.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/asc/yfm-context.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/asc/collections-tags.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/asc/collections.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/asc/yfm-context.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/asc/collections.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/asc/complex.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/asc/yfm-context.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/asc/complex.html
-                  dirname:       test/actual/collections/asc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/asc/context.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/asc/yfm-context.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/asc/context.html
-                  dirname:       test/actual/collections/asc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/asc/collections-categories.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/asc/yfm-context.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/asc/collections-categories.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1097,7 +591,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/asc/alert.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/asc/yfm-context.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/asc/alert.html
+                  dirname:       test/actual/collections/asc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/asc/collections-pages.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/asc/yfm-context.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/asc/collections-pages.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/asc/collections-tags.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/asc/yfm-context.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/asc/collections-tags.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/asc/collections.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/asc/yfm-context.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/asc/collections.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/asc/complex.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/asc/yfm-context.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/asc/complex.html
+                  dirname:       test/actual/collections/asc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/asc/context.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/asc/yfm-context.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/asc/context.html
+                  dirname:       test/actual/collections/asc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/asc/debug-helpers.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/asc/yfm-context.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/asc/debug-helpers.html
+                  dirname:       test/actual/collections/asc
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/asc/collections-categories.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/asc/yfm-context.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/asc/collections-categories.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1129,7 +879,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1161,7 +911,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1193,7 +943,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/asc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/asc/yfm-context.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/asc/no-yfm-data.html
+                  dirname:       test/actual/collections/asc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1225,7 +1007,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1257,7 +1039,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1289,7 +1071,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1331,6 +1112,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1345,16 +1127,16 @@
   },
   "filename": "yfm-context.html",
   "first": false,
-  "index": 13,
+  "index": 14,
   "isCurrentPage": false,
   "last": false,
   "middle": true,
-  "next": 14,
-  "number": 14,
+  "next": 15,
+  "number": 15,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n\n<div class=\"page-header\">\n  <h1>{{{default home.title \"Title from home.json didn't render.\"}}}</h1>\n  <p class=\"lead\">{{{default home.description \"Description from home.json didn't render.\"}}}</p>\n</div>\n\n<hr>\n\n<div class=\"page-header\">\n  <h1>{{{default page.title \"page.title didn't render.\"}}}</h1>\n  <p class=\"lead\">{{{default page.description \"page.description didn't render.\"}}}</p>\n</div>\n\n<hr>\n\n<div class=\"page-header\">\n  <h1>{{{default title \"title didn't render.\"}}}</h1>\n  <p class=\"lead\">{{{default description \"description didn't render.\"}}}</p>\n</div>\n\n\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "yfm-context.html",
   "pagename": "yfm-context.html",
-  "prev": 12,
+  "prev": 13,
   "relativeLink": "yfm-context.html",
   "src": "test/fixtures/pages/yfm-context.hbs",
   "title": "This title is from the YFM of the current page"

--- a/test/actual/collections/asc/yfm.html
+++ b/test/actual/collections/asc/yfm.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="yfm-context.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm-context.html">15</a>
+    </li>
     <li class="active pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="yfm-context.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
+    <li>
+      <a href="yfm-context.html">15</a>
+    </li>
     <li class="active">
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -711,37 +480,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -784,262 +538,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/asc/debug-helpers.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/asc/yfm.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/asc/debug-helpers.html
-                  dirname:       test/actual/collections/asc
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/asc/alert.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/asc/yfm.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/asc/alert.html
-                  dirname:       test/actual/collections/asc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/asc/collections-pages.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/asc/yfm.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/asc/collections-pages.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/asc/collections-tags.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/asc/yfm.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/asc/collections-tags.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/asc/collections.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/asc/yfm.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/asc/collections.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/asc/complex.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/asc/yfm.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/asc/complex.html
-                  dirname:       test/actual/collections/asc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/asc/context.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/asc/yfm.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/asc/context.html
-                  dirname:       test/actual/collections/asc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/asc/collections-categories.html
-                  this.dirname:  test/actual/collections/asc
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/asc/yfm.html
-                  page.dirname:  test/actual/collections/asc
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/asc/collections-categories.html
-                  dirname:       test/actual/collections/asc
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1072,7 +570,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/asc/alert.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/asc/yfm.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/asc/alert.html
+                  dirname:       test/actual/collections/asc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/asc/collections-pages.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/asc/yfm.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/asc/collections-pages.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/asc/collections-tags.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/asc/yfm.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/asc/collections-tags.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/asc/collections.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/asc/yfm.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/asc/collections.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/asc/complex.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/asc/yfm.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/asc/complex.html
+                  dirname:       test/actual/collections/asc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/asc/context.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/asc/yfm.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/asc/context.html
+                  dirname:       test/actual/collections/asc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/asc/debug-helpers.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/asc/yfm.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/asc/debug-helpers.html
+                  dirname:       test/actual/collections/asc
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/asc/collections-categories.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/asc/yfm.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/asc/collections-categories.html
+                  dirname:       test/actual/collections/asc
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1104,7 +858,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1136,7 +890,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1168,7 +922,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/asc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/asc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/asc/yfm.html
+                  page.dirname:  test/actual/collections/asc
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/asc/no-yfm-data.html
+                  dirname:       test/actual/collections/asc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1200,7 +986,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1232,7 +1018,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1264,7 +1050,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1299,6 +1084,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1314,7 +1100,7 @@
   "filename": "yfm.html",
   "first": false,
   "foo": "bar",
-  "index": 14,
+  "index": 15,
   "isCurrentPage": false,
   "items": [
     "alpha",
@@ -1322,11 +1108,11 @@
   ],
   "last": true,
   "middle": false,
-  "number": 15,
+  "number": 16,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n\n<div class=\"alert alert-info\">This is an alert</div>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "yfm.html",
   "pagename": "yfm.html",
-  "prev": 13,
+  "prev": 14,
   "relativeLink": "yfm.html",
   "src": "test/fixtures/pages/yfm.hbs",
   "title": "YFM"

--- a/test/actual/collections/complex/alert.html
+++ b/test/actual/collections/complex/alert.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
-      <a href="debug-helpers.html">&larr; Previous</a>
+      <a href="example.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="collections-pages.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
-      <a href="debug-helpers.html">&larr; Previous</a>
+      <a href="example.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="active">
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="collections-pages.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,286 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">components</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">components</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">2</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">2</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -718,37 +482,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -791,262 +540,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/complex/debug-helpers.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/complex/alert.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/complex/debug-helpers.html
-                  dirname:       test/actual/collections/complex
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/complex/alert.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/complex/alert.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/complex/alert.html
-                  dirname:       test/actual/collections/complex
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/complex/collections-pages.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/complex/alert.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/complex/collections-pages.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/complex/collections-tags.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/complex/alert.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/complex/collections-tags.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/complex/collections.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/complex/alert.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/complex/collections.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/complex/complex.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/complex/alert.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/complex/complex.html
-                  dirname:       test/actual/collections/complex
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/complex/context.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/complex/alert.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/complex/context.html
-                  dirname:       test/actual/collections/complex
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/complex/collections-categories.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/complex/alert.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/complex/collections-categories.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1079,7 +572,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/complex/alert.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/complex/alert.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/complex/alert.html
+                  dirname:       test/actual/collections/complex
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/complex/collections-pages.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/complex/alert.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/complex/collections-pages.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/complex/collections-tags.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/complex/alert.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/complex/collections-tags.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/complex/collections.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/complex/alert.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/complex/collections.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/complex/complex.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/complex/alert.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/complex/complex.html
+                  dirname:       test/actual/collections/complex
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/complex/context.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/complex/alert.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/complex/context.html
+                  dirname:       test/actual/collections/complex
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/complex/debug-helpers.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/complex/alert.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/complex/debug-helpers.html
+                  dirname:       test/actual/collections/complex
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/complex/collections-categories.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/complex/alert.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/complex/collections-categories.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1111,7 +860,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1143,7 +892,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1175,7 +924,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/complex/no-yfm-data.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/complex/alert.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/complex/no-yfm-data.html
+                  dirname:       test/actual/collections/complex
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1207,7 +988,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1239,7 +1020,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1271,7 +1052,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1318,6 +1098,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/complex/collections-categories.html
+++ b/test/actual/collections/complex/collections-categories.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
-      <a href="context.html">&larr; Previous</a>
+      <a href="debug-helpers.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
-    <li class="active pager-middle">
-      <a href="collections-categories.html">8</a>
-    </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
+    <li class="active pager-middle">
+      <a href="collections-categories.html">9</a>
+    </li>
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="example.html">Next &rarr;</a>
+      <a href="gist-helper.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
-      <a href="context.html">&larr; Previous</a>
+      <a href="debug-helpers.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
-    <li class="active">
-      <a href="collections-categories.html">8</a>
-    </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
+    <li class="active">
+      <a href="collections-categories.html">9</a>
+    </li>
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="example.html">Next &rarr;</a>
+      <a href="gist-helper.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,488 +187,289 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">5</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">three</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">5</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">three</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -718,33 +481,19 @@
     <h4>Categories</h4>
   </div>
   <div class="panel-body">
-  
     <span class="label label-info">categories</span>
-  
     <span class="label label-info">collections</span>
-  
     <span class="label label-info">components</span>
-  
     <span class="label label-info">context</span>
-  
     <span class="label label-info">fixtures</span>
-  
     <span class="label label-info">helper</span>
-  
     <span class="label label-info">markdown</span>
-  
     <span class="label label-info">one</span>
-  
     <span class="label label-info">pages</span>
-  
     <span class="label label-info">three</span>
-  
     <span class="label label-info">two</span>
-  
     <span class="label label-info">yaml</span>
-  
     <span class="label label-info">yfm</span>
-  
   </div>
 </div>
 
@@ -752,37 +501,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -825,262 +559,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/complex/debug-helpers.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/complex/collections-categories.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/complex/debug-helpers.html
-                  dirname:       test/actual/collections/complex
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/complex/alert.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/complex/collections-categories.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/complex/alert.html
-                  dirname:       test/actual/collections/complex
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/complex/collections-pages.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/complex/collections-categories.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/complex/collections-pages.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/complex/collections-tags.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/complex/collections-categories.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/complex/collections-tags.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/complex/collections.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/complex/collections-categories.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/complex/collections.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/complex/complex.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/complex/collections-categories.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/complex/complex.html
-                  dirname:       test/actual/collections/complex
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/complex/context.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/complex/collections-categories.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/complex/context.html
-                  dirname:       test/actual/collections/complex
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/complex/collections-categories.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/complex/collections-categories.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/complex/collections-categories.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1113,7 +591,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/complex/alert.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/complex/collections-categories.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/complex/alert.html
+                  dirname:       test/actual/collections/complex
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/complex/collections-pages.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/complex/collections-categories.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/complex/collections-pages.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/complex/collections-tags.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/complex/collections-categories.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/complex/collections-tags.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/complex/collections.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/complex/collections-categories.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/complex/collections.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/complex/complex.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/complex/collections-categories.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/complex/complex.html
+                  dirname:       test/actual/collections/complex
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/complex/context.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/complex/collections-categories.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/complex/context.html
+                  dirname:       test/actual/collections/complex
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/complex/debug-helpers.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/complex/collections-categories.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/complex/debug-helpers.html
+                  dirname:       test/actual/collections/complex
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/complex/collections-categories.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/complex/collections-categories.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/complex/collections-categories.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1145,7 +879,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1177,7 +911,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1209,7 +943,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/complex/no-yfm-data.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/complex/collections-categories.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/complex/no-yfm-data.html
+                  dirname:       test/actual/collections/complex
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1241,7 +1007,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1273,7 +1039,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1305,7 +1071,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1349,6 +1114,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1363,16 +1129,16 @@
   },
   "filename": "collections-categories.html",
   "first": false,
-  "index": 7,
+  "index": 8,
   "isCurrentPage": false,
   "last": false,
   "middle": true,
-  "next": 8,
-  "number": 8,
+  "next": 9,
+  "number": 9,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n<div class=\"panel panel-info\">\n  <div class=\"panel-heading\">\n    <h4>Categories</h4>\n  </div>\n  <div class=\"panel-body\">\n  {{#categories}}\n    <span class=\"label label-info\">{{category}}</span>\n  {{/categories}}\n  </div>\n</div>\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "collections-categories.html",
   "pagename": "collections-categories.html",
-  "prev": 6,
+  "prev": 7,
   "relativeLink": "collections-categories.html",
   "src": "test/fixtures/pages/collections-categories.hbs",
   "title": "Collections Categories"

--- a/test/actual/collections/complex/collections-pages.html
+++ b/test/actual/collections/complex/collections-pages.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="alert.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="collections-tags.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="alert.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li class="active">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="collections-tags.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,480 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">pages</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">pages</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -710,37 +477,22 @@
     <h4>Pages Collection</h4>
   </div>
   <div class="panel-body">
-    
-      <a href="#">Debug Helper</a>
-    
-      <a href="#">Title for "alert.hbs"</a>
-    
-      <a href="#">Pages Collection</a>
-    
-      <a href="#">Tags Test</a>
-    
-      <a href="#">Collections</a>
-    
-      <a href="#">Complex YFM</a>
-    
-      <a href="#">Context</a>
-    
-      <a href="#">Collections Categories</a>
-    
       <a href="#">Title from YFM of "example.hbs"</a>
-    
+      <a href="#">Title for "alert.hbs"</a>
+      <a href="#">Pages Collection</a>
+      <a href="#">Tags Test</a>
+      <a href="#">Collections</a>
+      <a href="#">Complex YFM</a>
+      <a href="#">Context</a>
+      <a href="#">Debug Helper</a>
+      <a href="#">Collections Categories</a>
       <a href="#">Gist Helper</a>
-    
       <a href="#"><%= site.title %></a>
-    
       <a href="#">md helper</a>
-    
       <a href="#"></a>
-    
+      <a href="#"></a>
       <a href="#">This title is from the YFM of the current page</a>
-    
       <a href="#">YFM</a>
-    
   </div>
 </div>
 
@@ -748,37 +500,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -821,262 +558,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/complex/debug-helpers.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/complex/collections-pages.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/complex/debug-helpers.html
-                  dirname:       test/actual/collections/complex
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/complex/alert.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/complex/collections-pages.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/complex/alert.html
-                  dirname:       test/actual/collections/complex
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/complex/collections-pages.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/complex/collections-pages.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/complex/collections-pages.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/complex/collections-tags.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/complex/collections-pages.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/complex/collections-tags.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/complex/collections.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/complex/collections-pages.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/complex/collections.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/complex/complex.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/complex/collections-pages.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/complex/complex.html
-                  dirname:       test/actual/collections/complex
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/complex/context.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/complex/collections-pages.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/complex/context.html
-                  dirname:       test/actual/collections/complex
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/complex/collections-categories.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/complex/collections-pages.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/complex/collections-categories.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1109,7 +590,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/complex/alert.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/complex/collections-pages.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/complex/alert.html
+                  dirname:       test/actual/collections/complex
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/complex/collections-pages.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/complex/collections-pages.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/complex/collections-pages.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/complex/collections-tags.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/complex/collections-pages.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/complex/collections-tags.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/complex/collections.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/complex/collections-pages.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/complex/collections.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/complex/complex.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/complex/collections-pages.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/complex/complex.html
+                  dirname:       test/actual/collections/complex
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/complex/context.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/complex/collections-pages.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/complex/context.html
+                  dirname:       test/actual/collections/complex
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/complex/debug-helpers.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/complex/collections-pages.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/complex/debug-helpers.html
+                  dirname:       test/actual/collections/complex
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/complex/collections-categories.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/complex/collections-pages.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/complex/collections-categories.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1141,7 +878,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1173,7 +910,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1205,7 +942,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/complex/no-yfm-data.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/complex/collections-pages.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/complex/no-yfm-data.html
+                  dirname:       test/actual/collections/complex
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1237,7 +1006,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1269,7 +1038,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1301,7 +1070,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1334,6 +1102,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/complex/collections-tags.html
+++ b/test/actual/collections/complex/collections-tags.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="collections-pages.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="collections.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="collections-pages.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="active">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="collections.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,488 +187,289 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">5</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">two</span>
-    
-      <span class="label label-success">three</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">5</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">two</span>
+                        <span class="label label-success">three</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -718,37 +481,21 @@
     <h4>Tags</h4>
   </div>
   <div class="panel-body">
-  
     <span class="label label-success">alert</span>
-  
     <span class="label label-success">bootstrap</span>
-  
     <span class="label label-success">collections</span>
-  
     <span class="label label-success">complex</span>
-  
     <span class="label label-success">example</span>
-  
     <span class="label label-success">examples</span>
-  
     <span class="label label-success">markdown</span>
-  
     <span class="label label-success">md</span>
-  
     <span class="label label-success">one</span>
-  
     <span class="label label-success">pages</span>
-  
     <span class="label label-success">tags</span>
-  
     <span class="label label-success">test</span>
-  
     <span class="label label-success">tests</span>
-  
     <span class="label label-success">three</span>
-  
     <span class="label label-success">two</span>
-  
   </div>
 </div>
 
@@ -756,37 +503,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -829,262 +561,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/complex/debug-helpers.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/complex/collections-tags.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/complex/debug-helpers.html
-                  dirname:       test/actual/collections/complex
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/complex/alert.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/complex/collections-tags.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/complex/alert.html
-                  dirname:       test/actual/collections/complex
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/complex/collections-pages.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/complex/collections-tags.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/complex/collections-pages.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/complex/collections-tags.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/complex/collections-tags.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/complex/collections-tags.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/complex/collections.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/complex/collections-tags.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/complex/collections.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/complex/complex.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/complex/collections-tags.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/complex/complex.html
-                  dirname:       test/actual/collections/complex
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/complex/context.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/complex/collections-tags.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/complex/context.html
-                  dirname:       test/actual/collections/complex
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/complex/collections-categories.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/complex/collections-tags.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/complex/collections-categories.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1117,7 +593,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/complex/alert.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/complex/collections-tags.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/complex/alert.html
+                  dirname:       test/actual/collections/complex
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/complex/collections-pages.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/complex/collections-tags.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/complex/collections-pages.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/complex/collections-tags.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/complex/collections-tags.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/complex/collections-tags.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/complex/collections.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/complex/collections-tags.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/complex/collections.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/complex/complex.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/complex/collections-tags.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/complex/complex.html
+                  dirname:       test/actual/collections/complex
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/complex/context.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/complex/collections-tags.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/complex/context.html
+                  dirname:       test/actual/collections/complex
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/complex/debug-helpers.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/complex/collections-tags.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/complex/debug-helpers.html
+                  dirname:       test/actual/collections/complex
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/complex/collections-categories.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/complex/collections-tags.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/complex/collections-categories.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1149,7 +881,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1181,7 +913,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1213,7 +945,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/complex/no-yfm-data.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/complex/collections-tags.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/complex/no-yfm-data.html
+                  dirname:       test/actual/collections/complex
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1245,7 +1009,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1277,7 +1041,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1309,7 +1073,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1346,6 +1109,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/complex/collections.html
+++ b/test/actual/collections/complex/collections.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="collections-tags.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="complex.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="collections-tags.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="active">
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="complex.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">one</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li class="active">
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li class="active">
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li class="active">
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">one</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li class="active">
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li class="active">
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li class="active">
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -711,101 +476,56 @@
             
 Collections
 <ul class="tags">
-
   <li>alert</li>
-
   <li>bootstrap</li>
-
   <li>collections</li>
-
   <li>complex</li>
-
   <li>example</li>
-
   <li>examples</li>
-
   <li>markdown</li>
-
   <li>md</li>
-
   <li>one</li>
-
   <li>pages</li>
-
   <li>tags</li>
-
   <li>test</li>
-
   <li>tests</li>
-
   <li>three</li>
-
   <li>two</li>
-
 </ul>
 
 <ul class="categories">
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
 </ul>
 
 <ul class="pages">
-
-	<li>debug-helpers</li>
-
-	<li>alert</li>
-
-	<li>collections-pages</li>
-
-	<li>collections-tags</li>
-
-	<li>collections</li>
-
-	<li>complex</li>
-
-	<li>context</li>
-
-	<li>collections-categories</li>
-
 	<li>example</li>
-
+	<li>alert</li>
+	<li>collections-pages</li>
+	<li>collections-tags</li>
+	<li>collections</li>
+	<li>complex</li>
+	<li>context</li>
+	<li>debug-helpers</li>
+	<li>collections-categories</li>
 	<li>gist-helper</li>
-
 	<li>lodash</li>
-
 	<li>md-helper</li>
-
+	<li>no-yfm-data</li>
 	<li>no-yfm</li>
-
 	<li>yfm-context</li>
-
 	<li>yfm</li>
-
 </ul>
 
 
@@ -813,37 +533,22 @@ Collections
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -886,262 +591,6 @@ Collections
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/complex/debug-helpers.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/complex/collections.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/complex/debug-helpers.html
-                  dirname:       test/actual/collections/complex
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/complex/alert.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/complex/collections.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/complex/alert.html
-                  dirname:       test/actual/collections/complex
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/complex/collections-pages.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/complex/collections.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/complex/collections-pages.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/complex/collections-tags.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/complex/collections.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/complex/collections-tags.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/complex/collections.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/complex/collections.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/complex/collections.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/complex/complex.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/complex/collections.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/complex/complex.html
-                  dirname:       test/actual/collections/complex
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/complex/context.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/complex/collections.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/complex/context.html
-                  dirname:       test/actual/collections/complex
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/complex/collections-categories.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/complex/collections.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/complex/collections-categories.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1174,7 +623,263 @@ Collections
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/complex/alert.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/complex/collections.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/complex/alert.html
+                  dirname:       test/actual/collections/complex
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/complex/collections-pages.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/complex/collections.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/complex/collections-pages.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/complex/collections-tags.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/complex/collections.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/complex/collections-tags.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/complex/collections.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/complex/collections.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/complex/collections.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/complex/complex.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/complex/collections.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/complex/complex.html
+                  dirname:       test/actual/collections/complex
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/complex/context.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/complex/collections.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/complex/context.html
+                  dirname:       test/actual/collections/complex
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/complex/debug-helpers.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/complex/collections.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/complex/debug-helpers.html
+                  dirname:       test/actual/collections/complex
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/complex/collections-categories.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/complex/collections.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/complex/collections-categories.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1206,7 +911,7 @@ Collections
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1238,7 +943,7 @@ Collections
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1270,7 +975,39 @@ Collections
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/complex/no-yfm-data.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/complex/collections.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/complex/no-yfm-data.html
+                  dirname:       test/actual/collections/complex
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1302,7 +1039,7 @@ Collections
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1334,7 +1071,7 @@ Collections
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1366,7 +1103,6 @@ Collections
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1405,6 +1141,7 @@ Collections
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/complex/complex.html
+++ b/test/actual/collections/complex/complex.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="collections.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="context.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="collections.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li class="active">
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="context.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,486 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">pages</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">pages</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">complex</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">complex</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -719,37 +482,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -792,262 +540,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/complex/debug-helpers.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/complex/complex.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/complex/debug-helpers.html
-                  dirname:       test/actual/collections/complex
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/complex/alert.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/complex/complex.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/complex/alert.html
-                  dirname:       test/actual/collections/complex
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/complex/collections-pages.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/complex/complex.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/complex/collections-pages.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/complex/collections-tags.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/complex/complex.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/complex/collections-tags.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/complex/collections.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/complex/complex.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/complex/collections.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/complex/complex.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/complex/complex.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/complex/complex.html
-                  dirname:       test/actual/collections/complex
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/complex/context.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/complex/complex.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/complex/context.html
-                  dirname:       test/actual/collections/complex
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/complex/collections-categories.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/complex/complex.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/complex/collections-categories.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1080,7 +572,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/complex/alert.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/complex/complex.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/complex/alert.html
+                  dirname:       test/actual/collections/complex
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/complex/collections-pages.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/complex/complex.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/complex/collections-pages.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/complex/collections-tags.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/complex/complex.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/complex/collections-tags.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/complex/collections.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/complex/complex.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/complex/collections.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/complex/complex.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/complex/complex.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/complex/complex.html
+                  dirname:       test/actual/collections/complex
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/complex/context.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/complex/complex.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/complex/context.html
+                  dirname:       test/actual/collections/complex
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/complex/debug-helpers.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/complex/complex.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/complex/debug-helpers.html
+                  dirname:       test/actual/collections/complex
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/complex/collections-categories.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/complex/complex.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/complex/collections-categories.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1112,7 +860,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1144,7 +892,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1176,7 +924,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/complex/no-yfm-data.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/complex/complex.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/complex/no-yfm-data.html
+                  dirname:       test/actual/collections/complex
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1208,7 +988,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1240,7 +1020,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1272,7 +1052,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1319,6 +1098,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/complex/context.html
+++ b/test/actual/collections/complex/context.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="complex.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="collections-categories.html">Next &rarr;</a>
+      <a href="debug-helpers.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="complex.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li class="active">
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="collections-categories.html">Next &rarr;</a>
+      <a href="debug-helpers.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">fixtures</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -753,193 +518,171 @@
 <hr>
 
 <ul class="context-test">
-
-  <li><a href="#" data-context="basename">debug-helpers</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">debug-helpers</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">alert</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">alert</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections-pages</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections-pages</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections-tags</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections-tags</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">complex</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">complex</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">context</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">context</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections-categories</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections-categories</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">example</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">example</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
+  <li><a href="#" data-context="basename">alert</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">alert</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections-pages</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections-pages</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections-tags</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections-tags</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">complex</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">complex</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">context</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">context</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">debug-helpers</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">debug-helpers</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections-categories</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections-categories</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
   <li><a href="#" data-context="basename">gist-helper</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">gist-helper</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">lodash</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">lodash</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">md-helper</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">md-helper</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
+  <li><a href="#" data-context="basename">no-yfm-data</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">no-yfm-data</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
   <li><a href="#" data-context="basename">no-yfm</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">no-yfm</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">yfm-context</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">yfm-context</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">yfm</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">yfm</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
 </ul>
 
 <hr>
 
 <ul class="context-test">
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Debug Helper</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Title for &quot;alert.hbs&quot;</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Pages Collection</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Tags Test</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Collections</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Complex YFM</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Context</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Collections Categories</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">Title from YFM of &quot;example.hbs&quot;</a></li>
-
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Title for &quot;alert.hbs&quot;</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Pages Collection</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Tags Test</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Collections</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Complex YFM</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Context</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Debug Helper</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Collections Categories</a></li>
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">Gist Helper</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">&lt;%= site.title %&gt;</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">md helper</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title"></a></li>
-
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title"></a></li>
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">This title is from the YFM of the current page</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">YFM</a></li>
-
 </ul>
 
 
@@ -947,37 +690,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -1020,262 +748,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/complex/debug-helpers.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/complex/context.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/complex/debug-helpers.html
-                  dirname:       test/actual/collections/complex
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/complex/alert.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/complex/context.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/complex/alert.html
-                  dirname:       test/actual/collections/complex
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/complex/collections-pages.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/complex/context.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/complex/collections-pages.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/complex/collections-tags.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/complex/context.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/complex/collections-tags.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/complex/collections.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/complex/context.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/complex/collections.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/complex/complex.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/complex/context.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/complex/complex.html
-                  dirname:       test/actual/collections/complex
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/complex/context.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/complex/context.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/complex/context.html
-                  dirname:       test/actual/collections/complex
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/complex/collections-categories.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/complex/context.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/complex/collections-categories.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1308,7 +780,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/complex/alert.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/complex/context.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/complex/alert.html
+                  dirname:       test/actual/collections/complex
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/complex/collections-pages.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/complex/context.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/complex/collections-pages.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/complex/collections-tags.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/complex/context.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/complex/collections-tags.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/complex/collections.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/complex/context.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/complex/collections.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/complex/complex.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/complex/context.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/complex/complex.html
+                  dirname:       test/actual/collections/complex
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/complex/context.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/complex/context.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/complex/context.html
+                  dirname:       test/actual/collections/complex
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/complex/debug-helpers.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/complex/context.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/complex/debug-helpers.html
+                  dirname:       test/actual/collections/complex
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/complex/collections-categories.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/complex/context.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/complex/collections-categories.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1340,7 +1068,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1372,7 +1100,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1404,7 +1132,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/complex/no-yfm-data.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/complex/context.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/complex/no-yfm-data.html
+                  dirname:       test/actual/collections/complex
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1436,7 +1196,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1468,7 +1228,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1500,7 +1260,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1546,6 +1305,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/complex/debug-helpers.html
+++ b/test/actual/collections/complex/debug-helpers.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
-    <li class="previous disabled">
-      <a unselectable="on" class="unselectable">First</a>
-    </li>
-    <li class="previous disabled">
-      <a unselectable="on" class="unselectable">&larr; Previous</a>
-    </li>
-  
 
-  
-
-  
-    <li class="active pager-middle">
-      <a href="debug-helpers.html">1</a>
+    <li class="previous">
+      <a href="example.html">First</a>
     </li>
-  
+    <li class="previous">
+      <a href="context.html">&larr; Previous</a>
+    </li>
+
+    <li class="pager-middle">
+      <a href="example.html">1</a>
+    </li>
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
-    <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+    <li class="active pager-middle">
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="alert.html">Next &rarr;</a>
+      <a href="collections-categories.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
-    <li class="prev disabled">
-      <a unselectable="on" class="unselectable">First</a>
-    </li>
-    <li class="prev disabled">
-      <a unselectable="on" class="unselectable">&larr; Previous</a>
-    </li>
-  
 
-  
-
-  
-    <li class="active">
-      <a href="debug-helpers.html">1</a>
+    <li class="prev">
+      <a href="example.html">First</a>
     </li>
-  
+    <li class="prev">
+      <a href="context.html">&larr; Previous</a>
+    </li>
+
+    <li>
+      <a href="example.html">1</a>
+    </li>
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
-    <li>
-      <a href="collections-categories.html">8</a>
+    <li class="active">
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="alert.html">Next &rarr;</a>
+      <a href="collections-categories.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -707,42 +476,26 @@
 <p>Uncomment the <code>debug</code> helper below, run <code>grunt assemble</code>, and watch the output in the command line to see how it works.</p>
 
 
-
             <div class="docs-header" id="content">
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -785,262 +538,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/complex/debug-helpers.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/complex/debug-helpers.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/complex/debug-helpers.html
-                  dirname:       test/actual/collections/complex
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/complex/alert.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/complex/debug-helpers.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/complex/alert.html
-                  dirname:       test/actual/collections/complex
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/complex/collections-pages.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/complex/debug-helpers.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/complex/collections-pages.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/complex/collections-tags.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/complex/debug-helpers.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/complex/collections-tags.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/complex/collections.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/complex/debug-helpers.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/complex/collections.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/complex/complex.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/complex/debug-helpers.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/complex/complex.html
-                  dirname:       test/actual/collections/complex
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/complex/context.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/complex/debug-helpers.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/complex/context.html
-                  dirname:       test/actual/collections/complex
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/complex/collections-categories.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/complex/debug-helpers.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/complex/collections-categories.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1073,7 +570,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/complex/alert.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/complex/debug-helpers.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/complex/alert.html
+                  dirname:       test/actual/collections/complex
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/complex/collections-pages.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/complex/debug-helpers.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/complex/collections-pages.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/complex/collections-tags.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/complex/debug-helpers.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/complex/collections-tags.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/complex/collections.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/complex/debug-helpers.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/complex/collections.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/complex/complex.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/complex/debug-helpers.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/complex/complex.html
+                  dirname:       test/actual/collections/complex
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/complex/context.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/complex/debug-helpers.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/complex/context.html
+                  dirname:       test/actual/collections/complex
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/complex/debug-helpers.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/complex/debug-helpers.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/complex/debug-helpers.html
+                  dirname:       test/actual/collections/complex
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/complex/collections-categories.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/complex/debug-helpers.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/complex/collections-categories.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1105,7 +858,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1137,7 +890,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1169,7 +922,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/complex/no-yfm-data.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/complex/debug-helpers.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/complex/no-yfm-data.html
+                  dirname:       test/actual/collections/complex
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1201,7 +986,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1233,7 +1018,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1265,7 +1050,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1295,6 +1079,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1308,15 +1093,18 @@
     }
   },
   "filename": "debug-helpers.html",
-  "first": true,
-  "index": 0,
+  "first": false,
+  "index": 7,
+  "isCurrentPage": false,
   "last": false,
-  "middle": false,
-  "next": 1,
-  "number": 1,
+  "middle": true,
+  "next": 8,
+  "number": 8,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n{{#markdown}}\n\n### \\{{debug}} helper\nUncomment the `debug` helper below, run `grunt assemble`, and watch the output in the command line to see how it works.\n{{!debug text}}\n\n{{/markdown}}\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "debug-helpers.html",
   "pagename": "debug-helpers.html",
+  "prev": 6,
+  "relativeLink": "debug-helpers.html",
   "src": "test/fixtures/pages/debug-helpers.hbs",
   "title": "Debug Helper"
 }

--- a/test/actual/collections/complex/example.html
+++ b/test/actual/collections/complex/example.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
+    <li class="previous disabled">
+      <a unselectable="on" class="unselectable">First</a>
+    </li>
+    <li class="previous disabled">
+      <a unselectable="on" class="unselectable">&larr; Previous</a>
+    </li>
 
-  
-    <li class="previous">
-      <a href="debug-helpers.html">First</a>
-    </li>
-    <li class="previous">
-      <a href="collections-categories.html">&larr; Previous</a>
-    </li>
-  
 
-  
-    <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+    <li class="active pager-middle">
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
-    <li class="active pager-middle">
-      <a href="example.html">9</a>
+    <li class="pager-middle">
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="gist-helper.html">Next &rarr;</a>
+      <a href="alert.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
+    <li class="prev disabled">
+      <a unselectable="on" class="unselectable">First</a>
+    </li>
+    <li class="prev disabled">
+      <a unselectable="on" class="unselectable">&larr; Previous</a>
+    </li>
 
-  
-    <li class="prev">
-      <a href="debug-helpers.html">First</a>
-    </li>
-    <li class="prev">
-      <a href="collections-categories.html">&larr; Previous</a>
-    </li>
-  
 
-  
-    <li>
-      <a href="debug-helpers.html">1</a>
+    <li class="active">
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
-    <li class="active">
-      <a href="example.html">9</a>
+    <li>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="gist-helper.html">Next &rarr;</a>
+      <a href="alert.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,286 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">2</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">2</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">example</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">example</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -726,37 +490,22 @@ This example shows that the properties from "example.json" and "example.hbs" are
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -799,262 +548,6 @@ This example shows that the properties from "example.json" and "example.hbs" are
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/complex/debug-helpers.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/complex/example.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/complex/debug-helpers.html
-                  dirname:       test/actual/collections/complex
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/complex/alert.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/complex/example.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/complex/alert.html
-                  dirname:       test/actual/collections/complex
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/complex/collections-pages.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/complex/example.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/complex/collections-pages.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/complex/collections-tags.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/complex/example.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/complex/collections-tags.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/complex/collections.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/complex/example.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/complex/collections.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/complex/complex.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/complex/example.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/complex/complex.html
-                  dirname:       test/actual/collections/complex
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/complex/context.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/complex/example.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/complex/context.html
-                  dirname:       test/actual/collections/complex
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/complex/collections-categories.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/complex/example.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/complex/collections-categories.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1087,7 +580,263 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/complex/alert.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/complex/example.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/complex/alert.html
+                  dirname:       test/actual/collections/complex
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/complex/collections-pages.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/complex/example.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/complex/collections-pages.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/complex/collections-tags.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/complex/example.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/complex/collections-tags.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/complex/collections.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/complex/example.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/complex/collections.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/complex/complex.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/complex/example.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/complex/complex.html
+                  dirname:       test/actual/collections/complex
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/complex/context.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/complex/example.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/complex/context.html
+                  dirname:       test/actual/collections/complex
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/complex/debug-helpers.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/complex/example.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/complex/debug-helpers.html
+                  dirname:       test/actual/collections/complex
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/complex/collections-categories.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/complex/example.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/complex/collections-categories.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1119,7 +868,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1151,7 +900,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1183,7 +932,39 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/complex/no-yfm-data.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/complex/example.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/complex/no-yfm-data.html
+                  dirname:       test/actual/collections/complex
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1215,7 +996,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1247,7 +1028,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1279,7 +1060,6 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1324,6 +1104,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1337,22 +1118,19 @@ This example shows that the properties from "example.json" and "example.hbs" are
     }
   },
   "filename": "example.html",
-  "first": false,
-  "index": 8,
-  "isCurrentPage": false,
+  "first": true,
+  "index": 0,
   "items": [
     "omega",
     "gamma"
   ],
   "last": false,
-  "middle": true,
-  "next": 9,
-  "number": 9,
+  "middle": false,
+  "next": 1,
+  "number": 1,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n\nThis example shows that the properties from \"example.json\" and \"example.hbs\" are on the page object.\n\n<hr>\n\n<div>{{page.title}}</div>\n<div>{{page.text}}</div>\n\n<hr>\n\n<div>{{title}}</div>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "example.html",
   "pagename": "example.html",
-  "prev": 7,
-  "relativeLink": "example.html",
   "src": "test/fixtures/pages/example.hbs",
   "tags": [
     "example"

--- a/test/actual/collections/complex/gist-helper.html
+++ b/test/actual/collections/complex/gist-helper.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
-      <a href="example.html">&larr; Previous</a>
+      <a href="collections-categories.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="lodash.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
-      <a href="example.html">&larr; Previous</a>
+      <a href="collections-categories.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="active">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="lodash.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -704,45 +473,28 @@
 
             
 <h1 id="-gist-helper">{{gist}} helper</h1>
-<script src="https://gist.github.com/5193239.js"></script>
-
-
+<p>&lt;script src=&quot;<a href="https://gist.github.com/5193239.js&quot;&gt;&lt;/script&amp;gt">https://gist.github.com/5193239.js&quot;&gt;&lt;/script&amp;gt</a>;</p>
 
             <div class="docs-header" id="content">
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -785,262 +537,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/complex/debug-helpers.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/complex/gist-helper.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/complex/debug-helpers.html
-                  dirname:       test/actual/collections/complex
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/complex/alert.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/complex/gist-helper.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/complex/alert.html
-                  dirname:       test/actual/collections/complex
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/complex/collections-pages.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/complex/gist-helper.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/complex/collections-pages.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/complex/collections-tags.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/complex/gist-helper.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/complex/collections-tags.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/complex/collections.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/complex/gist-helper.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/complex/collections.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/complex/complex.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/complex/gist-helper.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/complex/complex.html
-                  dirname:       test/actual/collections/complex
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/complex/context.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/complex/gist-helper.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/complex/context.html
-                  dirname:       test/actual/collections/complex
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/complex/collections-categories.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/complex/gist-helper.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/complex/collections-categories.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1073,7 +569,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/complex/alert.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/complex/gist-helper.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/complex/alert.html
+                  dirname:       test/actual/collections/complex
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/complex/collections-pages.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/complex/gist-helper.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/complex/collections-pages.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/complex/collections-tags.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/complex/gist-helper.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/complex/collections-tags.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/complex/collections.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/complex/gist-helper.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/complex/collections.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/complex/complex.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/complex/gist-helper.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/complex/complex.html
+                  dirname:       test/actual/collections/complex
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/complex/context.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/complex/gist-helper.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/complex/context.html
+                  dirname:       test/actual/collections/complex
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/complex/debug-helpers.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/complex/gist-helper.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/complex/debug-helpers.html
+                  dirname:       test/actual/collections/complex
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/complex/collections-categories.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/complex/gist-helper.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/complex/collections-categories.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1105,7 +857,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1137,7 +889,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1169,7 +921,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/complex/no-yfm-data.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/complex/gist-helper.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/complex/no-yfm-data.html
+                  dirname:       test/actual/collections/complex
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1201,7 +985,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1233,7 +1017,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1265,7 +1049,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1295,6 +1078,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/complex/lodash.html
+++ b/test/actual/collections/complex/lodash.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="gist-helper.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="md-helper.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="gist-helper.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="active">
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="md-helper.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -711,37 +480,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -784,262 +538,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/complex/debug-helpers.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/complex/lodash.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/complex/debug-helpers.html
-                  dirname:       test/actual/collections/complex
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/complex/alert.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/complex/lodash.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/complex/alert.html
-                  dirname:       test/actual/collections/complex
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/complex/collections-pages.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/complex/lodash.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/complex/collections-pages.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/complex/collections-tags.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/complex/lodash.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/complex/collections-tags.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/complex/collections.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/complex/lodash.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/complex/collections.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/complex/complex.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/complex/lodash.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/complex/complex.html
-                  dirname:       test/actual/collections/complex
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/complex/context.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/complex/lodash.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/complex/context.html
-                  dirname:       test/actual/collections/complex
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/complex/collections-categories.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/complex/lodash.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/complex/collections-categories.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1072,7 +570,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/complex/alert.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/complex/lodash.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/complex/alert.html
+                  dirname:       test/actual/collections/complex
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/complex/collections-pages.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/complex/lodash.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/complex/collections-pages.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/complex/collections-tags.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/complex/lodash.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/complex/collections-tags.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/complex/collections.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/complex/lodash.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/complex/collections.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/complex/complex.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/complex/lodash.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/complex/complex.html
+                  dirname:       test/actual/collections/complex
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/complex/context.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/complex/lodash.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/complex/context.html
+                  dirname:       test/actual/collections/complex
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/complex/debug-helpers.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/complex/lodash.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/complex/debug-helpers.html
+                  dirname:       test/actual/collections/complex
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/complex/collections-categories.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/complex/lodash.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/complex/collections-categories.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1104,7 +858,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1136,7 +890,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1168,7 +922,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/complex/no-yfm-data.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/complex/lodash.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/complex/no-yfm-data.html
+                  dirname:       test/actual/collections/complex
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1200,7 +986,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1232,7 +1018,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1264,7 +1050,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1296,6 +1081,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/complex/md-helper.html
+++ b/test/actual/collections/complex/md-helper.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="lodash.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="no-yfm.html">Next &rarr;</a>
+      <a href="no-yfm-data.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="lodash.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="active">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="no-yfm.html">Next &rarr;</a>
+      <a href="no-yfm-data.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,488 +187,288 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">2</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">helper</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">2</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">helper</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">markdown</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">markdown</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -738,37 +500,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -811,262 +558,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/complex/debug-helpers.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/complex/md-helper.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/complex/debug-helpers.html
-                  dirname:       test/actual/collections/complex
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/complex/alert.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/complex/md-helper.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/complex/alert.html
-                  dirname:       test/actual/collections/complex
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/complex/collections-pages.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/complex/md-helper.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/complex/collections-pages.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/complex/collections-tags.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/complex/md-helper.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/complex/collections-tags.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/complex/collections.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/complex/md-helper.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/complex/collections.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/complex/complex.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/complex/md-helper.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/complex/complex.html
-                  dirname:       test/actual/collections/complex
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/complex/context.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/complex/md-helper.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/complex/context.html
-                  dirname:       test/actual/collections/complex
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/complex/collections-categories.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/complex/md-helper.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/complex/collections-categories.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1099,7 +590,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/complex/alert.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/complex/md-helper.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/complex/alert.html
+                  dirname:       test/actual/collections/complex
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/complex/collections-pages.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/complex/md-helper.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/complex/collections-pages.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/complex/collections-tags.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/complex/md-helper.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/complex/collections-tags.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/complex/collections.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/complex/md-helper.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/complex/collections.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/complex/complex.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/complex/md-helper.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/complex/complex.html
+                  dirname:       test/actual/collections/complex
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/complex/context.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/complex/md-helper.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/complex/context.html
+                  dirname:       test/actual/collections/complex
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/complex/debug-helpers.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/complex/md-helper.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/complex/debug-helpers.html
+                  dirname:       test/actual/collections/complex
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/complex/collections-categories.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/complex/md-helper.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/complex/collections-categories.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1131,7 +878,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1163,7 +910,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1195,7 +942,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/complex/no-yfm-data.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/complex/md-helper.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/complex/no-yfm-data.html
+                  dirname:       test/actual/collections/complex
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1227,7 +1006,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1259,7 +1038,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1291,7 +1070,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1340,6 +1118,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/complex/no-yfm-data.html
+++ b/test/actual/collections/complex/no-yfm-data.html
@@ -1,0 +1,1121 @@
+<!DOCTYPE html>
+  <html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Layout filename: ''</title>
+    <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../../assets/validation.css">
+  </head>
+  <body style="padding-top: 60px;">
+    <div class="container">
+
+      <!-- validate assets path -->
+      <section id="validate"></section>
+      <div class="docs-section">
+        <div class="docs-header" id="content">
+          <h4><strong class="text-muted">test/fixtures/pages/no-yfm-data.hbs</strong> &#x2192; <strong class="text-success">test/actual/collections/complex/no-yfm-data.html</strong></h4>
+        </div>
+        <hr>
+      </div>
+
+      <ul class="pager">
+
+
+    <li class="previous">
+      <a href="example.html">First</a>
+    </li>
+    <li class="previous">
+      <a href="md-helper.html">&larr; Previous</a>
+    </li>
+
+    <li class="pager-middle">
+      <a href="example.html">1</a>
+    </li>
+    <li class="pager-middle">
+      <a href="alert.html">2</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections-pages.html">3</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections-tags.html">4</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections.html">5</a>
+    </li>
+    <li class="pager-middle">
+      <a href="complex.html">6</a>
+    </li>
+    <li class="pager-middle">
+      <a href="context.html">7</a>
+    </li>
+    <li class="pager-middle">
+      <a href="debug-helpers.html">8</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections-categories.html">9</a>
+    </li>
+    <li class="pager-middle">
+      <a href="gist-helper.html">10</a>
+    </li>
+    <li class="pager-middle">
+      <a href="lodash.html">11</a>
+    </li>
+    <li class="pager-middle">
+      <a href="md-helper.html">12</a>
+    </li>
+    <li class="active pager-middle">
+      <a href="no-yfm-data.html">13</a>
+    </li>
+    <li class="pager-middle">
+      <a href="no-yfm.html">14</a>
+    </li>
+    <li class="pager-middle">
+      <a href="yfm-context.html">15</a>
+    </li>
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
+
+    <li class="next">
+      <a href="yfm.html">Last</a>
+    </li>
+    <li class="next">
+      <a href="no-yfm.html">Next &rarr;</a>
+    </li>
+
+
+</ul><style>
+.unselectable {
+  -webkit-touch-callout: none;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+}
+</style>
+      <hr>
+
+      <div class="row">
+        <!-- Column: sidebar -->
+        <div class="col-md-3">
+          <div class="bs-sidebar hidden-print" role="complementary">
+            <!-- pagination -->
+            <ul class="nav nav-pills nav-stacked">
+
+
+    <li class="prev">
+      <a href="example.html">First</a>
+    </li>
+    <li class="prev">
+      <a href="md-helper.html">&larr; Previous</a>
+    </li>
+
+    <li>
+      <a href="example.html">1</a>
+    </li>
+    <li>
+      <a href="alert.html">2</a>
+    </li>
+    <li>
+      <a href="collections-pages.html">3</a>
+    </li>
+    <li>
+      <a href="collections-tags.html">4</a>
+    </li>
+    <li>
+      <a href="collections.html">5</a>
+    </li>
+    <li>
+      <a href="complex.html">6</a>
+    </li>
+    <li>
+      <a href="context.html">7</a>
+    </li>
+    <li>
+      <a href="debug-helpers.html">8</a>
+    </li>
+    <li>
+      <a href="collections-categories.html">9</a>
+    </li>
+    <li>
+      <a href="gist-helper.html">10</a>
+    </li>
+    <li>
+      <a href="lodash.html">11</a>
+    </li>
+    <li>
+      <a href="md-helper.html">12</a>
+    </li>
+    <li class="active">
+      <a href="no-yfm-data.html">13</a>
+    </li>
+    <li>
+      <a href="no-yfm.html">14</a>
+    </li>
+    <li>
+      <a href="yfm-context.html">15</a>
+    </li>
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
+
+    <li class="next">
+      <a href="no-yfm.html">Next &rarr;</a>
+    </li>
+    <li class="next">
+      <a href="yfm.html">Last</a>
+    </li>
+
+
+</ul>
+          </div>
+        </div>
+        <!-- Column: content -->
+        <div class="col-md-9" role="main">
+          <div class="docs-section">
+            <div class="docs-header" id="content">
+              <h4><strong>Page layout:</strong> default.hbs</h4>
+              <h4><strong>Page src:</strong> test/fixtures/pages/no-yfm-data.hbs</h4>
+              <h4><strong>Page dest:</strong> test/actual/collections/complex/no-yfm-data.html</h4>
+              <h4><strong>Dest filename:</strong> no-yfm-data.html</h4>
+              <h4><strong>Dest basename:</strong> no-yfm-data</h4>
+              <h4><strong>Page title:</strong> (no title defined)</h4>
+            </div>
+
+            <hr>
+            <div class="row">
+              <div class="col-md-6">
+                <!-- Categories Collection -->
+                  
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
+              </div>
+              <div class="col-md-6">
+                  
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
+              </div>
+            </div>
+
+            <hr>
+
+            There is no YAML front matter in this page.
+
+<ul>
+  <li></li>
+  <li></li>
+  <li></li>
+  <li>globalData1</li>
+</ul>
+
+
+            <div class="docs-header" id="content">
+              <h1>Content</h1>
+            </div>
+            <ul>
+              <li><a href="example.html">example.html</a></li>
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
+              <li><a href="gist-helper.html">gist-helper.html</a></li>
+              <li><a href="lodash.html">lodash.html</a></li>
+              <li><a href="md-helper.html">md-helper.html</a></li>
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+              <li><a href="no-yfm.html">no-yfm.html</a></li>
+              <li><a href="yfm-context.html">yfm-context.html</a></li>
+              <li><a href="yfm.html">yfm.html</a></li>
+            </ul>
+
+            <hr>
+            <div style="display: none">
+
+              <h1>Page</h1>
+              <!--
+              "this"
+              ===============================
+              this.src:      
+              this.dest:     
+              this.layout:   
+              this.dirname:  test/actual/collections/complex
+              this.filename: no-yfm-data.html
+              this.pagename: no-yfm-data.html
+              this.basename: no-yfm-data
+              this.ext:      .html
+
+              "page"
+              ===============================
+              page.src:        test/fixtures/pages/no-yfm-data.hbs
+              page.dest:       test/actual/collections/complex/no-yfm-data.html
+              page.layout:     
+              page.dirname:    test/actual/collections/complex
+              page.filename:   no-yfm-data.html
+              page.pagename:   no-yfm-data.html
+              page.basename:   no-yfm-data
+              page.ext:        .html
+
+              "root"
+              ===============================
+              src:           
+              dest:          
+              layout:        
+              dirname:       test/actual/collections/complex
+              filename:      no-yfm-data.html
+              pagename:      no-yfm-data.html
+              basename:      no-yfm-data
+              ext:           .html
+              -->
+              <h1>Each pages</h1>
+              <ul>
+                <li><a href="example.html">example.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/example.hbs
+                  this.dest:     test/actual/collections/complex/example.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: example.html
+                  this.pagename: example.html
+                  this.basename: example
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm-data.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/example.hbs
+                  dest:          test/actual/collections/complex/example.html
+                  dirname:       test/actual/collections/complex
+                  filename:      example.html
+                  pagename:      example.html
+                  basename:      example
+                  ext:           .html
+                  -->
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/complex/alert.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm-data.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/complex/alert.html
+                  dirname:       test/actual/collections/complex
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/complex/collections-pages.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm-data.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/complex/collections-pages.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/complex/collections-tags.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm-data.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/complex/collections-tags.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/complex/collections.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm-data.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/complex/collections.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/complex/complex.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm-data.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/complex/complex.html
+                  dirname:       test/actual/collections/complex
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/complex/context.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm-data.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/complex/context.html
+                  dirname:       test/actual/collections/complex
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/complex/debug-helpers.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm-data.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/complex/debug-helpers.html
+                  dirname:       test/actual/collections/complex
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/complex/collections-categories.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm-data.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/complex/collections-categories.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/gist-helper.hbs
+                  this.dest:     test/actual/collections/complex/gist-helper.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: gist-helper.html
+                  this.pagename: gist-helper.html
+                  this.basename: gist-helper
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm-data.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/gist-helper.hbs
+                  dest:          test/actual/collections/complex/gist-helper.html
+                  dirname:       test/actual/collections/complex
+                  filename:      gist-helper.html
+                  pagename:      gist-helper.html
+                  basename:      gist-helper
+                  ext:           .html
+                  -->
+<li><a href="lodash.html">lodash.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/lodash.hbs
+                  this.dest:     test/actual/collections/complex/lodash.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: lodash.html
+                  this.pagename: lodash.html
+                  this.basename: lodash
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm-data.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/lodash.hbs
+                  dest:          test/actual/collections/complex/lodash.html
+                  dirname:       test/actual/collections/complex
+                  filename:      lodash.html
+                  pagename:      lodash.html
+                  basename:      lodash
+                  ext:           .html
+                  -->
+<li><a href="md-helper.html">md-helper.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/md-helper.hbs
+                  this.dest:     test/actual/collections/complex/md-helper.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: md-helper.html
+                  this.pagename: md-helper.html
+                  this.basename: md-helper
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm-data.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/md-helper.hbs
+                  dest:          test/actual/collections/complex/md-helper.html
+                  dirname:       test/actual/collections/complex
+                  filename:      md-helper.html
+                  pagename:      md-helper.html
+                  basename:      md-helper
+                  ext:           .html
+                  -->
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/complex/no-yfm-data.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm-data.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/complex/no-yfm-data.html
+                  dirname:       test/actual/collections/complex
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm.hbs
+                  this.dest:     test/actual/collections/complex/no-yfm.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: no-yfm.html
+                  this.pagename: no-yfm.html
+                  this.basename: no-yfm
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm-data.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm.hbs
+                  dest:          test/actual/collections/complex/no-yfm.html
+                  dirname:       test/actual/collections/complex
+                  filename:      no-yfm.html
+                  pagename:      no-yfm.html
+                  basename:      no-yfm
+                  ext:           .html
+                  -->
+<li><a href="yfm-context.html">yfm-context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/yfm-context.hbs
+                  this.dest:     test/actual/collections/complex/yfm-context.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: yfm-context.html
+                  this.pagename: yfm-context.html
+                  this.basename: yfm-context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm-data.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/yfm-context.hbs
+                  dest:          test/actual/collections/complex/yfm-context.html
+                  dirname:       test/actual/collections/complex
+                  filename:      yfm-context.html
+                  pagename:      yfm-context.html
+                  basename:      yfm-context
+                  ext:           .html
+                  -->
+<li><a href="yfm.html">yfm.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/yfm.hbs
+                  this.dest:     test/actual/collections/complex/yfm.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: yfm.html
+                  this.pagename: yfm.html
+                  this.basename: yfm
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm-data.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/yfm.hbs
+                  dest:          test/actual/collections/complex/yfm.html
+                  dirname:       test/actual/collections/complex
+                  filename:      yfm.html
+                  pagename:      yfm.html
+                  basename:      yfm
+                  ext:           .html
+                  -->
+              </ul>
+
+              <h1>Debug Info</h1>
+              <pre><code class="json">
+{
+  "_page": "all",
+  "assets": "../../../assets",
+  "basename": "no-yfm-data",
+  "data": {},
+  "dest": "test/actual/collections/complex/no-yfm-data.html",
+  "dirname": "test/actual/collections/complex",
+  "ext": ".html",
+  "extname": ".html",
+  "filePair": {
+    "src": [
+      "test/fixtures/pages/alert.hbs",
+      "test/fixtures/pages/collections-categories.hbs",
+      "test/fixtures/pages/collections-pages.hbs",
+      "test/fixtures/pages/collections-tags.hbs",
+      "test/fixtures/pages/collections.hbs",
+      "test/fixtures/pages/complex.hbs",
+      "test/fixtures/pages/context.hbs",
+      "test/fixtures/pages/debug-helpers.hbs",
+      "test/fixtures/pages/example.hbs",
+      "test/fixtures/pages/gist-helper.hbs",
+      "test/fixtures/pages/lodash.hbs",
+      "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
+      "test/fixtures/pages/no-yfm.hbs",
+      "test/fixtures/pages/yfm-context.hbs",
+      "test/fixtures/pages/yfm.hbs"
+    ],
+    "dest": "test/actual/collections/complex/",
+    "orig": {
+      "src": [
+        "test/fixtures/pages/*.hbs"
+      ],
+      "dest": "test/actual/collections/complex/"
+    }
+  },
+  "filename": "no-yfm-data.html",
+  "first": false,
+  "index": 12,
+  "isCurrentPage": false,
+  "last": false,
+  "middle": true,
+  "next": 13,
+  "number": 13,
+  "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            There is no YAML front matter in this page.\n\n<ul>\n  <li>{{one}}</li>\n  <li>{{two}}</li>\n  <li>{{three}}</li>\n  <li>{{global1}}</li>\n</ul>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
+  "pageName": "no-yfm-data.html",
+  "pagename": "no-yfm-data.html",
+  "prev": 11,
+  "relativeLink": "no-yfm-data.html",
+  "src": "test/fixtures/pages/no-yfm-data.hbs"
+}
+</code></pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script src="../../../assets/validation.js"></script>
+  </body>
+</html>

--- a/test/actual/collections/complex/no-yfm.html
+++ b/test/actual/collections/complex/no-yfm.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
-      <a href="md-helper.html">&larr; Previous</a>
+      <a href="no-yfm-data.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="no-yfm-data.html">13</a>
+    </li>
     <li class="active pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="yfm-context.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
-      <a href="md-helper.html">&larr; Previous</a>
+      <a href="no-yfm-data.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
+    <li>
+      <a href="no-yfm-data.html">13</a>
+    </li>
     <li class="active">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="yfm-context.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -714,37 +483,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -787,262 +541,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/complex/debug-helpers.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/complex/no-yfm.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/complex/debug-helpers.html
-                  dirname:       test/actual/collections/complex
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/complex/alert.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/complex/no-yfm.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/complex/alert.html
-                  dirname:       test/actual/collections/complex
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/complex/collections-pages.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/complex/no-yfm.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/complex/collections-pages.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/complex/collections-tags.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/complex/no-yfm.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/complex/collections-tags.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/complex/collections.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/complex/no-yfm.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/complex/collections.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/complex/complex.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/complex/no-yfm.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/complex/complex.html
-                  dirname:       test/actual/collections/complex
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/complex/context.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/complex/no-yfm.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/complex/context.html
-                  dirname:       test/actual/collections/complex
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/complex/collections-categories.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/complex/no-yfm.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/complex/collections-categories.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1075,7 +573,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/complex/alert.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/complex/alert.html
+                  dirname:       test/actual/collections/complex
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/complex/collections-pages.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/complex/collections-pages.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/complex/collections-tags.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/complex/collections-tags.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/complex/collections.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/complex/collections.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/complex/complex.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/complex/complex.html
+                  dirname:       test/actual/collections/complex
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/complex/context.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/complex/context.html
+                  dirname:       test/actual/collections/complex
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/complex/debug-helpers.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/complex/debug-helpers.html
+                  dirname:       test/actual/collections/complex
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/complex/collections-categories.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/complex/collections-categories.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1107,7 +861,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1139,7 +893,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1171,7 +925,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/complex/no-yfm-data.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/complex/no-yfm.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/complex/no-yfm-data.html
+                  dirname:       test/actual/collections/complex
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1203,7 +989,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1235,7 +1021,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1267,7 +1053,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1295,6 +1080,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1309,16 +1095,16 @@
   },
   "filename": "no-yfm.html",
   "first": false,
-  "index": 12,
+  "index": 13,
   "isCurrentPage": false,
   "last": false,
   "middle": true,
-  "next": 13,
-  "number": 13,
+  "next": 14,
+  "number": 14,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            There is no YAML front matter in this page.\n\n<div>{{noyfm.one}}</div>\n<div>{{noyfm.two}}</div>\n\n\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "no-yfm.html",
   "pagename": "no-yfm.html",
-  "prev": 11,
+  "prev": 12,
   "relativeLink": "no-yfm.html",
   "src": "test/fixtures/pages/no-yfm.hbs"
 }

--- a/test/actual/collections/complex/yfm-context.html
+++ b/test/actual/collections/complex/yfm-context.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="no-yfm.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="no-yfm.html">14</a>
+    </li>
     <li class="active pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="yfm.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="no-yfm.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
+    <li>
+      <a href="no-yfm.html">14</a>
+    </li>
     <li class="active">
-      <a href="yfm-context.html">14</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="yfm.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yfm</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">context</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yfm</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">context</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -736,37 +501,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -809,262 +559,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/complex/debug-helpers.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/complex/yfm-context.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/complex/debug-helpers.html
-                  dirname:       test/actual/collections/complex
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/complex/alert.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/complex/yfm-context.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/complex/alert.html
-                  dirname:       test/actual/collections/complex
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/complex/collections-pages.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/complex/yfm-context.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/complex/collections-pages.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/complex/collections-tags.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/complex/yfm-context.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/complex/collections-tags.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/complex/collections.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/complex/yfm-context.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/complex/collections.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/complex/complex.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/complex/yfm-context.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/complex/complex.html
-                  dirname:       test/actual/collections/complex
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/complex/context.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/complex/yfm-context.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/complex/context.html
-                  dirname:       test/actual/collections/complex
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/complex/collections-categories.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/complex/yfm-context.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/complex/collections-categories.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1097,7 +591,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/complex/alert.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/complex/yfm-context.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/complex/alert.html
+                  dirname:       test/actual/collections/complex
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/complex/collections-pages.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/complex/yfm-context.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/complex/collections-pages.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/complex/collections-tags.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/complex/yfm-context.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/complex/collections-tags.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/complex/collections.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/complex/yfm-context.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/complex/collections.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/complex/complex.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/complex/yfm-context.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/complex/complex.html
+                  dirname:       test/actual/collections/complex
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/complex/context.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/complex/yfm-context.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/complex/context.html
+                  dirname:       test/actual/collections/complex
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/complex/debug-helpers.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/complex/yfm-context.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/complex/debug-helpers.html
+                  dirname:       test/actual/collections/complex
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/complex/collections-categories.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/complex/yfm-context.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/complex/collections-categories.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1129,7 +879,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1161,7 +911,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1193,7 +943,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/complex/no-yfm-data.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/complex/yfm-context.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/complex/no-yfm-data.html
+                  dirname:       test/actual/collections/complex
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1225,7 +1007,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1257,7 +1039,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1289,7 +1071,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1331,6 +1112,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1345,16 +1127,16 @@
   },
   "filename": "yfm-context.html",
   "first": false,
-  "index": 13,
+  "index": 14,
   "isCurrentPage": false,
   "last": false,
   "middle": true,
-  "next": 14,
-  "number": 14,
+  "next": 15,
+  "number": 15,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n\n<div class=\"page-header\">\n  <h1>{{{default home.title \"Title from home.json didn't render.\"}}}</h1>\n  <p class=\"lead\">{{{default home.description \"Description from home.json didn't render.\"}}}</p>\n</div>\n\n<hr>\n\n<div class=\"page-header\">\n  <h1>{{{default page.title \"page.title didn't render.\"}}}</h1>\n  <p class=\"lead\">{{{default page.description \"page.description didn't render.\"}}}</p>\n</div>\n\n<hr>\n\n<div class=\"page-header\">\n  <h1>{{{default title \"title didn't render.\"}}}</h1>\n  <p class=\"lead\">{{{default description \"description didn't render.\"}}}</p>\n</div>\n\n\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "yfm-context.html",
   "pagename": "yfm-context.html",
-  "prev": 12,
+  "prev": 13,
   "relativeLink": "yfm-context.html",
   "src": "test/fixtures/pages/yfm-context.hbs",
   "title": "This title is from the YFM of the current page"

--- a/test/actual/collections/complex/yfm.html
+++ b/test/actual/collections/complex/yfm.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="yfm-context.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm-context.html">15</a>
+    </li>
     <li class="active pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="yfm-context.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
+    <li>
+      <a href="yfm-context.html">15</a>
+    </li>
     <li class="active">
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -711,37 +480,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -784,262 +538,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/complex/debug-helpers.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/complex/yfm.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/complex/debug-helpers.html
-                  dirname:       test/actual/collections/complex
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/complex/alert.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/complex/yfm.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/complex/alert.html
-                  dirname:       test/actual/collections/complex
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/complex/collections-pages.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/complex/yfm.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/complex/collections-pages.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/complex/collections-tags.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/complex/yfm.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/complex/collections-tags.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/complex/collections.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/complex/yfm.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/complex/collections.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/complex/complex.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/complex/yfm.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/complex/complex.html
-                  dirname:       test/actual/collections/complex
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/complex/context.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/complex/yfm.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/complex/context.html
-                  dirname:       test/actual/collections/complex
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/complex/collections-categories.html
-                  this.dirname:  test/actual/collections/complex
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/complex/yfm.html
-                  page.dirname:  test/actual/collections/complex
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/complex/collections-categories.html
-                  dirname:       test/actual/collections/complex
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1072,7 +570,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/complex/alert.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/complex/yfm.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/complex/alert.html
+                  dirname:       test/actual/collections/complex
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/complex/collections-pages.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/complex/yfm.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/complex/collections-pages.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/complex/collections-tags.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/complex/yfm.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/complex/collections-tags.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/complex/collections.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/complex/yfm.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/complex/collections.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/complex/complex.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/complex/yfm.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/complex/complex.html
+                  dirname:       test/actual/collections/complex
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/complex/context.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/complex/yfm.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/complex/context.html
+                  dirname:       test/actual/collections/complex
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/complex/debug-helpers.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/complex/yfm.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/complex/debug-helpers.html
+                  dirname:       test/actual/collections/complex
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/complex/collections-categories.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/complex/yfm.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/complex/collections-categories.html
+                  dirname:       test/actual/collections/complex
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1104,7 +858,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1136,7 +890,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1168,7 +922,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/complex/no-yfm-data.html
+                  this.dirname:  test/actual/collections/complex
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/complex/yfm.html
+                  page.dirname:  test/actual/collections/complex
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/complex/no-yfm-data.html
+                  dirname:       test/actual/collections/complex
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1200,7 +986,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1232,7 +1018,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1264,7 +1050,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1299,6 +1084,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1314,7 +1100,7 @@
   "filename": "yfm.html",
   "first": false,
   "foo": "bar",
-  "index": 14,
+  "index": 15,
   "isCurrentPage": false,
   "items": [
     "alpha",
@@ -1322,11 +1108,11 @@
   ],
   "last": true,
   "middle": false,
-  "number": 15,
+  "number": 16,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n\n<div class=\"alert alert-info\">This is an alert</div>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "yfm.html",
   "pagename": "yfm.html",
-  "prev": 13,
+  "prev": 14,
   "relativeLink": "yfm.html",
   "src": "test/fixtures/pages/yfm.hbs",
   "title": "YFM"

--- a/test/actual/collections/custom/alert.html
+++ b/test/actual/collections/custom/alert.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
-      <a href="debug-helpers.html">&larr; Previous</a>
+      <a href="example.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="collections-pages.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
-      <a href="debug-helpers.html">&larr; Previous</a>
+      <a href="example.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="active">
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="collections-pages.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,286 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">components</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">components</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">2</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">2</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -718,37 +482,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -791,262 +540,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/custom/debug-helpers.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/custom/alert.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/custom/debug-helpers.html
-                  dirname:       test/actual/collections/custom
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/custom/alert.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/custom/alert.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/custom/alert.html
-                  dirname:       test/actual/collections/custom
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/custom/collections-pages.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/custom/alert.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/custom/collections-pages.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/custom/collections-tags.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/custom/alert.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/custom/collections-tags.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/custom/collections.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/custom/alert.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/custom/collections.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/custom/complex.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/custom/alert.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/custom/complex.html
-                  dirname:       test/actual/collections/custom
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/custom/context.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/custom/alert.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/custom/context.html
-                  dirname:       test/actual/collections/custom
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/custom/collections-categories.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/custom/alert.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/custom/collections-categories.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1079,7 +572,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/custom/alert.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/custom/alert.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/custom/alert.html
+                  dirname:       test/actual/collections/custom
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/custom/collections-pages.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/custom/alert.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/custom/collections-pages.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/custom/collections-tags.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/custom/alert.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/custom/collections-tags.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/custom/collections.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/custom/alert.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/custom/collections.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/custom/complex.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/custom/alert.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/custom/complex.html
+                  dirname:       test/actual/collections/custom
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/custom/context.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/custom/alert.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/custom/context.html
+                  dirname:       test/actual/collections/custom
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/custom/debug-helpers.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/custom/alert.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/custom/debug-helpers.html
+                  dirname:       test/actual/collections/custom
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/custom/collections-categories.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/custom/alert.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/custom/collections-categories.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1111,7 +860,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1143,7 +892,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1175,7 +924,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/custom/no-yfm-data.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/custom/alert.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/custom/no-yfm-data.html
+                  dirname:       test/actual/collections/custom
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1207,7 +988,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1239,7 +1020,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1271,7 +1052,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1318,6 +1098,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/custom/collections-categories.html
+++ b/test/actual/collections/custom/collections-categories.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
-      <a href="context.html">&larr; Previous</a>
+      <a href="debug-helpers.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
-    <li class="active pager-middle">
-      <a href="collections-categories.html">8</a>
-    </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
+    <li class="active pager-middle">
+      <a href="collections-categories.html">9</a>
+    </li>
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="example.html">Next &rarr;</a>
+      <a href="gist-helper.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
-      <a href="context.html">&larr; Previous</a>
+      <a href="debug-helpers.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
-    <li class="active">
-      <a href="collections-categories.html">8</a>
-    </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
+    <li class="active">
+      <a href="collections-categories.html">9</a>
+    </li>
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="example.html">Next &rarr;</a>
+      <a href="gist-helper.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,488 +187,289 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">5</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">three</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">5</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">three</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -718,33 +481,19 @@
     <h4>Categories</h4>
   </div>
   <div class="panel-body">
-  
     <span class="label label-info">categories</span>
-  
     <span class="label label-info">collections</span>
-  
     <span class="label label-info">components</span>
-  
     <span class="label label-info">context</span>
-  
     <span class="label label-info">fixtures</span>
-  
     <span class="label label-info">helper</span>
-  
     <span class="label label-info">markdown</span>
-  
     <span class="label label-info">one</span>
-  
     <span class="label label-info">pages</span>
-  
     <span class="label label-info">three</span>
-  
     <span class="label label-info">two</span>
-  
     <span class="label label-info">yaml</span>
-  
     <span class="label label-info">yfm</span>
-  
   </div>
 </div>
 
@@ -752,37 +501,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -825,262 +559,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/custom/debug-helpers.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/custom/collections-categories.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/custom/debug-helpers.html
-                  dirname:       test/actual/collections/custom
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/custom/alert.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/custom/collections-categories.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/custom/alert.html
-                  dirname:       test/actual/collections/custom
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/custom/collections-pages.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/custom/collections-categories.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/custom/collections-pages.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/custom/collections-tags.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/custom/collections-categories.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/custom/collections-tags.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/custom/collections.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/custom/collections-categories.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/custom/collections.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/custom/complex.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/custom/collections-categories.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/custom/complex.html
-                  dirname:       test/actual/collections/custom
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/custom/context.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/custom/collections-categories.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/custom/context.html
-                  dirname:       test/actual/collections/custom
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/custom/collections-categories.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/custom/collections-categories.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/custom/collections-categories.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1113,7 +591,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/custom/alert.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/custom/collections-categories.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/custom/alert.html
+                  dirname:       test/actual/collections/custom
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/custom/collections-pages.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/custom/collections-categories.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/custom/collections-pages.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/custom/collections-tags.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/custom/collections-categories.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/custom/collections-tags.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/custom/collections.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/custom/collections-categories.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/custom/collections.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/custom/complex.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/custom/collections-categories.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/custom/complex.html
+                  dirname:       test/actual/collections/custom
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/custom/context.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/custom/collections-categories.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/custom/context.html
+                  dirname:       test/actual/collections/custom
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/custom/debug-helpers.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/custom/collections-categories.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/custom/debug-helpers.html
+                  dirname:       test/actual/collections/custom
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/custom/collections-categories.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/custom/collections-categories.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/custom/collections-categories.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1145,7 +879,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1177,7 +911,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1209,7 +943,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/custom/no-yfm-data.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/custom/collections-categories.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/custom/no-yfm-data.html
+                  dirname:       test/actual/collections/custom
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1241,7 +1007,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1273,7 +1039,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1305,7 +1071,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1349,6 +1114,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1363,16 +1129,16 @@
   },
   "filename": "collections-categories.html",
   "first": false,
-  "index": 7,
+  "index": 8,
   "isCurrentPage": false,
   "last": false,
   "middle": true,
-  "next": 8,
-  "number": 8,
+  "next": 9,
+  "number": 9,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n<div class=\"panel panel-info\">\n  <div class=\"panel-heading\">\n    <h4>Categories</h4>\n  </div>\n  <div class=\"panel-body\">\n  {{#categories}}\n    <span class=\"label label-info\">{{category}}</span>\n  {{/categories}}\n  </div>\n</div>\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "collections-categories.html",
   "pagename": "collections-categories.html",
-  "prev": 6,
+  "prev": 7,
   "relativeLink": "collections-categories.html",
   "src": "test/fixtures/pages/collections-categories.hbs",
   "title": "Collections Categories"

--- a/test/actual/collections/custom/collections-pages.html
+++ b/test/actual/collections/custom/collections-pages.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="alert.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="collections-tags.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="alert.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li class="active">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="collections-tags.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,480 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">pages</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">pages</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -710,37 +477,22 @@
     <h4>Pages Collection</h4>
   </div>
   <div class="panel-body">
-    
-      <a href="#">Debug Helper</a>
-    
-      <a href="#">Title for "alert.hbs"</a>
-    
-      <a href="#">Pages Collection</a>
-    
-      <a href="#">Tags Test</a>
-    
-      <a href="#">Collections</a>
-    
-      <a href="#">Complex YFM</a>
-    
-      <a href="#">Context</a>
-    
-      <a href="#">Collections Categories</a>
-    
       <a href="#">Title from YFM of "example.hbs"</a>
-    
+      <a href="#">Title for "alert.hbs"</a>
+      <a href="#">Pages Collection</a>
+      <a href="#">Tags Test</a>
+      <a href="#">Collections</a>
+      <a href="#">Complex YFM</a>
+      <a href="#">Context</a>
+      <a href="#">Debug Helper</a>
+      <a href="#">Collections Categories</a>
       <a href="#">Gist Helper</a>
-    
       <a href="#"><%= site.title %></a>
-    
       <a href="#">md helper</a>
-    
       <a href="#"></a>
-    
+      <a href="#"></a>
       <a href="#">This title is from the YFM of the current page</a>
-    
       <a href="#">YFM</a>
-    
   </div>
 </div>
 
@@ -748,37 +500,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -821,262 +558,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/custom/debug-helpers.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/custom/collections-pages.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/custom/debug-helpers.html
-                  dirname:       test/actual/collections/custom
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/custom/alert.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/custom/collections-pages.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/custom/alert.html
-                  dirname:       test/actual/collections/custom
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/custom/collections-pages.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/custom/collections-pages.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/custom/collections-pages.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/custom/collections-tags.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/custom/collections-pages.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/custom/collections-tags.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/custom/collections.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/custom/collections-pages.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/custom/collections.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/custom/complex.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/custom/collections-pages.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/custom/complex.html
-                  dirname:       test/actual/collections/custom
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/custom/context.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/custom/collections-pages.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/custom/context.html
-                  dirname:       test/actual/collections/custom
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/custom/collections-categories.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/custom/collections-pages.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/custom/collections-categories.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1109,7 +590,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/custom/alert.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/custom/collections-pages.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/custom/alert.html
+                  dirname:       test/actual/collections/custom
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/custom/collections-pages.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/custom/collections-pages.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/custom/collections-pages.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/custom/collections-tags.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/custom/collections-pages.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/custom/collections-tags.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/custom/collections.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/custom/collections-pages.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/custom/collections.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/custom/complex.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/custom/collections-pages.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/custom/complex.html
+                  dirname:       test/actual/collections/custom
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/custom/context.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/custom/collections-pages.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/custom/context.html
+                  dirname:       test/actual/collections/custom
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/custom/debug-helpers.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/custom/collections-pages.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/custom/debug-helpers.html
+                  dirname:       test/actual/collections/custom
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/custom/collections-categories.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/custom/collections-pages.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/custom/collections-categories.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1141,7 +878,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1173,7 +910,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1205,7 +942,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/custom/no-yfm-data.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/custom/collections-pages.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/custom/no-yfm-data.html
+                  dirname:       test/actual/collections/custom
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1237,7 +1006,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1269,7 +1038,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1301,7 +1070,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1334,6 +1102,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/custom/collections-tags.html
+++ b/test/actual/collections/custom/collections-tags.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="collections-pages.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="collections.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="collections-pages.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="active">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="collections.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,488 +187,289 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">5</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">two</span>
-    
-      <span class="label label-success">three</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">5</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">two</span>
+                        <span class="label label-success">three</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -718,37 +481,21 @@
     <h4>Tags</h4>
   </div>
   <div class="panel-body">
-  
     <span class="label label-success">alert</span>
-  
     <span class="label label-success">bootstrap</span>
-  
     <span class="label label-success">collections</span>
-  
     <span class="label label-success">complex</span>
-  
     <span class="label label-success">example</span>
-  
     <span class="label label-success">examples</span>
-  
     <span class="label label-success">markdown</span>
-  
     <span class="label label-success">md</span>
-  
     <span class="label label-success">one</span>
-  
     <span class="label label-success">pages</span>
-  
     <span class="label label-success">tags</span>
-  
     <span class="label label-success">test</span>
-  
     <span class="label label-success">tests</span>
-  
     <span class="label label-success">three</span>
-  
     <span class="label label-success">two</span>
-  
   </div>
 </div>
 
@@ -756,37 +503,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -829,262 +561,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/custom/debug-helpers.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/custom/collections-tags.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/custom/debug-helpers.html
-                  dirname:       test/actual/collections/custom
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/custom/alert.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/custom/collections-tags.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/custom/alert.html
-                  dirname:       test/actual/collections/custom
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/custom/collections-pages.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/custom/collections-tags.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/custom/collections-pages.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/custom/collections-tags.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/custom/collections-tags.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/custom/collections-tags.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/custom/collections.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/custom/collections-tags.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/custom/collections.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/custom/complex.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/custom/collections-tags.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/custom/complex.html
-                  dirname:       test/actual/collections/custom
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/custom/context.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/custom/collections-tags.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/custom/context.html
-                  dirname:       test/actual/collections/custom
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/custom/collections-categories.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/custom/collections-tags.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/custom/collections-categories.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1117,7 +593,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/custom/alert.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/custom/collections-tags.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/custom/alert.html
+                  dirname:       test/actual/collections/custom
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/custom/collections-pages.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/custom/collections-tags.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/custom/collections-pages.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/custom/collections-tags.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/custom/collections-tags.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/custom/collections-tags.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/custom/collections.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/custom/collections-tags.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/custom/collections.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/custom/complex.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/custom/collections-tags.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/custom/complex.html
+                  dirname:       test/actual/collections/custom
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/custom/context.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/custom/collections-tags.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/custom/context.html
+                  dirname:       test/actual/collections/custom
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/custom/debug-helpers.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/custom/collections-tags.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/custom/debug-helpers.html
+                  dirname:       test/actual/collections/custom
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/custom/collections-categories.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/custom/collections-tags.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/custom/collections-categories.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1149,7 +881,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1181,7 +913,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1213,7 +945,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/custom/no-yfm-data.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/custom/collections-tags.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/custom/no-yfm-data.html
+                  dirname:       test/actual/collections/custom
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1245,7 +1009,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1277,7 +1041,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1309,7 +1073,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1346,6 +1109,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/custom/collections.html
+++ b/test/actual/collections/custom/collections.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="collections-tags.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="complex.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="collections-tags.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="active">
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="complex.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">one</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li class="active">
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li class="active">
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li class="active">
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">one</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li class="active">
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li class="active">
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li class="active">
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -711,101 +476,56 @@
             
 Collections
 <ul class="tags">
-
   <li>alert</li>
-
   <li>bootstrap</li>
-
   <li>collections</li>
-
   <li>complex</li>
-
   <li>example</li>
-
   <li>examples</li>
-
   <li>markdown</li>
-
   <li>md</li>
-
   <li>one</li>
-
   <li>pages</li>
-
   <li>tags</li>
-
   <li>test</li>
-
   <li>tests</li>
-
   <li>three</li>
-
   <li>two</li>
-
 </ul>
 
 <ul class="categories">
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
 </ul>
 
 <ul class="pages">
-
-	<li>debug-helpers</li>
-
-	<li>alert</li>
-
-	<li>collections-pages</li>
-
-	<li>collections-tags</li>
-
-	<li>collections</li>
-
-	<li>complex</li>
-
-	<li>context</li>
-
-	<li>collections-categories</li>
-
 	<li>example</li>
-
+	<li>alert</li>
+	<li>collections-pages</li>
+	<li>collections-tags</li>
+	<li>collections</li>
+	<li>complex</li>
+	<li>context</li>
+	<li>debug-helpers</li>
+	<li>collections-categories</li>
 	<li>gist-helper</li>
-
 	<li>lodash</li>
-
 	<li>md-helper</li>
-
+	<li>no-yfm-data</li>
 	<li>no-yfm</li>
-
 	<li>yfm-context</li>
-
 	<li>yfm</li>
-
 </ul>
 
 
@@ -813,37 +533,22 @@ Collections
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -886,262 +591,6 @@ Collections
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/custom/debug-helpers.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/custom/collections.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/custom/debug-helpers.html
-                  dirname:       test/actual/collections/custom
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/custom/alert.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/custom/collections.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/custom/alert.html
-                  dirname:       test/actual/collections/custom
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/custom/collections-pages.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/custom/collections.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/custom/collections-pages.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/custom/collections-tags.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/custom/collections.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/custom/collections-tags.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/custom/collections.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/custom/collections.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/custom/collections.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/custom/complex.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/custom/collections.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/custom/complex.html
-                  dirname:       test/actual/collections/custom
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/custom/context.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/custom/collections.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/custom/context.html
-                  dirname:       test/actual/collections/custom
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/custom/collections-categories.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/custom/collections.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/custom/collections-categories.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1174,7 +623,263 @@ Collections
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/custom/alert.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/custom/collections.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/custom/alert.html
+                  dirname:       test/actual/collections/custom
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/custom/collections-pages.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/custom/collections.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/custom/collections-pages.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/custom/collections-tags.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/custom/collections.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/custom/collections-tags.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/custom/collections.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/custom/collections.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/custom/collections.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/custom/complex.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/custom/collections.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/custom/complex.html
+                  dirname:       test/actual/collections/custom
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/custom/context.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/custom/collections.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/custom/context.html
+                  dirname:       test/actual/collections/custom
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/custom/debug-helpers.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/custom/collections.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/custom/debug-helpers.html
+                  dirname:       test/actual/collections/custom
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/custom/collections-categories.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/custom/collections.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/custom/collections-categories.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1206,7 +911,7 @@ Collections
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1238,7 +943,7 @@ Collections
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1270,7 +975,39 @@ Collections
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/custom/no-yfm-data.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/custom/collections.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/custom/no-yfm-data.html
+                  dirname:       test/actual/collections/custom
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1302,7 +1039,7 @@ Collections
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1334,7 +1071,7 @@ Collections
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1366,7 +1103,6 @@ Collections
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1405,6 +1141,7 @@ Collections
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/custom/complex.html
+++ b/test/actual/collections/custom/complex.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="collections.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="context.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="collections.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li class="active">
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="context.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,486 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">pages</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">pages</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">complex</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">complex</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -719,37 +482,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -792,262 +540,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/custom/debug-helpers.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/custom/complex.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/custom/debug-helpers.html
-                  dirname:       test/actual/collections/custom
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/custom/alert.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/custom/complex.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/custom/alert.html
-                  dirname:       test/actual/collections/custom
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/custom/collections-pages.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/custom/complex.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/custom/collections-pages.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/custom/collections-tags.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/custom/complex.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/custom/collections-tags.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/custom/collections.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/custom/complex.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/custom/collections.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/custom/complex.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/custom/complex.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/custom/complex.html
-                  dirname:       test/actual/collections/custom
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/custom/context.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/custom/complex.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/custom/context.html
-                  dirname:       test/actual/collections/custom
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/custom/collections-categories.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/custom/complex.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/custom/collections-categories.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1080,7 +572,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/custom/alert.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/custom/complex.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/custom/alert.html
+                  dirname:       test/actual/collections/custom
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/custom/collections-pages.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/custom/complex.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/custom/collections-pages.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/custom/collections-tags.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/custom/complex.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/custom/collections-tags.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/custom/collections.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/custom/complex.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/custom/collections.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/custom/complex.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/custom/complex.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/custom/complex.html
+                  dirname:       test/actual/collections/custom
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/custom/context.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/custom/complex.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/custom/context.html
+                  dirname:       test/actual/collections/custom
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/custom/debug-helpers.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/custom/complex.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/custom/debug-helpers.html
+                  dirname:       test/actual/collections/custom
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/custom/collections-categories.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/custom/complex.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/custom/collections-categories.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1112,7 +860,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1144,7 +892,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1176,7 +924,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/custom/no-yfm-data.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/custom/complex.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/custom/no-yfm-data.html
+                  dirname:       test/actual/collections/custom
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1208,7 +988,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1240,7 +1020,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1272,7 +1052,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1319,6 +1098,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/custom/context.html
+++ b/test/actual/collections/custom/context.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="complex.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="collections-categories.html">Next &rarr;</a>
+      <a href="debug-helpers.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="complex.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li class="active">
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="collections-categories.html">Next &rarr;</a>
+      <a href="debug-helpers.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">fixtures</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -753,193 +518,171 @@
 <hr>
 
 <ul class="context-test">
-
-  <li><a href="#" data-context="basename">debug-helpers</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">debug-helpers</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">alert</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">alert</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections-pages</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections-pages</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections-tags</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections-tags</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">complex</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">complex</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">context</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">context</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections-categories</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections-categories</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">example</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">example</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
+  <li><a href="#" data-context="basename">alert</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">alert</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections-pages</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections-pages</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections-tags</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections-tags</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">complex</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">complex</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">context</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">context</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">debug-helpers</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">debug-helpers</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections-categories</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections-categories</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
   <li><a href="#" data-context="basename">gist-helper</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">gist-helper</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">lodash</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">lodash</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">md-helper</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">md-helper</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
+  <li><a href="#" data-context="basename">no-yfm-data</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">no-yfm-data</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
   <li><a href="#" data-context="basename">no-yfm</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">no-yfm</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">yfm-context</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">yfm-context</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">yfm</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">yfm</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
 </ul>
 
 <hr>
 
 <ul class="context-test">
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Debug Helper</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Title for &quot;alert.hbs&quot;</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Pages Collection</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Tags Test</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Collections</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Complex YFM</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Context</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Collections Categories</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">Title from YFM of &quot;example.hbs&quot;</a></li>
-
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Title for &quot;alert.hbs&quot;</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Pages Collection</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Tags Test</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Collections</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Complex YFM</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Context</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Debug Helper</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Collections Categories</a></li>
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">Gist Helper</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">&lt;%= site.title %&gt;</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">md helper</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title"></a></li>
-
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title"></a></li>
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">This title is from the YFM of the current page</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">YFM</a></li>
-
 </ul>
 
 
@@ -947,37 +690,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -1020,262 +748,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/custom/debug-helpers.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/custom/context.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/custom/debug-helpers.html
-                  dirname:       test/actual/collections/custom
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/custom/alert.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/custom/context.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/custom/alert.html
-                  dirname:       test/actual/collections/custom
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/custom/collections-pages.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/custom/context.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/custom/collections-pages.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/custom/collections-tags.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/custom/context.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/custom/collections-tags.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/custom/collections.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/custom/context.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/custom/collections.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/custom/complex.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/custom/context.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/custom/complex.html
-                  dirname:       test/actual/collections/custom
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/custom/context.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/custom/context.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/custom/context.html
-                  dirname:       test/actual/collections/custom
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/custom/collections-categories.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/custom/context.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/custom/collections-categories.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1308,7 +780,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/custom/alert.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/custom/context.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/custom/alert.html
+                  dirname:       test/actual/collections/custom
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/custom/collections-pages.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/custom/context.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/custom/collections-pages.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/custom/collections-tags.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/custom/context.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/custom/collections-tags.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/custom/collections.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/custom/context.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/custom/collections.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/custom/complex.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/custom/context.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/custom/complex.html
+                  dirname:       test/actual/collections/custom
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/custom/context.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/custom/context.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/custom/context.html
+                  dirname:       test/actual/collections/custom
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/custom/debug-helpers.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/custom/context.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/custom/debug-helpers.html
+                  dirname:       test/actual/collections/custom
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/custom/collections-categories.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/custom/context.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/custom/collections-categories.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1340,7 +1068,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1372,7 +1100,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1404,7 +1132,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/custom/no-yfm-data.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/custom/context.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/custom/no-yfm-data.html
+                  dirname:       test/actual/collections/custom
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1436,7 +1196,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1468,7 +1228,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1500,7 +1260,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1546,6 +1305,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/custom/debug-helpers.html
+++ b/test/actual/collections/custom/debug-helpers.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
-    <li class="previous disabled">
-      <a unselectable="on" class="unselectable">First</a>
-    </li>
-    <li class="previous disabled">
-      <a unselectable="on" class="unselectable">&larr; Previous</a>
-    </li>
-  
 
-  
-
-  
-    <li class="active pager-middle">
-      <a href="debug-helpers.html">1</a>
+    <li class="previous">
+      <a href="example.html">First</a>
     </li>
-  
+    <li class="previous">
+      <a href="context.html">&larr; Previous</a>
+    </li>
+
+    <li class="pager-middle">
+      <a href="example.html">1</a>
+    </li>
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
-    <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+    <li class="active pager-middle">
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="alert.html">Next &rarr;</a>
+      <a href="collections-categories.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
-    <li class="prev disabled">
-      <a unselectable="on" class="unselectable">First</a>
-    </li>
-    <li class="prev disabled">
-      <a unselectable="on" class="unselectable">&larr; Previous</a>
-    </li>
-  
 
-  
-
-  
-    <li class="active">
-      <a href="debug-helpers.html">1</a>
+    <li class="prev">
+      <a href="example.html">First</a>
     </li>
-  
+    <li class="prev">
+      <a href="context.html">&larr; Previous</a>
+    </li>
+
+    <li>
+      <a href="example.html">1</a>
+    </li>
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
-    <li>
-      <a href="collections-categories.html">8</a>
+    <li class="active">
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="alert.html">Next &rarr;</a>
+      <a href="collections-categories.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -707,42 +476,26 @@
 <p>Uncomment the <code>debug</code> helper below, run <code>grunt assemble</code>, and watch the output in the command line to see how it works.</p>
 
 
-
             <div class="docs-header" id="content">
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -785,262 +538,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/custom/debug-helpers.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/custom/debug-helpers.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/custom/debug-helpers.html
-                  dirname:       test/actual/collections/custom
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/custom/alert.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/custom/debug-helpers.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/custom/alert.html
-                  dirname:       test/actual/collections/custom
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/custom/collections-pages.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/custom/debug-helpers.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/custom/collections-pages.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/custom/collections-tags.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/custom/debug-helpers.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/custom/collections-tags.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/custom/collections.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/custom/debug-helpers.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/custom/collections.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/custom/complex.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/custom/debug-helpers.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/custom/complex.html
-                  dirname:       test/actual/collections/custom
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/custom/context.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/custom/debug-helpers.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/custom/context.html
-                  dirname:       test/actual/collections/custom
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/custom/collections-categories.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/custom/debug-helpers.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/custom/collections-categories.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1073,7 +570,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/custom/alert.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/custom/debug-helpers.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/custom/alert.html
+                  dirname:       test/actual/collections/custom
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/custom/collections-pages.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/custom/debug-helpers.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/custom/collections-pages.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/custom/collections-tags.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/custom/debug-helpers.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/custom/collections-tags.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/custom/collections.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/custom/debug-helpers.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/custom/collections.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/custom/complex.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/custom/debug-helpers.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/custom/complex.html
+                  dirname:       test/actual/collections/custom
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/custom/context.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/custom/debug-helpers.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/custom/context.html
+                  dirname:       test/actual/collections/custom
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/custom/debug-helpers.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/custom/debug-helpers.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/custom/debug-helpers.html
+                  dirname:       test/actual/collections/custom
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/custom/collections-categories.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/custom/debug-helpers.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/custom/collections-categories.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1105,7 +858,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1137,7 +890,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1169,7 +922,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/custom/no-yfm-data.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/custom/debug-helpers.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/custom/no-yfm-data.html
+                  dirname:       test/actual/collections/custom
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1201,7 +986,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1233,7 +1018,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1265,7 +1050,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1295,6 +1079,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1308,15 +1093,18 @@
     }
   },
   "filename": "debug-helpers.html",
-  "first": true,
-  "index": 0,
+  "first": false,
+  "index": 7,
+  "isCurrentPage": false,
   "last": false,
-  "middle": false,
-  "next": 1,
-  "number": 1,
+  "middle": true,
+  "next": 8,
+  "number": 8,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n{{#markdown}}\n\n### \\{{debug}} helper\nUncomment the `debug` helper below, run `grunt assemble`, and watch the output in the command line to see how it works.\n{{!debug text}}\n\n{{/markdown}}\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "debug-helpers.html",
   "pagename": "debug-helpers.html",
+  "prev": 6,
+  "relativeLink": "debug-helpers.html",
   "src": "test/fixtures/pages/debug-helpers.hbs",
   "title": "Debug Helper"
 }

--- a/test/actual/collections/custom/example.html
+++ b/test/actual/collections/custom/example.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
+    <li class="previous disabled">
+      <a unselectable="on" class="unselectable">First</a>
+    </li>
+    <li class="previous disabled">
+      <a unselectable="on" class="unselectable">&larr; Previous</a>
+    </li>
 
-  
-    <li class="previous">
-      <a href="debug-helpers.html">First</a>
-    </li>
-    <li class="previous">
-      <a href="collections-categories.html">&larr; Previous</a>
-    </li>
-  
 
-  
-    <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+    <li class="active pager-middle">
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
-    <li class="active pager-middle">
-      <a href="example.html">9</a>
+    <li class="pager-middle">
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="gist-helper.html">Next &rarr;</a>
+      <a href="alert.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
+    <li class="prev disabled">
+      <a unselectable="on" class="unselectable">First</a>
+    </li>
+    <li class="prev disabled">
+      <a unselectable="on" class="unselectable">&larr; Previous</a>
+    </li>
 
-  
-    <li class="prev">
-      <a href="debug-helpers.html">First</a>
-    </li>
-    <li class="prev">
-      <a href="collections-categories.html">&larr; Previous</a>
-    </li>
-  
 
-  
-    <li>
-      <a href="debug-helpers.html">1</a>
+    <li class="active">
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
-    <li class="active">
-      <a href="example.html">9</a>
+    <li>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="gist-helper.html">Next &rarr;</a>
+      <a href="alert.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,286 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">2</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">2</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">example</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">example</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -715,7 +479,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
 <hr>
 
 <div>Title from YFM of &quot;example.hbs&quot;</div>
-<div></div>
+<div>This is text from example.json.</div>
 
 <hr>
 
@@ -726,37 +490,22 @@ This example shows that the properties from "example.json" and "example.hbs" are
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -799,262 +548,6 @@ This example shows that the properties from "example.json" and "example.hbs" are
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/custom/debug-helpers.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/custom/example.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/custom/debug-helpers.html
-                  dirname:       test/actual/collections/custom
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/custom/alert.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/custom/example.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/custom/alert.html
-                  dirname:       test/actual/collections/custom
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/custom/collections-pages.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/custom/example.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/custom/collections-pages.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/custom/collections-tags.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/custom/example.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/custom/collections-tags.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/custom/collections.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/custom/example.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/custom/collections.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/custom/complex.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/custom/example.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/custom/complex.html
-                  dirname:       test/actual/collections/custom
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/custom/context.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/custom/example.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/custom/context.html
-                  dirname:       test/actual/collections/custom
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/custom/collections-categories.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/custom/example.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/custom/collections-categories.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1087,7 +580,263 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/custom/alert.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/custom/example.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/custom/alert.html
+                  dirname:       test/actual/collections/custom
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/custom/collections-pages.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/custom/example.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/custom/collections-pages.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/custom/collections-tags.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/custom/example.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/custom/collections-tags.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/custom/collections.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/custom/example.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/custom/collections.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/custom/complex.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/custom/example.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/custom/complex.html
+                  dirname:       test/actual/collections/custom
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/custom/context.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/custom/example.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/custom/context.html
+                  dirname:       test/actual/collections/custom
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/custom/debug-helpers.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/custom/example.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/custom/debug-helpers.html
+                  dirname:       test/actual/collections/custom
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/custom/collections-categories.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/custom/example.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/custom/collections-categories.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1119,7 +868,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1151,7 +900,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1183,7 +932,39 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/custom/no-yfm-data.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/custom/example.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/custom/no-yfm-data.html
+                  dirname:       test/actual/collections/custom
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1215,7 +996,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1247,7 +1028,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1279,7 +1060,6 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1324,6 +1104,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1337,26 +1118,25 @@ This example shows that the properties from "example.json" and "example.hbs" are
     }
   },
   "filename": "example.html",
-  "first": false,
-  "index": 8,
-  "isCurrentPage": false,
+  "first": true,
+  "index": 0,
+  "info": "Congratulations! This is data from example.yml.",
   "items": [
     "omega",
     "gamma"
   ],
   "last": false,
-  "middle": true,
-  "next": 9,
-  "number": 9,
+  "middle": false,
+  "next": 1,
+  "number": 1,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n\nThis example shows that the properties from \"example.json\" and \"example.hbs\" are on the page object.\n\n<hr>\n\n<div>{{page.title}}</div>\n<div>{{page.text}}</div>\n\n<hr>\n\n<div>{{title}}</div>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "example.html",
   "pagename": "example.html",
-  "prev": 7,
-  "relativeLink": "example.html",
   "src": "test/fixtures/pages/example.hbs",
   "tags": [
     "example"
   ],
+  "text": "This is text from example.json.",
   "title": "Title from YFM of \"example.hbs\""
 }
 </code></pre>

--- a/test/actual/collections/custom/gist-helper.html
+++ b/test/actual/collections/custom/gist-helper.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
-      <a href="example.html">&larr; Previous</a>
+      <a href="collections-categories.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="lodash.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
-      <a href="example.html">&larr; Previous</a>
+      <a href="collections-categories.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="active">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="lodash.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -704,45 +473,28 @@
 
             
 <h1 id="-gist-helper">{{gist}} helper</h1>
-<script src="https://gist.github.com/5193239.js"></script>
-
-
+<p>&lt;script src=&quot;<a href="https://gist.github.com/5193239.js&quot;&gt;&lt;/script&amp;gt">https://gist.github.com/5193239.js&quot;&gt;&lt;/script&amp;gt</a>;</p>
 
             <div class="docs-header" id="content">
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -785,262 +537,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/custom/debug-helpers.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/custom/gist-helper.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/custom/debug-helpers.html
-                  dirname:       test/actual/collections/custom
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/custom/alert.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/custom/gist-helper.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/custom/alert.html
-                  dirname:       test/actual/collections/custom
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/custom/collections-pages.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/custom/gist-helper.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/custom/collections-pages.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/custom/collections-tags.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/custom/gist-helper.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/custom/collections-tags.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/custom/collections.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/custom/gist-helper.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/custom/collections.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/custom/complex.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/custom/gist-helper.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/custom/complex.html
-                  dirname:       test/actual/collections/custom
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/custom/context.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/custom/gist-helper.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/custom/context.html
-                  dirname:       test/actual/collections/custom
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/custom/collections-categories.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/custom/gist-helper.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/custom/collections-categories.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1073,7 +569,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/custom/alert.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/custom/gist-helper.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/custom/alert.html
+                  dirname:       test/actual/collections/custom
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/custom/collections-pages.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/custom/gist-helper.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/custom/collections-pages.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/custom/collections-tags.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/custom/gist-helper.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/custom/collections-tags.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/custom/collections.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/custom/gist-helper.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/custom/collections.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/custom/complex.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/custom/gist-helper.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/custom/complex.html
+                  dirname:       test/actual/collections/custom
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/custom/context.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/custom/gist-helper.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/custom/context.html
+                  dirname:       test/actual/collections/custom
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/custom/debug-helpers.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/custom/gist-helper.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/custom/debug-helpers.html
+                  dirname:       test/actual/collections/custom
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/custom/collections-categories.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/custom/gist-helper.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/custom/collections-categories.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1105,7 +857,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1137,7 +889,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1169,7 +921,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/custom/no-yfm-data.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/custom/gist-helper.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/custom/no-yfm-data.html
+                  dirname:       test/actual/collections/custom
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1201,7 +985,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1233,7 +1017,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1265,7 +1049,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1295,6 +1078,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/custom/lodash.html
+++ b/test/actual/collections/custom/lodash.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="gist-helper.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="md-helper.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="gist-helper.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="active">
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="md-helper.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -711,37 +480,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -784,262 +538,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/custom/debug-helpers.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/custom/lodash.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/custom/debug-helpers.html
-                  dirname:       test/actual/collections/custom
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/custom/alert.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/custom/lodash.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/custom/alert.html
-                  dirname:       test/actual/collections/custom
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/custom/collections-pages.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/custom/lodash.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/custom/collections-pages.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/custom/collections-tags.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/custom/lodash.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/custom/collections-tags.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/custom/collections.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/custom/lodash.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/custom/collections.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/custom/complex.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/custom/lodash.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/custom/complex.html
-                  dirname:       test/actual/collections/custom
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/custom/context.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/custom/lodash.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/custom/context.html
-                  dirname:       test/actual/collections/custom
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/custom/collections-categories.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/custom/lodash.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/custom/collections-categories.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1072,7 +570,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/custom/alert.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/custom/lodash.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/custom/alert.html
+                  dirname:       test/actual/collections/custom
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/custom/collections-pages.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/custom/lodash.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/custom/collections-pages.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/custom/collections-tags.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/custom/lodash.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/custom/collections-tags.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/custom/collections.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/custom/lodash.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/custom/collections.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/custom/complex.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/custom/lodash.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/custom/complex.html
+                  dirname:       test/actual/collections/custom
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/custom/context.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/custom/lodash.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/custom/context.html
+                  dirname:       test/actual/collections/custom
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/custom/debug-helpers.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/custom/lodash.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/custom/debug-helpers.html
+                  dirname:       test/actual/collections/custom
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/custom/collections-categories.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/custom/lodash.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/custom/collections-categories.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1104,7 +858,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1136,7 +890,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1168,7 +922,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/custom/no-yfm-data.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/custom/lodash.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/custom/no-yfm-data.html
+                  dirname:       test/actual/collections/custom
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1200,7 +986,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1232,7 +1018,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1264,7 +1050,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1296,6 +1081,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/custom/md-helper.html
+++ b/test/actual/collections/custom/md-helper.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="lodash.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="no-yfm.html">Next &rarr;</a>
+      <a href="no-yfm-data.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="lodash.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="active">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="no-yfm.html">Next &rarr;</a>
+      <a href="no-yfm-data.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,488 +187,288 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">2</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">helper</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">2</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">helper</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">markdown</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">markdown</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -738,37 +500,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -811,262 +558,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/custom/debug-helpers.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/custom/md-helper.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/custom/debug-helpers.html
-                  dirname:       test/actual/collections/custom
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/custom/alert.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/custom/md-helper.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/custom/alert.html
-                  dirname:       test/actual/collections/custom
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/custom/collections-pages.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/custom/md-helper.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/custom/collections-pages.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/custom/collections-tags.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/custom/md-helper.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/custom/collections-tags.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/custom/collections.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/custom/md-helper.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/custom/collections.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/custom/complex.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/custom/md-helper.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/custom/complex.html
-                  dirname:       test/actual/collections/custom
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/custom/context.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/custom/md-helper.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/custom/context.html
-                  dirname:       test/actual/collections/custom
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/custom/collections-categories.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/custom/md-helper.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/custom/collections-categories.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1099,7 +590,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/custom/alert.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/custom/md-helper.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/custom/alert.html
+                  dirname:       test/actual/collections/custom
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/custom/collections-pages.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/custom/md-helper.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/custom/collections-pages.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/custom/collections-tags.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/custom/md-helper.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/custom/collections-tags.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/custom/collections.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/custom/md-helper.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/custom/collections.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/custom/complex.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/custom/md-helper.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/custom/complex.html
+                  dirname:       test/actual/collections/custom
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/custom/context.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/custom/md-helper.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/custom/context.html
+                  dirname:       test/actual/collections/custom
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/custom/debug-helpers.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/custom/md-helper.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/custom/debug-helpers.html
+                  dirname:       test/actual/collections/custom
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/custom/collections-categories.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/custom/md-helper.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/custom/collections-categories.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1131,7 +878,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1163,7 +910,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1195,7 +942,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/custom/no-yfm-data.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/custom/md-helper.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/custom/no-yfm-data.html
+                  dirname:       test/actual/collections/custom
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1227,7 +1006,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1259,7 +1038,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1291,7 +1070,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1340,6 +1118,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/custom/no-yfm-data.html
+++ b/test/actual/collections/custom/no-yfm-data.html
@@ -1,0 +1,1121 @@
+<!DOCTYPE html>
+  <html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Layout filename: ''</title>
+    <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../../assets/validation.css">
+  </head>
+  <body style="padding-top: 60px;">
+    <div class="container">
+
+      <!-- validate assets path -->
+      <section id="validate"></section>
+      <div class="docs-section">
+        <div class="docs-header" id="content">
+          <h4><strong class="text-muted">test/fixtures/pages/no-yfm-data.hbs</strong> &#x2192; <strong class="text-success">test/actual/collections/custom/no-yfm-data.html</strong></h4>
+        </div>
+        <hr>
+      </div>
+
+      <ul class="pager">
+
+
+    <li class="previous">
+      <a href="example.html">First</a>
+    </li>
+    <li class="previous">
+      <a href="md-helper.html">&larr; Previous</a>
+    </li>
+
+    <li class="pager-middle">
+      <a href="example.html">1</a>
+    </li>
+    <li class="pager-middle">
+      <a href="alert.html">2</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections-pages.html">3</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections-tags.html">4</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections.html">5</a>
+    </li>
+    <li class="pager-middle">
+      <a href="complex.html">6</a>
+    </li>
+    <li class="pager-middle">
+      <a href="context.html">7</a>
+    </li>
+    <li class="pager-middle">
+      <a href="debug-helpers.html">8</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections-categories.html">9</a>
+    </li>
+    <li class="pager-middle">
+      <a href="gist-helper.html">10</a>
+    </li>
+    <li class="pager-middle">
+      <a href="lodash.html">11</a>
+    </li>
+    <li class="pager-middle">
+      <a href="md-helper.html">12</a>
+    </li>
+    <li class="active pager-middle">
+      <a href="no-yfm-data.html">13</a>
+    </li>
+    <li class="pager-middle">
+      <a href="no-yfm.html">14</a>
+    </li>
+    <li class="pager-middle">
+      <a href="yfm-context.html">15</a>
+    </li>
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
+
+    <li class="next">
+      <a href="yfm.html">Last</a>
+    </li>
+    <li class="next">
+      <a href="no-yfm.html">Next &rarr;</a>
+    </li>
+
+
+</ul><style>
+.unselectable {
+  -webkit-touch-callout: none;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+}
+</style>
+      <hr>
+
+      <div class="row">
+        <!-- Column: sidebar -->
+        <div class="col-md-3">
+          <div class="bs-sidebar hidden-print" role="complementary">
+            <!-- pagination -->
+            <ul class="nav nav-pills nav-stacked">
+
+
+    <li class="prev">
+      <a href="example.html">First</a>
+    </li>
+    <li class="prev">
+      <a href="md-helper.html">&larr; Previous</a>
+    </li>
+
+    <li>
+      <a href="example.html">1</a>
+    </li>
+    <li>
+      <a href="alert.html">2</a>
+    </li>
+    <li>
+      <a href="collections-pages.html">3</a>
+    </li>
+    <li>
+      <a href="collections-tags.html">4</a>
+    </li>
+    <li>
+      <a href="collections.html">5</a>
+    </li>
+    <li>
+      <a href="complex.html">6</a>
+    </li>
+    <li>
+      <a href="context.html">7</a>
+    </li>
+    <li>
+      <a href="debug-helpers.html">8</a>
+    </li>
+    <li>
+      <a href="collections-categories.html">9</a>
+    </li>
+    <li>
+      <a href="gist-helper.html">10</a>
+    </li>
+    <li>
+      <a href="lodash.html">11</a>
+    </li>
+    <li>
+      <a href="md-helper.html">12</a>
+    </li>
+    <li class="active">
+      <a href="no-yfm-data.html">13</a>
+    </li>
+    <li>
+      <a href="no-yfm.html">14</a>
+    </li>
+    <li>
+      <a href="yfm-context.html">15</a>
+    </li>
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
+
+    <li class="next">
+      <a href="no-yfm.html">Next &rarr;</a>
+    </li>
+    <li class="next">
+      <a href="yfm.html">Last</a>
+    </li>
+
+
+</ul>
+          </div>
+        </div>
+        <!-- Column: content -->
+        <div class="col-md-9" role="main">
+          <div class="docs-section">
+            <div class="docs-header" id="content">
+              <h4><strong>Page layout:</strong> default.hbs</h4>
+              <h4><strong>Page src:</strong> test/fixtures/pages/no-yfm-data.hbs</h4>
+              <h4><strong>Page dest:</strong> test/actual/collections/custom/no-yfm-data.html</h4>
+              <h4><strong>Dest filename:</strong> no-yfm-data.html</h4>
+              <h4><strong>Dest basename:</strong> no-yfm-data</h4>
+              <h4><strong>Page title:</strong> (no title defined)</h4>
+            </div>
+
+            <hr>
+            <div class="row">
+              <div class="col-md-6">
+                <!-- Categories Collection -->
+                  
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
+              </div>
+              <div class="col-md-6">
+                  
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
+              </div>
+            </div>
+
+            <hr>
+
+            There is no YAML front matter in this page.
+
+<ul>
+  <li>first</li>
+  <li>second</li>
+  <li>third</li>
+  <li>globalData1</li>
+</ul>
+
+
+            <div class="docs-header" id="content">
+              <h1>Content</h1>
+            </div>
+            <ul>
+              <li><a href="example.html">example.html</a></li>
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
+              <li><a href="gist-helper.html">gist-helper.html</a></li>
+              <li><a href="lodash.html">lodash.html</a></li>
+              <li><a href="md-helper.html">md-helper.html</a></li>
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+              <li><a href="no-yfm.html">no-yfm.html</a></li>
+              <li><a href="yfm-context.html">yfm-context.html</a></li>
+              <li><a href="yfm.html">yfm.html</a></li>
+            </ul>
+
+            <hr>
+            <div style="display: none">
+
+              <h1>Page</h1>
+              <!--
+              "this"
+              ===============================
+              this.src:      
+              this.dest:     
+              this.layout:   
+              this.dirname:  test/actual/collections/custom
+              this.filename: no-yfm-data.html
+              this.pagename: no-yfm-data.html
+              this.basename: no-yfm-data
+              this.ext:      .html
+
+              "page"
+              ===============================
+              page.src:        test/fixtures/pages/no-yfm-data.hbs
+              page.dest:       test/actual/collections/custom/no-yfm-data.html
+              page.layout:     
+              page.dirname:    test/actual/collections/custom
+              page.filename:   no-yfm-data.html
+              page.pagename:   no-yfm-data.html
+              page.basename:   no-yfm-data
+              page.ext:        .html
+
+              "root"
+              ===============================
+              src:           
+              dest:          
+              layout:        
+              dirname:       test/actual/collections/custom
+              filename:      no-yfm-data.html
+              pagename:      no-yfm-data.html
+              basename:      no-yfm-data
+              ext:           .html
+              -->
+              <h1>Each pages</h1>
+              <ul>
+                <li><a href="example.html">example.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/example.hbs
+                  this.dest:     test/actual/collections/custom/example.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: example.html
+                  this.pagename: example.html
+                  this.basename: example
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm-data.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/example.hbs
+                  dest:          test/actual/collections/custom/example.html
+                  dirname:       test/actual/collections/custom
+                  filename:      example.html
+                  pagename:      example.html
+                  basename:      example
+                  ext:           .html
+                  -->
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/custom/alert.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm-data.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/custom/alert.html
+                  dirname:       test/actual/collections/custom
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/custom/collections-pages.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm-data.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/custom/collections-pages.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/custom/collections-tags.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm-data.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/custom/collections-tags.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/custom/collections.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm-data.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/custom/collections.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/custom/complex.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm-data.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/custom/complex.html
+                  dirname:       test/actual/collections/custom
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/custom/context.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm-data.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/custom/context.html
+                  dirname:       test/actual/collections/custom
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/custom/debug-helpers.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm-data.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/custom/debug-helpers.html
+                  dirname:       test/actual/collections/custom
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/custom/collections-categories.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm-data.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/custom/collections-categories.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/gist-helper.hbs
+                  this.dest:     test/actual/collections/custom/gist-helper.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: gist-helper.html
+                  this.pagename: gist-helper.html
+                  this.basename: gist-helper
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm-data.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/gist-helper.hbs
+                  dest:          test/actual/collections/custom/gist-helper.html
+                  dirname:       test/actual/collections/custom
+                  filename:      gist-helper.html
+                  pagename:      gist-helper.html
+                  basename:      gist-helper
+                  ext:           .html
+                  -->
+<li><a href="lodash.html">lodash.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/lodash.hbs
+                  this.dest:     test/actual/collections/custom/lodash.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: lodash.html
+                  this.pagename: lodash.html
+                  this.basename: lodash
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm-data.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/lodash.hbs
+                  dest:          test/actual/collections/custom/lodash.html
+                  dirname:       test/actual/collections/custom
+                  filename:      lodash.html
+                  pagename:      lodash.html
+                  basename:      lodash
+                  ext:           .html
+                  -->
+<li><a href="md-helper.html">md-helper.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/md-helper.hbs
+                  this.dest:     test/actual/collections/custom/md-helper.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: md-helper.html
+                  this.pagename: md-helper.html
+                  this.basename: md-helper
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm-data.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/md-helper.hbs
+                  dest:          test/actual/collections/custom/md-helper.html
+                  dirname:       test/actual/collections/custom
+                  filename:      md-helper.html
+                  pagename:      md-helper.html
+                  basename:      md-helper
+                  ext:           .html
+                  -->
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/custom/no-yfm-data.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm-data.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/custom/no-yfm-data.html
+                  dirname:       test/actual/collections/custom
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm.hbs
+                  this.dest:     test/actual/collections/custom/no-yfm.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: no-yfm.html
+                  this.pagename: no-yfm.html
+                  this.basename: no-yfm
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm-data.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm.hbs
+                  dest:          test/actual/collections/custom/no-yfm.html
+                  dirname:       test/actual/collections/custom
+                  filename:      no-yfm.html
+                  pagename:      no-yfm.html
+                  basename:      no-yfm
+                  ext:           .html
+                  -->
+<li><a href="yfm-context.html">yfm-context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/yfm-context.hbs
+                  this.dest:     test/actual/collections/custom/yfm-context.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: yfm-context.html
+                  this.pagename: yfm-context.html
+                  this.basename: yfm-context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm-data.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/yfm-context.hbs
+                  dest:          test/actual/collections/custom/yfm-context.html
+                  dirname:       test/actual/collections/custom
+                  filename:      yfm-context.html
+                  pagename:      yfm-context.html
+                  basename:      yfm-context
+                  ext:           .html
+                  -->
+<li><a href="yfm.html">yfm.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/yfm.hbs
+                  this.dest:     test/actual/collections/custom/yfm.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: yfm.html
+                  this.pagename: yfm.html
+                  this.basename: yfm
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm-data.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/yfm.hbs
+                  dest:          test/actual/collections/custom/yfm.html
+                  dirname:       test/actual/collections/custom
+                  filename:      yfm.html
+                  pagename:      yfm.html
+                  basename:      yfm
+                  ext:           .html
+                  -->
+              </ul>
+
+              <h1>Debug Info</h1>
+              <pre><code class="json">
+{
+  "_page": "all",
+  "assets": "../../../assets",
+  "basename": "no-yfm-data",
+  "data": {},
+  "dest": "test/actual/collections/custom/no-yfm-data.html",
+  "dirname": "test/actual/collections/custom",
+  "ext": ".html",
+  "extname": ".html",
+  "filePair": {
+    "src": [
+      "test/fixtures/pages/alert.hbs",
+      "test/fixtures/pages/collections-categories.hbs",
+      "test/fixtures/pages/collections-pages.hbs",
+      "test/fixtures/pages/collections-tags.hbs",
+      "test/fixtures/pages/collections.hbs",
+      "test/fixtures/pages/complex.hbs",
+      "test/fixtures/pages/context.hbs",
+      "test/fixtures/pages/debug-helpers.hbs",
+      "test/fixtures/pages/example.hbs",
+      "test/fixtures/pages/gist-helper.hbs",
+      "test/fixtures/pages/lodash.hbs",
+      "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
+      "test/fixtures/pages/no-yfm.hbs",
+      "test/fixtures/pages/yfm-context.hbs",
+      "test/fixtures/pages/yfm.hbs"
+    ],
+    "dest": "test/actual/collections/custom/",
+    "orig": {
+      "src": [
+        "test/fixtures/pages/*.hbs"
+      ],
+      "dest": "test/actual/collections/custom/"
+    }
+  },
+  "filename": "no-yfm-data.html",
+  "first": false,
+  "index": 12,
+  "isCurrentPage": false,
+  "last": false,
+  "middle": true,
+  "next": 13,
+  "number": 13,
+  "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            There is no YAML front matter in this page.\n\n<ul>\n  <li>{{one}}</li>\n  <li>{{two}}</li>\n  <li>{{three}}</li>\n  <li>{{global1}}</li>\n</ul>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
+  "pageName": "no-yfm-data.html",
+  "pagename": "no-yfm-data.html",
+  "prev": 11,
+  "relativeLink": "no-yfm-data.html",
+  "src": "test/fixtures/pages/no-yfm-data.hbs"
+}
+</code></pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script src="../../../assets/validation.js"></script>
+  </body>
+</html>

--- a/test/actual/collections/custom/no-yfm.html
+++ b/test/actual/collections/custom/no-yfm.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
-      <a href="md-helper.html">&larr; Previous</a>
+      <a href="no-yfm-data.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="no-yfm-data.html">13</a>
+    </li>
     <li class="active pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="yfm-context.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
-      <a href="md-helper.html">&larr; Previous</a>
+      <a href="no-yfm-data.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
+    <li>
+      <a href="no-yfm-data.html">13</a>
+    </li>
     <li class="active">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="yfm-context.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -704,8 +473,8 @@
 
             There is no YAML front matter in this page.
 
-<div></div>
-<div></div>
+<div>Variable number one</div>
+<div>Variable number two</div>
 
 
 
@@ -714,37 +483,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -787,262 +541,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/custom/debug-helpers.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/custom/no-yfm.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/custom/debug-helpers.html
-                  dirname:       test/actual/collections/custom
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/custom/alert.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/custom/no-yfm.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/custom/alert.html
-                  dirname:       test/actual/collections/custom
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/custom/collections-pages.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/custom/no-yfm.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/custom/collections-pages.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/custom/collections-tags.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/custom/no-yfm.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/custom/collections-tags.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/custom/collections.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/custom/no-yfm.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/custom/collections.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/custom/complex.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/custom/no-yfm.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/custom/complex.html
-                  dirname:       test/actual/collections/custom
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/custom/context.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/custom/no-yfm.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/custom/context.html
-                  dirname:       test/actual/collections/custom
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/custom/collections-categories.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/custom/no-yfm.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/custom/collections-categories.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1075,7 +573,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/custom/alert.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/custom/alert.html
+                  dirname:       test/actual/collections/custom
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/custom/collections-pages.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/custom/collections-pages.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/custom/collections-tags.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/custom/collections-tags.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/custom/collections.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/custom/collections.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/custom/complex.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/custom/complex.html
+                  dirname:       test/actual/collections/custom
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/custom/context.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/custom/context.html
+                  dirname:       test/actual/collections/custom
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/custom/debug-helpers.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/custom/debug-helpers.html
+                  dirname:       test/actual/collections/custom
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/custom/collections-categories.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/custom/collections-categories.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1107,7 +861,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1139,7 +893,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1171,7 +925,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/custom/no-yfm-data.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/custom/no-yfm.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/custom/no-yfm-data.html
+                  dirname:       test/actual/collections/custom
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1203,7 +989,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1235,7 +1021,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1267,7 +1053,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1295,6 +1080,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1309,16 +1095,16 @@
   },
   "filename": "no-yfm.html",
   "first": false,
-  "index": 12,
+  "index": 13,
   "isCurrentPage": false,
   "last": false,
   "middle": true,
-  "next": 13,
-  "number": 13,
+  "next": 14,
+  "number": 14,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            There is no YAML front matter in this page.\n\n<div>{{noyfm.one}}</div>\n<div>{{noyfm.two}}</div>\n\n\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "no-yfm.html",
   "pagename": "no-yfm.html",
-  "prev": 11,
+  "prev": 12,
   "relativeLink": "no-yfm.html",
   "src": "test/fixtures/pages/no-yfm.hbs"
 }

--- a/test/actual/collections/custom/yfm-context.html
+++ b/test/actual/collections/custom/yfm-context.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="no-yfm.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="no-yfm.html">14</a>
+    </li>
     <li class="active pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="yfm.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="no-yfm.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
+    <li>
+      <a href="no-yfm.html">14</a>
+    </li>
     <li class="active">
-      <a href="yfm-context.html">14</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="yfm.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yfm</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">context</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yfm</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">context</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -711,8 +476,8 @@
             
 
 <div class="page-header">
-  <h1>Title from home.json didn't render.</h1>
-  <p class="lead">Description from home.json didn't render.</p>
+  <h1>This title is from a JSON file.</h1>
+  <p class="lead">This description is from a JSON file.</p>
 </div>
 
 <hr>
@@ -736,37 +501,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -809,262 +559,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/custom/debug-helpers.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/custom/yfm-context.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/custom/debug-helpers.html
-                  dirname:       test/actual/collections/custom
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/custom/alert.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/custom/yfm-context.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/custom/alert.html
-                  dirname:       test/actual/collections/custom
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/custom/collections-pages.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/custom/yfm-context.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/custom/collections-pages.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/custom/collections-tags.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/custom/yfm-context.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/custom/collections-tags.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/custom/collections.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/custom/yfm-context.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/custom/collections.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/custom/complex.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/custom/yfm-context.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/custom/complex.html
-                  dirname:       test/actual/collections/custom
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/custom/context.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/custom/yfm-context.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/custom/context.html
-                  dirname:       test/actual/collections/custom
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/custom/collections-categories.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/custom/yfm-context.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/custom/collections-categories.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1097,7 +591,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/custom/alert.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/custom/yfm-context.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/custom/alert.html
+                  dirname:       test/actual/collections/custom
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/custom/collections-pages.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/custom/yfm-context.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/custom/collections-pages.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/custom/collections-tags.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/custom/yfm-context.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/custom/collections-tags.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/custom/collections.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/custom/yfm-context.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/custom/collections.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/custom/complex.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/custom/yfm-context.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/custom/complex.html
+                  dirname:       test/actual/collections/custom
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/custom/context.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/custom/yfm-context.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/custom/context.html
+                  dirname:       test/actual/collections/custom
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/custom/debug-helpers.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/custom/yfm-context.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/custom/debug-helpers.html
+                  dirname:       test/actual/collections/custom
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/custom/collections-categories.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/custom/yfm-context.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/custom/collections-categories.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1129,7 +879,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1161,7 +911,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1193,7 +943,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/custom/no-yfm-data.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/custom/yfm-context.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/custom/no-yfm-data.html
+                  dirname:       test/actual/collections/custom
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1225,7 +1007,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1257,7 +1039,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1289,7 +1071,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1331,6 +1112,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1345,16 +1127,16 @@
   },
   "filename": "yfm-context.html",
   "first": false,
-  "index": 13,
+  "index": 14,
   "isCurrentPage": false,
   "last": false,
   "middle": true,
-  "next": 14,
-  "number": 14,
+  "next": 15,
+  "number": 15,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n\n<div class=\"page-header\">\n  <h1>{{{default home.title \"Title from home.json didn't render.\"}}}</h1>\n  <p class=\"lead\">{{{default home.description \"Description from home.json didn't render.\"}}}</p>\n</div>\n\n<hr>\n\n<div class=\"page-header\">\n  <h1>{{{default page.title \"page.title didn't render.\"}}}</h1>\n  <p class=\"lead\">{{{default page.description \"page.description didn't render.\"}}}</p>\n</div>\n\n<hr>\n\n<div class=\"page-header\">\n  <h1>{{{default title \"title didn't render.\"}}}</h1>\n  <p class=\"lead\">{{{default description \"description didn't render.\"}}}</p>\n</div>\n\n\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "yfm-context.html",
   "pagename": "yfm-context.html",
-  "prev": 12,
+  "prev": 13,
   "relativeLink": "yfm-context.html",
   "src": "test/fixtures/pages/yfm-context.hbs",
   "title": "This title is from the YFM of the current page"

--- a/test/actual/collections/custom/yfm.html
+++ b/test/actual/collections/custom/yfm.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="yfm-context.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm-context.html">15</a>
+    </li>
     <li class="active pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="yfm-context.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
+    <li>
+      <a href="yfm-context.html">15</a>
+    </li>
     <li class="active">
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -711,37 +480,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -784,262 +538,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/collections/custom/debug-helpers.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/custom/yfm.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/collections/custom/debug-helpers.html
-                  dirname:       test/actual/collections/custom
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/custom/alert.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/custom/yfm.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/custom/alert.html
-                  dirname:       test/actual/collections/custom
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/custom/collections-pages.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/custom/yfm.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/custom/collections-pages.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/custom/collections-tags.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/custom/yfm.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/custom/collections-tags.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/custom/collections.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/custom/yfm.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/custom/collections.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/custom/complex.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/custom/yfm.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/custom/complex.html
-                  dirname:       test/actual/collections/custom
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/custom/context.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/custom/yfm.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/custom/context.html
-                  dirname:       test/actual/collections/custom
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/collections/custom/collections-categories.html
-                  this.dirname:  test/actual/collections/custom
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/custom/yfm.html
-                  page.dirname:  test/actual/collections/custom
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/collections/custom/collections-categories.html
-                  dirname:       test/actual/collections/custom
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1072,7 +570,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/custom/alert.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/custom/yfm.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/custom/alert.html
+                  dirname:       test/actual/collections/custom
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/custom/collections-pages.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/custom/yfm.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/custom/collections-pages.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/custom/collections-tags.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/custom/yfm.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/custom/collections-tags.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/custom/collections.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/custom/yfm.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/custom/collections.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/custom/complex.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/custom/yfm.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/custom/complex.html
+                  dirname:       test/actual/collections/custom
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/custom/context.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/custom/yfm.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/custom/context.html
+                  dirname:       test/actual/collections/custom
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/custom/debug-helpers.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/custom/yfm.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/custom/debug-helpers.html
+                  dirname:       test/actual/collections/custom
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/custom/collections-categories.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/custom/yfm.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/custom/collections-categories.html
+                  dirname:       test/actual/collections/custom
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1104,7 +858,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1136,7 +890,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1168,7 +922,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/custom/no-yfm-data.html
+                  this.dirname:  test/actual/collections/custom
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/custom/yfm.html
+                  page.dirname:  test/actual/collections/custom
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/custom/no-yfm-data.html
+                  dirname:       test/actual/collections/custom
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1200,7 +986,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1232,7 +1018,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1264,7 +1050,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1299,6 +1084,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1314,7 +1100,7 @@
   "filename": "yfm.html",
   "first": false,
   "foo": "bar",
-  "index": 14,
+  "index": 15,
   "isCurrentPage": false,
   "items": [
     "alpha",
@@ -1322,11 +1108,11 @@
   ],
   "last": true,
   "middle": false,
-  "number": 15,
+  "number": 16,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n\n<div class=\"alert alert-info\">This is an alert</div>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "yfm.html",
   "pagename": "yfm.html",
-  "prev": 13,
+  "prev": 14,
   "relativeLink": "yfm.html",
   "src": "test/fixtures/pages/yfm.hbs",
   "title": "YFM"

--- a/test/actual/collections/desc/alert.html
+++ b/test/actual/collections/desc/alert.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="yfm.html">First</a>
     </li>
     <li class="previous">
       <a href="collections-pages.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="yfm.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">7</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections.html">11</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-tags.html">12</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-pages.html">13</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="collections-pages.html">14</a>
+    </li>
     <li class="active pager-middle">
-      <a href="alert.html">14</a>
+      <a href="alert.html">15</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">15</a>
+      <a href="example.html">16</a>
     </li>
-  
 
-  
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
     <li class="next">
-      <a href="debug-helpers.html">Next &rarr;</a>
+      <a href="example.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="yfm.html">First</a>
     </li>
     <li class="prev">
       <a href="collections-pages.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="yfm.html">1</a>
     </li>
-  
     <li>
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li>
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li>
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li>
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li>
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li>
-      <a href="example.html">7</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li>
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li>
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li>
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li>
-      <a href="collections.html">11</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li>
-      <a href="collections-tags.html">12</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li>
-      <a href="collections-pages.html">13</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
+    <li>
+      <a href="collections-pages.html">14</a>
+    </li>
     <li class="active">
-      <a href="alert.html">14</a>
+      <a href="alert.html">15</a>
     </li>
-  
     <li>
-      <a href="debug-helpers.html">15</a>
+      <a href="example.html">16</a>
     </li>
-  
 
-  
     <li class="next">
-      <a href="debug-helpers.html">Next &rarr;</a>
+      <a href="example.html">Next &rarr;</a>
     </li>
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,286 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">components</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yfm</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">categories</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">components</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yfm</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">categories</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">2</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">two</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">alert</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">2</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">two</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">alert</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -718,37 +482,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
-              <li><a href="example.html">example.html</a></li>
-            
               <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
               <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="example.html">example.html</a></li>
             </ul>
 
             <hr>
@@ -823,7 +572,7 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -855,7 +604,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -887,7 +636,39 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/desc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/desc/alert.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/desc/no-yfm-data.html
+                  dirname:       test/actual/collections/desc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -919,7 +700,7 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -951,7 +732,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -983,39 +764,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="example.html">example.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/example.hbs
-                  this.dest:     test/actual/collections/desc/example.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: example.html
-                  this.pagename: example.html
-                  this.basename: example
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/desc/alert.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/example.hbs
-                  dest:          test/actual/collections/desc/example.html
-                  dirname:       test/actual/collections/desc
-                  filename:      example.html
-                  pagename:      example.html
-                  basename:      example
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
+<li><a href="collections-categories.html">collections-categories.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1047,199 +796,7 @@
                   basename:      collections-categories
                   ext:           .html
                   -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/desc/context.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/desc/alert.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/desc/context.html
-                  dirname:       test/actual/collections/desc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/desc/complex.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/desc/alert.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/desc/complex.html
-                  dirname:       test/actual/collections/desc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/desc/collections.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/desc/alert.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/desc/collections.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/desc/collections-tags.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/desc/alert.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/desc/collections-tags.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/desc/collections-pages.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/desc/alert.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/desc/collections-pages.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/desc/alert.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/collections/desc/alert.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/desc/alert.html
-                  dirname:       test/actual/collections/desc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1271,7 +828,230 @@
                   basename:      debug-helpers
                   ext:           .html
                   -->
-                
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/desc/context.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/desc/alert.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/desc/context.html
+                  dirname:       test/actual/collections/desc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/desc/complex.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/desc/alert.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/desc/complex.html
+                  dirname:       test/actual/collections/desc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/desc/collections.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/desc/alert.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/desc/collections.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/desc/collections-tags.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/desc/alert.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/desc/collections-tags.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/desc/collections-pages.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/desc/alert.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/desc/collections-pages.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/desc/alert.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/desc/alert.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/desc/alert.html
+                  dirname:       test/actual/collections/desc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="example.html">example.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/example.hbs
+                  this.dest:     test/actual/collections/desc/example.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: example.html
+                  this.pagename: example.html
+                  this.basename: example
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/collections/desc/alert.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/example.hbs
+                  dest:          test/actual/collections/desc/example.html
+                  dirname:       test/actual/collections/desc
+                  filename:      example.html
+                  pagename:      example.html
+                  basename:      example
+                  ext:           .html
+                  -->
               </ul>
 
               <h1>Debug Info</h1>
@@ -1318,6 +1098,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1332,7 +1113,7 @@
   },
   "filename": "alert.html",
   "first": false,
-  "index": 13,
+  "index": 14,
   "isCurrentPage": false,
   "items": [
     "collections",
@@ -1340,15 +1121,15 @@
   ],
   "last": false,
   "middle": true,
-  "next": 14,
-  "number": 14,
+  "next": 15,
+  "number": 15,
   "one": {
     "two": "This is an alert"
   },
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n\n<h2>{{{title}}}</h2>\n<div class=\"alert alert-info\">{{{one.two}}}</div>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "alert.html",
   "pagename": "alert.html",
-  "prev": 12,
+  "prev": 13,
   "relativeLink": "alert.html",
   "src": "test/fixtures/pages/alert.hbs",
   "tags": [

--- a/test/actual/collections/desc/collections-categories.html
+++ b/test/actual/collections/desc/collections-categories.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="yfm.html">First</a>
     </li>
     <li class="previous">
-      <a href="example.html">&larr; Previous</a>
+      <a href="gist-helper.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="yfm.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">7</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections.html">11</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-tags.html">12</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-pages.html">13</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="alert.html">14</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">15</a>
+      <a href="alert.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="example.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
     <li class="next">
-      <a href="context.html">Next &rarr;</a>
+      <a href="debug-helpers.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="yfm.html">First</a>
     </li>
     <li class="prev">
-      <a href="example.html">&larr; Previous</a>
+      <a href="gist-helper.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="yfm.html">1</a>
     </li>
-  
     <li>
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li>
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li>
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li>
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li>
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li>
-      <a href="example.html">7</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li class="active">
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li>
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li>
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li>
-      <a href="collections.html">11</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li>
-      <a href="collections-tags.html">12</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li>
-      <a href="collections-pages.html">13</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li>
-      <a href="alert.html">14</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li>
-      <a href="debug-helpers.html">15</a>
+      <a href="alert.html">15</a>
     </li>
-  
+    <li>
+      <a href="example.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="context.html">Next &rarr;</a>
+      <a href="debug-helpers.html">Next &rarr;</a>
     </li>
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,488 +187,289 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">5</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">three</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yfm</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">categories</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">5</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">three</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yfm</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">categories</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">two</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">alert</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">two</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">alert</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -718,33 +481,19 @@
     <h4>Categories</h4>
   </div>
   <div class="panel-body">
-  
     <span class="label label-info">yfm</span>
-  
     <span class="label label-info">yaml</span>
-  
     <span class="label label-info">two</span>
-  
     <span class="label label-info">three</span>
-  
     <span class="label label-info">pages</span>
-  
     <span class="label label-info">one</span>
-  
     <span class="label label-info">markdown</span>
-  
     <span class="label label-info">helper</span>
-  
     <span class="label label-info">fixtures</span>
-  
     <span class="label label-info">context</span>
-  
     <span class="label label-info">components</span>
-  
     <span class="label label-info">collections</span>
-  
     <span class="label label-info">categories</span>
-  
   </div>
 </div>
 
@@ -752,37 +501,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
-              <li><a href="example.html">example.html</a></li>
-            
               <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
               <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="example.html">example.html</a></li>
             </ul>
 
             <hr>
@@ -857,7 +591,7 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -889,7 +623,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -921,7 +655,39 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/desc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/desc/collections-categories.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/desc/no-yfm-data.html
+                  dirname:       test/actual/collections/desc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -953,7 +719,7 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -985,7 +751,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1017,39 +783,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="example.html">example.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/example.hbs
-                  this.dest:     test/actual/collections/desc/example.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: example.html
-                  this.pagename: example.html
-                  this.basename: example
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/desc/collections-categories.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/example.hbs
-                  dest:          test/actual/collections/desc/example.html
-                  dirname:       test/actual/collections/desc
-                  filename:      example.html
-                  pagename:      example.html
-                  basename:      example
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
+<li><a href="collections-categories.html">collections-categories.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1081,199 +815,7 @@
                   basename:      collections-categories
                   ext:           .html
                   -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/desc/context.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/desc/collections-categories.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/desc/context.html
-                  dirname:       test/actual/collections/desc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/desc/complex.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/desc/collections-categories.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/desc/complex.html
-                  dirname:       test/actual/collections/desc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/desc/collections.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/desc/collections-categories.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/desc/collections.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/desc/collections-tags.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/desc/collections-categories.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/desc/collections-tags.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/desc/collections-pages.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/desc/collections-categories.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/desc/collections-pages.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/desc/alert.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/collections/desc/collections-categories.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/desc/alert.html
-                  dirname:       test/actual/collections/desc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1305,7 +847,230 @@
                   basename:      debug-helpers
                   ext:           .html
                   -->
-                
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/desc/context.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/desc/collections-categories.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/desc/context.html
+                  dirname:       test/actual/collections/desc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/desc/complex.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/desc/collections-categories.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/desc/complex.html
+                  dirname:       test/actual/collections/desc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/desc/collections.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/desc/collections-categories.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/desc/collections.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/desc/collections-tags.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/desc/collections-categories.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/desc/collections-tags.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/desc/collections-pages.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/desc/collections-categories.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/desc/collections-pages.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/desc/alert.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/desc/collections-categories.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/desc/alert.html
+                  dirname:       test/actual/collections/desc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="example.html">example.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/example.hbs
+                  this.dest:     test/actual/collections/desc/example.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: example.html
+                  this.pagename: example.html
+                  this.basename: example
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/collections/desc/collections-categories.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/example.hbs
+                  dest:          test/actual/collections/desc/example.html
+                  dirname:       test/actual/collections/desc
+                  filename:      example.html
+                  pagename:      example.html
+                  basename:      example
+                  ext:           .html
+                  -->
               </ul>
 
               <h1>Debug Info</h1>
@@ -1349,6 +1114,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/desc/collections-pages.html
+++ b/test/actual/collections/desc/collections-pages.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="yfm.html">First</a>
     </li>
     <li class="previous">
       <a href="collections-tags.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="yfm.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">7</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections.html">11</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-tags.html">12</a>
+      <a href="collections.html">12</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="collections-tags.html">13</a>
+    </li>
     <li class="active pager-middle">
-      <a href="collections-pages.html">13</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="alert.html">14</a>
+      <a href="alert.html">15</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">15</a>
+      <a href="example.html">16</a>
     </li>
-  
 
-  
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
     <li class="next">
       <a href="alert.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="yfm.html">First</a>
     </li>
     <li class="prev">
       <a href="collections-tags.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="yfm.html">1</a>
     </li>
-  
     <li>
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li>
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li>
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li>
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li>
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li>
-      <a href="example.html">7</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li>
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li>
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li>
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li>
-      <a href="collections.html">11</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li>
-      <a href="collections-tags.html">12</a>
+      <a href="collections.html">12</a>
     </li>
-  
+    <li>
+      <a href="collections-tags.html">13</a>
+    </li>
     <li class="active">
-      <a href="collections-pages.html">13</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li>
-      <a href="alert.html">14</a>
+      <a href="alert.html">15</a>
     </li>
-  
     <li>
-      <a href="debug-helpers.html">15</a>
+      <a href="example.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="alert.html">Next &rarr;</a>
     </li>
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,480 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yfm</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">categories</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yfm</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">categories</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">pages</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">two</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">alert</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">pages</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">two</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">alert</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -710,37 +477,22 @@
     <h4>Pages Collection</h4>
   </div>
   <div class="panel-body">
-    
       <a href="#">YFM</a>
-    
       <a href="#">This title is from the YFM of the current page</a>
-    
       <a href="#"></a>
-    
+      <a href="#"></a>
       <a href="#">md helper</a>
-    
       <a href="#">Assemble</a>
-    
       <a href="#">Gist Helper</a>
-    
-      <a href="#">Title from YFM of "example.hbs"</a>
-    
       <a href="#">Collections Categories</a>
-    
-      <a href="#">Context</a>
-    
-      <a href="#">Complex YFM</a>
-    
-      <a href="#">Collections</a>
-    
-      <a href="#">Tags Test</a>
-    
-      <a href="#">Pages Collection</a>
-    
-      <a href="#">Title for "alert.hbs"</a>
-    
       <a href="#">Debug Helper</a>
-    
+      <a href="#">Context</a>
+      <a href="#">Complex YFM</a>
+      <a href="#">Collections</a>
+      <a href="#">Tags Test</a>
+      <a href="#">Pages Collection</a>
+      <a href="#">Title for "alert.hbs"</a>
+      <a href="#">Title from YFM of "example.hbs"</a>
   </div>
 </div>
 
@@ -748,37 +500,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
-              <li><a href="example.html">example.html</a></li>
-            
               <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
               <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="example.html">example.html</a></li>
             </ul>
 
             <hr>
@@ -853,7 +590,7 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -885,7 +622,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -917,7 +654,39 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/desc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/desc/collections-pages.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/desc/no-yfm-data.html
+                  dirname:       test/actual/collections/desc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -949,7 +718,7 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -981,7 +750,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1013,39 +782,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="example.html">example.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/example.hbs
-                  this.dest:     test/actual/collections/desc/example.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: example.html
-                  this.pagename: example.html
-                  this.basename: example
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/desc/collections-pages.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/example.hbs
-                  dest:          test/actual/collections/desc/example.html
-                  dirname:       test/actual/collections/desc
-                  filename:      example.html
-                  pagename:      example.html
-                  basename:      example
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
+<li><a href="collections-categories.html">collections-categories.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1077,199 +814,7 @@
                   basename:      collections-categories
                   ext:           .html
                   -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/desc/context.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/desc/collections-pages.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/desc/context.html
-                  dirname:       test/actual/collections/desc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/desc/complex.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/desc/collections-pages.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/desc/complex.html
-                  dirname:       test/actual/collections/desc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/desc/collections.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/desc/collections-pages.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/desc/collections.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/desc/collections-tags.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/desc/collections-pages.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/desc/collections-tags.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/desc/collections-pages.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/desc/collections-pages.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/desc/collections-pages.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/desc/alert.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/collections/desc/collections-pages.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/desc/alert.html
-                  dirname:       test/actual/collections/desc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1301,7 +846,230 @@
                   basename:      debug-helpers
                   ext:           .html
                   -->
-                
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/desc/context.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/desc/collections-pages.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/desc/context.html
+                  dirname:       test/actual/collections/desc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/desc/complex.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/desc/collections-pages.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/desc/complex.html
+                  dirname:       test/actual/collections/desc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/desc/collections.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/desc/collections-pages.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/desc/collections.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/desc/collections-tags.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/desc/collections-pages.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/desc/collections-tags.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/desc/collections-pages.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/desc/collections-pages.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/desc/collections-pages.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/desc/alert.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/desc/collections-pages.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/desc/alert.html
+                  dirname:       test/actual/collections/desc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="example.html">example.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/example.hbs
+                  this.dest:     test/actual/collections/desc/example.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: example.html
+                  this.pagename: example.html
+                  this.basename: example
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/collections/desc/collections-pages.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/example.hbs
+                  dest:          test/actual/collections/desc/example.html
+                  dirname:       test/actual/collections/desc
+                  filename:      example.html
+                  pagename:      example.html
+                  basename:      example
+                  ext:           .html
+                  -->
               </ul>
 
               <h1>Debug Info</h1>
@@ -1334,6 +1102,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1348,16 +1117,16 @@
   },
   "filename": "collections-pages.html",
   "first": false,
-  "index": 12,
+  "index": 13,
   "isCurrentPage": false,
   "last": false,
   "middle": true,
-  "next": 13,
-  "number": 13,
+  "next": 14,
+  "number": 14,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n<div class=\"panel panel-success\">\n  <div class=\"panel-heading\">\n    <h4>{{title}}</h4>\n  </div>\n  <div class=\"panel-body\">\n    {{#each pages}}\n      <a href=\"#\">{{{data.title}}}</a>\n    {{/each}}\n  </div>\n</div>\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "collections-pages.html",
   "pagename": "collections-pages.html",
-  "prev": 11,
+  "prev": 12,
   "relativeLink": "collections-pages.html",
   "src": "test/fixtures/pages/collections-pages.hbs",
   "tags": [

--- a/test/actual/collections/desc/collections-tags.html
+++ b/test/actual/collections/desc/collections-tags.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="yfm.html">First</a>
     </li>
     <li class="previous">
       <a href="collections.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="yfm.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">7</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections.html">11</a>
+      <a href="complex.html">11</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="collections.html">12</a>
+    </li>
     <li class="active pager-middle">
-      <a href="collections-tags.html">12</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-pages.html">13</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="alert.html">14</a>
+      <a href="alert.html">15</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">15</a>
+      <a href="example.html">16</a>
     </li>
-  
 
-  
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
     <li class="next">
       <a href="collections-pages.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="yfm.html">First</a>
     </li>
     <li class="prev">
       <a href="collections.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="yfm.html">1</a>
     </li>
-  
     <li>
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li>
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li>
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li>
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li>
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li>
-      <a href="example.html">7</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li>
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li>
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li>
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li>
-      <a href="collections.html">11</a>
+      <a href="complex.html">11</a>
     </li>
-  
+    <li>
+      <a href="collections.html">12</a>
+    </li>
     <li class="active">
-      <a href="collections-tags.html">12</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li>
-      <a href="collections-pages.html">13</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li>
-      <a href="alert.html">14</a>
+      <a href="alert.html">15</a>
     </li>
-  
     <li>
-      <a href="debug-helpers.html">15</a>
+      <a href="example.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="collections-pages.html">Next &rarr;</a>
     </li>
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,488 +187,289 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yfm</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">categories</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yfm</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">categories</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">5</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">two</span>
-    
-      <span class="label label-success">three</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">two</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">alert</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">5</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">two</span>
+                        <span class="label label-success">three</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">two</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">alert</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -718,37 +481,21 @@
     <h4>Tags</h4>
   </div>
   <div class="panel-body">
-  
     <span class="label label-success">two</span>
-  
     <span class="label label-success">three</span>
-  
     <span class="label label-success">tests</span>
-  
     <span class="label label-success">test</span>
-  
     <span class="label label-success">tags</span>
-  
     <span class="label label-success">pages</span>
-  
     <span class="label label-success">one</span>
-  
     <span class="label label-success">md</span>
-  
     <span class="label label-success">markdown</span>
-  
     <span class="label label-success">examples</span>
-  
     <span class="label label-success">example</span>
-  
     <span class="label label-success">complex</span>
-  
     <span class="label label-success">collections</span>
-  
     <span class="label label-success">bootstrap</span>
-  
     <span class="label label-success">alert</span>
-  
   </div>
 </div>
 
@@ -756,37 +503,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
-              <li><a href="example.html">example.html</a></li>
-            
               <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
               <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="example.html">example.html</a></li>
             </ul>
 
             <hr>
@@ -861,7 +593,7 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -893,7 +625,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -925,7 +657,39 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/desc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/desc/collections-tags.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/desc/no-yfm-data.html
+                  dirname:       test/actual/collections/desc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -957,7 +721,7 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -989,7 +753,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1021,39 +785,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="example.html">example.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/example.hbs
-                  this.dest:     test/actual/collections/desc/example.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: example.html
-                  this.pagename: example.html
-                  this.basename: example
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/desc/collections-tags.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/example.hbs
-                  dest:          test/actual/collections/desc/example.html
-                  dirname:       test/actual/collections/desc
-                  filename:      example.html
-                  pagename:      example.html
-                  basename:      example
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
+<li><a href="collections-categories.html">collections-categories.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1085,199 +817,7 @@
                   basename:      collections-categories
                   ext:           .html
                   -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/desc/context.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/desc/collections-tags.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/desc/context.html
-                  dirname:       test/actual/collections/desc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/desc/complex.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/desc/collections-tags.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/desc/complex.html
-                  dirname:       test/actual/collections/desc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/desc/collections.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/desc/collections-tags.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/desc/collections.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/desc/collections-tags.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/desc/collections-tags.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/desc/collections-tags.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/desc/collections-pages.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/desc/collections-tags.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/desc/collections-pages.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/desc/alert.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/collections/desc/collections-tags.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/desc/alert.html
-                  dirname:       test/actual/collections/desc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1309,7 +849,230 @@
                   basename:      debug-helpers
                   ext:           .html
                   -->
-                
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/desc/context.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/desc/collections-tags.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/desc/context.html
+                  dirname:       test/actual/collections/desc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/desc/complex.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/desc/collections-tags.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/desc/complex.html
+                  dirname:       test/actual/collections/desc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/desc/collections.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/desc/collections-tags.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/desc/collections.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/desc/collections-tags.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/desc/collections-tags.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/desc/collections-tags.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/desc/collections-pages.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/desc/collections-tags.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/desc/collections-pages.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/desc/alert.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/desc/collections-tags.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/desc/alert.html
+                  dirname:       test/actual/collections/desc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="example.html">example.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/example.hbs
+                  this.dest:     test/actual/collections/desc/example.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: example.html
+                  this.pagename: example.html
+                  this.basename: example
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/collections/desc/collections-tags.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/example.hbs
+                  dest:          test/actual/collections/desc/example.html
+                  dirname:       test/actual/collections/desc
+                  filename:      example.html
+                  pagename:      example.html
+                  basename:      example
+                  ext:           .html
+                  -->
               </ul>
 
               <h1>Debug Info</h1>
@@ -1346,6 +1109,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1360,16 +1124,16 @@
   },
   "filename": "collections-tags.html",
   "first": false,
-  "index": 11,
+  "index": 12,
   "isCurrentPage": false,
   "last": false,
   "middle": true,
-  "next": 12,
-  "number": 12,
+  "next": 13,
+  "number": 13,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n<div class=\"panel panel-success\">\n  <div class=\"panel-heading\">\n    <h4>Tags</h4>\n  </div>\n  <div class=\"panel-body\">\n  {{#tags}}\n    <span class=\"label label-success\">{{tag}}</span>\n  {{/tags}}\n  </div>\n</div>\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "collections-tags.html",
   "pagename": "collections-tags.html",
-  "prev": 10,
+  "prev": 11,
   "relativeLink": "collections-tags.html",
   "src": "test/fixtures/pages/collections-tags.hbs",
   "tags": [

--- a/test/actual/collections/desc/collections.html
+++ b/test/actual/collections/desc/collections.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="yfm.html">First</a>
     </li>
     <li class="previous">
       <a href="complex.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="yfm.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">7</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="complex.html">11</a>
+    </li>
     <li class="active pager-middle">
-      <a href="collections.html">11</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-tags.html">12</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-pages.html">13</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="alert.html">14</a>
+      <a href="alert.html">15</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">15</a>
+      <a href="example.html">16</a>
     </li>
-  
 
-  
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
     <li class="next">
       <a href="collections-tags.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="yfm.html">First</a>
     </li>
     <li class="prev">
       <a href="complex.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="yfm.html">1</a>
     </li>
-  
     <li>
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li>
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li>
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li>
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li>
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li>
-      <a href="example.html">7</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li>
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li>
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li>
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
+    <li>
+      <a href="complex.html">11</a>
+    </li>
     <li class="active">
-      <a href="collections.html">11</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li>
-      <a href="collections-tags.html">12</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li>
-      <a href="collections-pages.html">13</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li>
-      <a href="alert.html">14</a>
+      <a href="alert.html">15</a>
     </li>
-  
     <li>
-      <a href="debug-helpers.html">15</a>
+      <a href="example.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="collections-tags.html">Next &rarr;</a>
     </li>
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yfm</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">categories</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yfm</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">categories</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">one</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">two</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">alert</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li class="active">
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li class="active">
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li class="active">
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">one</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">two</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">alert</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li class="active">
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li class="active">
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li class="active">
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -711,101 +476,56 @@
             
 Collections
 <ul class="tags">
-
   <li>two</li>
-
   <li>three</li>
-
   <li>tests</li>
-
   <li>test</li>
-
   <li>tags</li>
-
   <li>pages</li>
-
   <li>one</li>
-
   <li>md</li>
-
   <li>markdown</li>
-
   <li>examples</li>
-
   <li>example</li>
-
   <li>complex</li>
-
   <li>collections</li>
-
   <li>bootstrap</li>
-
   <li>alert</li>
-
 </ul>
 
 <ul class="categories">
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
 </ul>
 
 <ul class="pages">
-
 	<li>yfm</li>
-
 	<li>yfm-context</li>
-
 	<li>no-yfm</li>
-
+	<li>no-yfm-data</li>
 	<li>md-helper</li>
-
 	<li>lodash</li>
-
 	<li>gist-helper</li>
-
-	<li>example</li>
-
 	<li>collections-categories</li>
-
-	<li>context</li>
-
-	<li>complex</li>
-
-	<li>collections</li>
-
-	<li>collections-tags</li>
-
-	<li>collections-pages</li>
-
-	<li>alert</li>
-
 	<li>debug-helpers</li>
-
+	<li>context</li>
+	<li>complex</li>
+	<li>collections</li>
+	<li>collections-tags</li>
+	<li>collections-pages</li>
+	<li>alert</li>
+	<li>example</li>
 </ul>
 
 
@@ -813,37 +533,22 @@ Collections
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
-              <li><a href="example.html">example.html</a></li>
-            
               <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
               <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="example.html">example.html</a></li>
             </ul>
 
             <hr>
@@ -918,7 +623,7 @@ Collections
                   basename:      yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -950,7 +655,7 @@ Collections
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -982,7 +687,39 @@ Collections
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/desc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/desc/collections.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/desc/no-yfm-data.html
+                  dirname:       test/actual/collections/desc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1014,7 +751,7 @@ Collections
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1046,7 +783,7 @@ Collections
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1078,39 +815,7 @@ Collections
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="example.html">example.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/example.hbs
-                  this.dest:     test/actual/collections/desc/example.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: example.html
-                  this.pagename: example.html
-                  this.basename: example
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/desc/collections.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/example.hbs
-                  dest:          test/actual/collections/desc/example.html
-                  dirname:       test/actual/collections/desc
-                  filename:      example.html
-                  pagename:      example.html
-                  basename:      example
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
+<li><a href="collections-categories.html">collections-categories.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1142,199 +847,7 @@ Collections
                   basename:      collections-categories
                   ext:           .html
                   -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/desc/context.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/desc/collections.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/desc/context.html
-                  dirname:       test/actual/collections/desc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/desc/complex.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/desc/collections.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/desc/complex.html
-                  dirname:       test/actual/collections/desc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/desc/collections.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/desc/collections.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/desc/collections.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/desc/collections-tags.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/desc/collections.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/desc/collections-tags.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/desc/collections-pages.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/desc/collections.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/desc/collections-pages.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/desc/alert.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/collections/desc/collections.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/desc/alert.html
-                  dirname:       test/actual/collections/desc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1366,7 +879,230 @@ Collections
                   basename:      debug-helpers
                   ext:           .html
                   -->
-                
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/desc/context.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/desc/collections.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/desc/context.html
+                  dirname:       test/actual/collections/desc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/desc/complex.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/desc/collections.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/desc/complex.html
+                  dirname:       test/actual/collections/desc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/desc/collections.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/desc/collections.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/desc/collections.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/desc/collections-tags.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/desc/collections.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/desc/collections-tags.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/desc/collections-pages.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/desc/collections.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/desc/collections-pages.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/desc/alert.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/desc/collections.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/desc/alert.html
+                  dirname:       test/actual/collections/desc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="example.html">example.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/example.hbs
+                  this.dest:     test/actual/collections/desc/example.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: example.html
+                  this.pagename: example.html
+                  this.basename: example
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/collections/desc/collections.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/example.hbs
+                  dest:          test/actual/collections/desc/example.html
+                  dirname:       test/actual/collections/desc
+                  filename:      example.html
+                  pagename:      example.html
+                  basename:      example
+                  ext:           .html
+                  -->
               </ul>
 
               <h1>Debug Info</h1>
@@ -1405,6 +1141,7 @@ Collections
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1419,7 +1156,7 @@ Collections
   },
   "filename": "collections.html",
   "first": false,
-  "index": 10,
+  "index": 11,
   "isCurrentPage": false,
   "items": [
     "collections",
@@ -1427,12 +1164,12 @@ Collections
   ],
   "last": false,
   "middle": true,
-  "next": 11,
-  "number": 11,
+  "next": 12,
+  "number": 12,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n{{title}}\n<ul class=\"tags\">\n{{#tags}}\n  <li>{{tag}}</li>\n{{/tags}}\n</ul>\n\n<ul class=\"categories\">\n{{#categories}}\n  <li>{{categories}}</li>\n{{/categories}}\n</ul>\n\n<ul class=\"pages\">\n{{#pages}}\n\t<li>{{basename}}</li>\n{{/pages}}\n</ul>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "collections.html",
   "pagename": "collections.html",
-  "prev": 9,
+  "prev": 10,
   "relativeLink": "collections.html",
   "src": "test/fixtures/pages/collections.hbs",
   "tags": [

--- a/test/actual/collections/desc/complex.html
+++ b/test/actual/collections/desc/complex.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="yfm.html">First</a>
     </li>
     <li class="previous">
       <a href="context.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="yfm.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">7</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="context.html">10</a>
+    </li>
     <li class="active pager-middle">
-      <a href="complex.html">10</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections.html">11</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-tags.html">12</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-pages.html">13</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="alert.html">14</a>
+      <a href="alert.html">15</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">15</a>
+      <a href="example.html">16</a>
     </li>
-  
 
-  
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
     <li class="next">
       <a href="collections.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="yfm.html">First</a>
     </li>
     <li class="prev">
       <a href="context.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="yfm.html">1</a>
     </li>
-  
     <li>
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li>
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li>
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li>
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li>
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li>
-      <a href="example.html">7</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li>
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li>
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
+    <li>
+      <a href="context.html">10</a>
+    </li>
     <li class="active">
-      <a href="complex.html">10</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li>
-      <a href="collections.html">11</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li>
-      <a href="collections-tags.html">12</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li>
-      <a href="collections-pages.html">13</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li>
-      <a href="alert.html">14</a>
+      <a href="alert.html">15</a>
     </li>
-  
     <li>
-      <a href="debug-helpers.html">15</a>
+      <a href="example.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="collections.html">Next &rarr;</a>
     </li>
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,486 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">pages</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yfm</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">categories</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">pages</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yfm</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">categories</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">complex</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">two</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">alert</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">complex</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">two</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">alert</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -719,37 +482,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
-              <li><a href="example.html">example.html</a></li>
-            
               <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
               <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="example.html">example.html</a></li>
             </ul>
 
             <hr>
@@ -824,7 +572,7 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -856,7 +604,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -888,7 +636,39 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/desc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/desc/complex.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/desc/no-yfm-data.html
+                  dirname:       test/actual/collections/desc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -920,7 +700,7 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -952,7 +732,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -984,39 +764,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="example.html">example.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/example.hbs
-                  this.dest:     test/actual/collections/desc/example.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: example.html
-                  this.pagename: example.html
-                  this.basename: example
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/desc/complex.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/example.hbs
-                  dest:          test/actual/collections/desc/example.html
-                  dirname:       test/actual/collections/desc
-                  filename:      example.html
-                  pagename:      example.html
-                  basename:      example
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
+<li><a href="collections-categories.html">collections-categories.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1048,199 +796,7 @@
                   basename:      collections-categories
                   ext:           .html
                   -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/desc/context.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/desc/complex.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/desc/context.html
-                  dirname:       test/actual/collections/desc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/desc/complex.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/desc/complex.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/desc/complex.html
-                  dirname:       test/actual/collections/desc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/desc/collections.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/desc/complex.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/desc/collections.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/desc/collections-tags.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/desc/complex.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/desc/collections-tags.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/desc/collections-pages.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/desc/complex.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/desc/collections-pages.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/desc/alert.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/collections/desc/complex.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/desc/alert.html
-                  dirname:       test/actual/collections/desc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1272,7 +828,230 @@
                   basename:      debug-helpers
                   ext:           .html
                   -->
-                
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/desc/context.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/desc/complex.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/desc/context.html
+                  dirname:       test/actual/collections/desc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/desc/complex.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/desc/complex.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/desc/complex.html
+                  dirname:       test/actual/collections/desc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/desc/collections.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/desc/complex.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/desc/collections.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/desc/collections-tags.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/desc/complex.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/desc/collections-tags.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/desc/collections-pages.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/desc/complex.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/desc/collections-pages.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/desc/alert.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/desc/complex.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/desc/alert.html
+                  dirname:       test/actual/collections/desc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="example.html">example.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/example.hbs
+                  this.dest:     test/actual/collections/desc/example.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: example.html
+                  this.pagename: example.html
+                  this.basename: example
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/collections/desc/complex.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/example.hbs
+                  dest:          test/actual/collections/desc/example.html
+                  dirname:       test/actual/collections/desc
+                  filename:      example.html
+                  pagename:      example.html
+                  basename:      example
+                  ext:           .html
+                  -->
               </ul>
 
               <h1>Debug Info</h1>
@@ -1319,6 +1098,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1334,7 +1114,7 @@
   "filename": "complex.html",
   "first": false,
   "foo": "bar",
-  "index": 9,
+  "index": 10,
   "isCurrentPage": false,
   "items": [
     "alpha",
@@ -1342,12 +1122,12 @@
   ],
   "last": false,
   "middle": true,
-  "next": 10,
-  "number": 10,
+  "next": 11,
+  "number": 11,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n\n<div class=\"alert alert-info\">This is an alert</div>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "complex.html",
   "pagename": "complex.html",
-  "prev": 8,
+  "prev": 9,
   "relativeLink": "complex.html",
   "src": "test/fixtures/pages/complex.hbs",
   "tags": [

--- a/test/actual/collections/desc/context.html
+++ b/test/actual/collections/desc/context.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="yfm.html">First</a>
     </li>
     <li class="previous">
-      <a href="collections-categories.html">&larr; Previous</a>
+      <a href="debug-helpers.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="yfm.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">7</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-categories.html">8</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="debug-helpers.html">9</a>
+    </li>
     <li class="active pager-middle">
-      <a href="context.html">9</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="complex.html">10</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections.html">11</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-tags.html">12</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-pages.html">13</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="alert.html">14</a>
+      <a href="alert.html">15</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">15</a>
+      <a href="example.html">16</a>
     </li>
-  
 
-  
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
     <li class="next">
       <a href="complex.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="yfm.html">First</a>
     </li>
     <li class="prev">
-      <a href="collections-categories.html">&larr; Previous</a>
+      <a href="debug-helpers.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="yfm.html">1</a>
     </li>
-  
     <li>
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li>
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li>
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li>
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li>
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li>
-      <a href="example.html">7</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li>
       <a href="collections-categories.html">8</a>
     </li>
-  
+    <li>
+      <a href="debug-helpers.html">9</a>
+    </li>
     <li class="active">
-      <a href="context.html">9</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li>
-      <a href="complex.html">10</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li>
-      <a href="collections.html">11</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li>
-      <a href="collections-tags.html">12</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li>
-      <a href="collections-pages.html">13</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li>
-      <a href="alert.html">14</a>
+      <a href="alert.html">15</a>
     </li>
-  
     <li>
-      <a href="debug-helpers.html">15</a>
+      <a href="example.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="complex.html">Next &rarr;</a>
     </li>
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yfm</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">categories</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">fixtures</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yfm</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">categories</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">two</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">alert</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">two</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">alert</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -753,193 +518,171 @@
 <hr>
 
 <ul class="context-test">
-
   <li><a href="#" data-context="basename">yfm</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">yfm</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">yfm-context</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">yfm-context</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">no-yfm</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">no-yfm</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
+  <li><a href="#" data-context="basename">no-yfm-data</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">no-yfm-data</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
   <li><a href="#" data-context="basename">md-helper</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">md-helper</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">lodash</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">lodash</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">gist-helper</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">gist-helper</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">example</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">example</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">collections-categories</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">collections-categories</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">context</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">context</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">complex</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">complex</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections-tags</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections-tags</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections-pages</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections-pages</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">alert</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">alert</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">debug-helpers</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">debug-helpers</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
+  <li><a href="#" data-context="basename">context</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">context</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">complex</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">complex</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections-tags</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections-tags</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections-pages</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections-pages</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">alert</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">alert</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">example</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">example</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
 </ul>
 
 <hr>
 
 <ul class="context-test">
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">YFM</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">This title is from the YFM of the current page</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title"></a></li>
-
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title"></a></li>
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">md helper</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">Assemble</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">Gist Helper</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Title from YFM of &quot;example.hbs&quot;</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">Collections Categories</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Context</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Complex YFM</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Collections</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Tags Test</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Pages Collection</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Title for &quot;alert.hbs&quot;</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">Debug Helper</a></li>
-
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Context</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Complex YFM</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Collections</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Tags Test</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Pages Collection</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Title for &quot;alert.hbs&quot;</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Title from YFM of &quot;example.hbs&quot;</a></li>
 </ul>
 
 
@@ -947,37 +690,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
-              <li><a href="example.html">example.html</a></li>
-            
               <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
               <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="example.html">example.html</a></li>
             </ul>
 
             <hr>
@@ -1052,7 +780,7 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1084,7 +812,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1116,7 +844,39 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/desc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/desc/context.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/desc/no-yfm-data.html
+                  dirname:       test/actual/collections/desc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1148,7 +908,7 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1180,7 +940,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1212,39 +972,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="example.html">example.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/example.hbs
-                  this.dest:     test/actual/collections/desc/example.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: example.html
-                  this.pagename: example.html
-                  this.basename: example
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/desc/context.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/example.hbs
-                  dest:          test/actual/collections/desc/example.html
-                  dirname:       test/actual/collections/desc
-                  filename:      example.html
-                  pagename:      example.html
-                  basename:      example
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
+<li><a href="collections-categories.html">collections-categories.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1276,199 +1004,7 @@
                   basename:      collections-categories
                   ext:           .html
                   -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/desc/context.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/desc/context.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/desc/context.html
-                  dirname:       test/actual/collections/desc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/desc/complex.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/desc/context.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/desc/complex.html
-                  dirname:       test/actual/collections/desc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/desc/collections.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/desc/context.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/desc/collections.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/desc/collections-tags.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/desc/context.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/desc/collections-tags.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/desc/collections-pages.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/desc/context.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/desc/collections-pages.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/desc/alert.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/collections/desc/context.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/desc/alert.html
-                  dirname:       test/actual/collections/desc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1500,7 +1036,230 @@
                   basename:      debug-helpers
                   ext:           .html
                   -->
-                
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/desc/context.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/desc/context.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/desc/context.html
+                  dirname:       test/actual/collections/desc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/desc/complex.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/desc/context.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/desc/complex.html
+                  dirname:       test/actual/collections/desc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/desc/collections.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/desc/context.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/desc/collections.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/desc/collections-tags.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/desc/context.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/desc/collections-tags.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/desc/collections-pages.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/desc/context.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/desc/collections-pages.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/desc/alert.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/desc/context.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/desc/alert.html
+                  dirname:       test/actual/collections/desc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="example.html">example.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/example.hbs
+                  this.dest:     test/actual/collections/desc/example.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: example.html
+                  this.pagename: example.html
+                  this.basename: example
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/collections/desc/context.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/example.hbs
+                  dest:          test/actual/collections/desc/example.html
+                  dirname:       test/actual/collections/desc
+                  filename:      example.html
+                  pagename:      example.html
+                  basename:      example
+                  ext:           .html
+                  -->
               </ul>
 
               <h1>Debug Info</h1>
@@ -1546,6 +1305,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1560,7 +1320,7 @@
   },
   "filename": "context.html",
   "first": false,
-  "index": 8,
+  "index": 9,
   "isCurrentPage": false,
   "items": [
     "alpha",
@@ -1568,12 +1328,12 @@
   ],
   "last": false,
   "middle": true,
-  "next": 9,
-  "number": 9,
+  "next": 10,
+  "number": 10,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n<style>\n.context-test > li {\n  position: relative;\n  line-height: 1.8;\n}\n.context-test > li > a:after {\n  position: absolute;\n  left: auto;\n  right: auto;\n  content: attr(data-context);\n  font-family: Monaco, Menlo, Consolas, \"Courier New\", monospace;\n  padding: 2px 4px;\n  margin-left: 10px;\n  line-height: 1.5;\n  font-size: 90%;\n  color: #C7254E;\n  white-space: nowrap;\n  background-color: #F9F2F4;\n  border-radius: 4px;\n  clear: both;\n}\n</style>\n\n<p>If a list item is empty, or rather only has a label and no link, then the variable did not populate a value.</p>\n\n<ul class=\"context-test\">\n  <li><a href=\"#\" data-context=\"title\">{{title}}</a></li>\n  <li><a href=\"#\" data-context=\"this.title\">{{this.title}}</a></li>\n  <li><a href=\"#\" data-context=\"page.title\">{{page.title}}</a></li>\n  <li><a href=\"#\" data-context=\"data.title\">{{data.title}}</a></li>\n</ul>\n\n<hr>\n\n<ul class=\"context-test\">\n  <li><a href=\"#\" data-context=\"basename\">{{basename}}</a></li>\n  <li><a href=\"#\" data-context=\"this.basename\">{{this.basename}}</a></li>\n  <li><a href=\"#\" data-context=\"page.basename\">{{page.basename}}</a></li>\n  <li><a href=\"#\" data-context=\"data.basename\">{{data.basename}}</a></li>\n</ul>\n\n<hr>\n\n<ul class=\"context-test\">\n{{#each pages}}\n  <li><a href=\"#\" data-context=\"basename\">{{basename}}</a></li>\n  <li><a href=\"#\" data-context=\"../basename\">{{../basename}}</a></li>\n  <li><a href=\"#\" data-context=\"this.basename\">{{this.basename}}</a></li>\n  <li><a href=\"#\" data-context=\"page.basename\">{{page.basename}}</a></li>\n  <li><a href=\"#\" data-context=\"data.basename\">{{data.basename}}</a></li>\n{{/each}}\n</ul>\n\n<hr>\n\n<ul class=\"context-test\">\n{{#each pages}}\n  <li><a href=\"#\" data-context=\"title\">{{title}}</a></li>\n  <li><a href=\"#\" data-context=\"../title\">{{../title}}</a></li>\n  <li><a href=\"#\" data-context=\"this.title\">{{this.title}}</a></li>\n  <li><a href=\"#\" data-context=\"page.title\">{{page.title}}</a></li>\n  <li><a href=\"#\" data-context=\"data.title\">{{data.title}}</a></li>\n{{/each}}\n</ul>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "context.html",
   "pagename": "context.html",
-  "prev": 7,
+  "prev": 8,
   "relativeLink": "context.html",
   "src": "test/fixtures/pages/context.hbs",
   "title": "Context"

--- a/test/actual/collections/desc/debug-helpers.html
+++ b/test/actual/collections/desc/debug-helpers.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="yfm.html">First</a>
     </li>
     <li class="previous">
-      <a href="alert.html">&larr; Previous</a>
+      <a href="collections-categories.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="yfm.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">7</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-categories.html">8</a>
     </li>
-  
-    <li class="pager-middle">
-      <a href="context.html">9</a>
-    </li>
-  
-    <li class="pager-middle">
-      <a href="complex.html">10</a>
-    </li>
-  
-    <li class="pager-middle">
-      <a href="collections.html">11</a>
-    </li>
-  
-    <li class="pager-middle">
-      <a href="collections-tags.html">12</a>
-    </li>
-  
-    <li class="pager-middle">
-      <a href="collections-pages.html">13</a>
-    </li>
-  
-    <li class="pager-middle">
-      <a href="alert.html">14</a>
-    </li>
-  
     <li class="active pager-middle">
-      <a href="debug-helpers.html">15</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="context.html">10</a>
+    </li>
+    <li class="pager-middle">
+      <a href="complex.html">11</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections.html">12</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections-tags.html">13</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections-pages.html">14</a>
+    </li>
+    <li class="pager-middle">
+      <a href="alert.html">15</a>
+    </li>
+    <li class="pager-middle">
+      <a href="example.html">16</a>
+    </li>
 
-  
+    <li class="next">
+      <a href="example.html">Last</a>
+    </li>
+    <li class="next">
+      <a href="context.html">Next &rarr;</a>
+    </li>
 
-  
-    <li class="next disabled">
-      <a unselectable="on" class="unselectable">Last</a>
-    </li>
-    <li class="next disabled">
-      <a unselectable="on" class="unselectable">Next &rarr;</a>
-    </li>
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="yfm.html">First</a>
     </li>
     <li class="prev">
-      <a href="alert.html">&larr; Previous</a>
+      <a href="collections-categories.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="yfm.html">1</a>
     </li>
-  
     <li>
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li>
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li>
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li>
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li>
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li>
-      <a href="example.html">7</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li>
       <a href="collections-categories.html">8</a>
     </li>
-  
-    <li>
-      <a href="context.html">9</a>
-    </li>
-  
-    <li>
-      <a href="complex.html">10</a>
-    </li>
-  
-    <li>
-      <a href="collections.html">11</a>
-    </li>
-  
-    <li>
-      <a href="collections-tags.html">12</a>
-    </li>
-  
-    <li>
-      <a href="collections-pages.html">13</a>
-    </li>
-  
-    <li>
-      <a href="alert.html">14</a>
-    </li>
-  
     <li class="active">
-      <a href="debug-helpers.html">15</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
+    <li>
+      <a href="context.html">10</a>
+    </li>
+    <li>
+      <a href="complex.html">11</a>
+    </li>
+    <li>
+      <a href="collections.html">12</a>
+    </li>
+    <li>
+      <a href="collections-tags.html">13</a>
+    </li>
+    <li>
+      <a href="collections-pages.html">14</a>
+    </li>
+    <li>
+      <a href="alert.html">15</a>
+    </li>
+    <li>
+      <a href="example.html">16</a>
+    </li>
 
-  
+    <li class="next">
+      <a href="context.html">Next &rarr;</a>
+    </li>
+    <li class="next">
+      <a href="example.html">Last</a>
+    </li>
 
-  
-    <li class="next disabled">
-      <a unselectable="on" class="unselectable">Next &rarr;</a>
-    </li>
-    <li class="next disabled">
-      <a unselectable="on" class="unselectable">Last</a>
-    </li>
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yfm</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">categories</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yfm</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">categories</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">two</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">alert</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">two</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">alert</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -707,42 +476,26 @@
 <p>Uncomment the <code>debug</code> helper below, run <code>grunt assemble</code>, and watch the output in the command line to see how it works.</p>
 
 
-
             <div class="docs-header" id="content">
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
-              <li><a href="example.html">example.html</a></li>
-            
               <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
               <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="example.html">example.html</a></li>
             </ul>
 
             <hr>
@@ -817,7 +570,7 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -849,7 +602,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -881,7 +634,39 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/desc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/desc/debug-helpers.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/desc/no-yfm-data.html
+                  dirname:       test/actual/collections/desc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -913,7 +698,7 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -945,7 +730,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -977,39 +762,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="example.html">example.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/example.hbs
-                  this.dest:     test/actual/collections/desc/example.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: example.html
-                  this.pagename: example.html
-                  this.basename: example
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/desc/debug-helpers.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/example.hbs
-                  dest:          test/actual/collections/desc/example.html
-                  dirname:       test/actual/collections/desc
-                  filename:      example.html
-                  pagename:      example.html
-                  basename:      example
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
+<li><a href="collections-categories.html">collections-categories.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1041,199 +794,7 @@
                   basename:      collections-categories
                   ext:           .html
                   -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/desc/context.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/desc/debug-helpers.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/desc/context.html
-                  dirname:       test/actual/collections/desc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/desc/complex.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/desc/debug-helpers.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/desc/complex.html
-                  dirname:       test/actual/collections/desc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/desc/collections.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/desc/debug-helpers.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/desc/collections.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/desc/collections-tags.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/desc/debug-helpers.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/desc/collections-tags.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/desc/collections-pages.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/desc/debug-helpers.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/desc/collections-pages.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/desc/alert.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/collections/desc/debug-helpers.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/desc/alert.html
-                  dirname:       test/actual/collections/desc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1265,7 +826,230 @@
                   basename:      debug-helpers
                   ext:           .html
                   -->
-                
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/desc/context.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/desc/debug-helpers.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/desc/context.html
+                  dirname:       test/actual/collections/desc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/desc/complex.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/desc/debug-helpers.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/desc/complex.html
+                  dirname:       test/actual/collections/desc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/desc/collections.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/desc/debug-helpers.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/desc/collections.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/desc/collections-tags.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/desc/debug-helpers.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/desc/collections-tags.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/desc/collections-pages.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/desc/debug-helpers.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/desc/collections-pages.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/desc/alert.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/desc/debug-helpers.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/desc/alert.html
+                  dirname:       test/actual/collections/desc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="example.html">example.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/example.hbs
+                  this.dest:     test/actual/collections/desc/example.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: example.html
+                  this.pagename: example.html
+                  this.basename: example
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/collections/desc/debug-helpers.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/example.hbs
+                  dest:          test/actual/collections/desc/example.html
+                  dirname:       test/actual/collections/desc
+                  filename:      example.html
+                  pagename:      example.html
+                  basename:      example
+                  ext:           .html
+                  -->
               </ul>
 
               <h1>Debug Info</h1>
@@ -1295,6 +1079,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1309,15 +1094,16 @@
   },
   "filename": "debug-helpers.html",
   "first": false,
-  "index": 14,
+  "index": 8,
   "isCurrentPage": false,
-  "last": true,
-  "middle": false,
-  "number": 15,
+  "last": false,
+  "middle": true,
+  "next": 9,
+  "number": 9,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n{{#markdown}}\n\n### \\{{debug}} helper\nUncomment the `debug` helper below, run `grunt assemble`, and watch the output in the command line to see how it works.\n{{!debug text}}\n\n{{/markdown}}\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "debug-helpers.html",
   "pagename": "debug-helpers.html",
-  "prev": 13,
+  "prev": 7,
   "relativeLink": "debug-helpers.html",
   "src": "test/fixtures/pages/debug-helpers.hbs",
   "title": "Debug Helper"

--- a/test/actual/collections/desc/example.html
+++ b/test/actual/collections/desc/example.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="yfm.html">First</a>
     </li>
     <li class="previous">
-      <a href="gist-helper.html">&larr; Previous</a>
+      <a href="alert.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="yfm.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
-    <li class="active pager-middle">
-      <a href="example.html">7</a>
+    <li class="pager-middle">
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections.html">11</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-tags.html">12</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-pages.html">13</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="alert.html">14</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">15</a>
+      <a href="alert.html">15</a>
     </li>
-  
+    <li class="active pager-middle">
+      <a href="example.html">16</a>
+    </li>
 
-  
-    <li class="next">
-      <a href="debug-helpers.html">Last</a>
-    </li>
-    <li class="next">
-      <a href="collections-categories.html">Next &rarr;</a>
-    </li>
-  
 
-  
+    <li class="next disabled">
+      <a unselectable="on" class="unselectable">Last</a>
+    </li>
+    <li class="next disabled">
+      <a unselectable="on" class="unselectable">Next &rarr;</a>
+    </li>
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="yfm.html">First</a>
     </li>
     <li class="prev">
-      <a href="gist-helper.html">&larr; Previous</a>
+      <a href="alert.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="yfm.html">1</a>
     </li>
-  
     <li>
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li>
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li>
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li>
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li>
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
-    <li class="active">
-      <a href="example.html">7</a>
+    <li>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li>
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li>
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li>
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li>
-      <a href="collections.html">11</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li>
-      <a href="collections-tags.html">12</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li>
-      <a href="collections-pages.html">13</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li>
-      <a href="alert.html">14</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li>
-      <a href="debug-helpers.html">15</a>
+      <a href="alert.html">15</a>
     </li>
-  
+    <li class="active">
+      <a href="example.html">16</a>
+    </li>
 
-  
-    <li class="next">
-      <a href="collections-categories.html">Next &rarr;</a>
-    </li>
-    <li class="next">
-      <a href="debug-helpers.html">Last</a>
-    </li>
-  
 
-  
+    <li class="next disabled">
+      <a unselectable="on" class="unselectable">Next &rarr;</a>
+    </li>
+    <li class="next disabled">
+      <a unselectable="on" class="unselectable">Last</a>
+    </li>
 
 </ul>
           </div>
@@ -225,484 +187,286 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">2</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yfm</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">categories</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">2</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yfm</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">categories</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">example</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">two</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">alert</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">example</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">two</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">alert</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -715,7 +479,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
 <hr>
 
 <div>Title from YFM of &quot;example.hbs&quot;</div>
-<div></div>
+<div>This is text from example.json.</div>
 
 <hr>
 
@@ -726,37 +490,22 @@ This example shows that the properties from "example.json" and "example.hbs" are
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
-              <li><a href="example.html">example.html</a></li>
-            
               <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
               <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="example.html">example.html</a></li>
             </ul>
 
             <hr>
@@ -831,7 +580,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -863,7 +612,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -895,7 +644,39 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/desc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/desc/example.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/desc/no-yfm-data.html
+                  dirname:       test/actual/collections/desc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -927,7 +708,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -959,7 +740,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -991,39 +772,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="example.html">example.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/example.hbs
-                  this.dest:     test/actual/collections/desc/example.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: example.html
-                  this.pagename: example.html
-                  this.basename: example
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/desc/example.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/example.hbs
-                  dest:          test/actual/collections/desc/example.html
-                  dirname:       test/actual/collections/desc
-                  filename:      example.html
-                  pagename:      example.html
-                  basename:      example
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
+<li><a href="collections-categories.html">collections-categories.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1055,199 +804,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      collections-categories
                   ext:           .html
                   -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/desc/context.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/desc/example.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/desc/context.html
-                  dirname:       test/actual/collections/desc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/desc/complex.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/desc/example.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/desc/complex.html
-                  dirname:       test/actual/collections/desc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/desc/collections.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/desc/example.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/desc/collections.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/desc/collections-tags.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/desc/example.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/desc/collections-tags.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/desc/collections-pages.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/desc/example.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/desc/collections-pages.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/desc/alert.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/collections/desc/example.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/desc/alert.html
-                  dirname:       test/actual/collections/desc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1279,7 +836,230 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      debug-helpers
                   ext:           .html
                   -->
-                
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/desc/context.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/desc/example.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/desc/context.html
+                  dirname:       test/actual/collections/desc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/desc/complex.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/desc/example.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/desc/complex.html
+                  dirname:       test/actual/collections/desc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/desc/collections.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/desc/example.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/desc/collections.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/desc/collections-tags.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/desc/example.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/desc/collections-tags.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/desc/collections-pages.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/desc/example.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/desc/collections-pages.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/desc/alert.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/desc/example.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/desc/alert.html
+                  dirname:       test/actual/collections/desc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="example.html">example.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/example.hbs
+                  this.dest:     test/actual/collections/desc/example.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: example.html
+                  this.pagename: example.html
+                  this.basename: example
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/collections/desc/example.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/example.hbs
+                  dest:          test/actual/collections/desc/example.html
+                  dirname:       test/actual/collections/desc
+                  filename:      example.html
+                  pagename:      example.html
+                  basename:      example
+                  ext:           .html
+                  -->
               </ul>
 
               <h1>Debug Info</h1>
@@ -1324,6 +1104,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1338,25 +1119,26 @@ This example shows that the properties from "example.json" and "example.hbs" are
   },
   "filename": "example.html",
   "first": false,
-  "index": 6,
+  "index": 15,
+  "info": "Congratulations! This is data from example.yml.",
   "isCurrentPage": false,
   "items": [
     "omega",
     "gamma"
   ],
-  "last": false,
-  "middle": true,
-  "next": 7,
-  "number": 7,
+  "last": true,
+  "middle": false,
+  "number": 16,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n\nThis example shows that the properties from \"example.json\" and \"example.hbs\" are on the page object.\n\n<hr>\n\n<div>{{page.title}}</div>\n<div>{{page.text}}</div>\n\n<hr>\n\n<div>{{title}}</div>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "example.html",
   "pagename": "example.html",
-  "prev": 5,
+  "prev": 14,
   "relativeLink": "example.html",
   "src": "test/fixtures/pages/example.hbs",
   "tags": [
     "example"
   ],
+  "text": "This is text from example.json.",
   "title": "Title from YFM of \"example.hbs\""
 }
 </code></pre>

--- a/test/actual/collections/desc/gist-helper.html
+++ b/test/actual/collections/desc/gist-helper.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="yfm.html">First</a>
     </li>
     <li class="previous">
       <a href="lodash.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="yfm.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="lodash.html">6</a>
+    </li>
     <li class="active pager-middle">
-      <a href="gist-helper.html">6</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
-    <li class="pager-middle">
-      <a href="example.html">7</a>
-    </li>
-  
     <li class="pager-middle">
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections.html">11</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-tags.html">12</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-pages.html">13</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="alert.html">14</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">15</a>
+      <a href="alert.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="example.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
     <li class="next">
-      <a href="example.html">Next &rarr;</a>
+      <a href="collections-categories.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="yfm.html">First</a>
     </li>
     <li class="prev">
       <a href="lodash.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="yfm.html">1</a>
     </li>
-  
     <li>
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li>
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li>
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li>
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
+    <li>
+      <a href="lodash.html">6</a>
+    </li>
     <li class="active">
-      <a href="gist-helper.html">6</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
-    <li>
-      <a href="example.html">7</a>
-    </li>
-  
     <li>
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li>
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li>
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li>
-      <a href="collections.html">11</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li>
-      <a href="collections-tags.html">12</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li>
-      <a href="collections-pages.html">13</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li>
-      <a href="alert.html">14</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li>
-      <a href="debug-helpers.html">15</a>
+      <a href="alert.html">15</a>
     </li>
-  
+    <li>
+      <a href="example.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="example.html">Next &rarr;</a>
+      <a href="collections-categories.html">Next &rarr;</a>
     </li>
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yfm</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">categories</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yfm</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">categories</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">two</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">alert</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">two</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">alert</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -704,45 +473,28 @@
 
             
 <h1 id="-gist-helper">{{gist}} helper</h1>
-<script src="https://gist.github.com/5193239.js"></script>
-
-
+<p>&lt;script src=&quot;<a href="https://gist.github.com/5193239.js&quot;&gt;&lt;/script&amp;gt">https://gist.github.com/5193239.js&quot;&gt;&lt;/script&amp;gt</a>;</p>
 
             <div class="docs-header" id="content">
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
-              <li><a href="example.html">example.html</a></li>
-            
               <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
               <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="example.html">example.html</a></li>
             </ul>
 
             <hr>
@@ -817,7 +569,7 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -849,7 +601,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -881,7 +633,39 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/desc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/desc/gist-helper.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/desc/no-yfm-data.html
+                  dirname:       test/actual/collections/desc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -913,7 +697,7 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -945,7 +729,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -977,39 +761,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="example.html">example.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/example.hbs
-                  this.dest:     test/actual/collections/desc/example.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: example.html
-                  this.pagename: example.html
-                  this.basename: example
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/desc/gist-helper.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/example.hbs
-                  dest:          test/actual/collections/desc/example.html
-                  dirname:       test/actual/collections/desc
-                  filename:      example.html
-                  pagename:      example.html
-                  basename:      example
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
+<li><a href="collections-categories.html">collections-categories.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1041,199 +793,7 @@
                   basename:      collections-categories
                   ext:           .html
                   -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/desc/context.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/desc/gist-helper.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/desc/context.html
-                  dirname:       test/actual/collections/desc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/desc/complex.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/desc/gist-helper.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/desc/complex.html
-                  dirname:       test/actual/collections/desc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/desc/collections.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/desc/gist-helper.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/desc/collections.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/desc/collections-tags.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/desc/gist-helper.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/desc/collections-tags.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/desc/collections-pages.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/desc/gist-helper.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/desc/collections-pages.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/desc/alert.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/collections/desc/gist-helper.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/desc/alert.html
-                  dirname:       test/actual/collections/desc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1265,7 +825,230 @@
                   basename:      debug-helpers
                   ext:           .html
                   -->
-                
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/desc/context.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/desc/gist-helper.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/desc/context.html
+                  dirname:       test/actual/collections/desc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/desc/complex.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/desc/gist-helper.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/desc/complex.html
+                  dirname:       test/actual/collections/desc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/desc/collections.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/desc/gist-helper.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/desc/collections.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/desc/collections-tags.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/desc/gist-helper.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/desc/collections-tags.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/desc/collections-pages.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/desc/gist-helper.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/desc/collections-pages.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/desc/alert.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/desc/gist-helper.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/desc/alert.html
+                  dirname:       test/actual/collections/desc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="example.html">example.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/example.hbs
+                  this.dest:     test/actual/collections/desc/example.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: example.html
+                  this.pagename: example.html
+                  this.basename: example
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/collections/desc/gist-helper.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/example.hbs
+                  dest:          test/actual/collections/desc/example.html
+                  dirname:       test/actual/collections/desc
+                  filename:      example.html
+                  pagename:      example.html
+                  basename:      example
+                  ext:           .html
+                  -->
               </ul>
 
               <h1>Debug Info</h1>
@@ -1295,6 +1078,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1309,16 +1093,16 @@
   },
   "filename": "gist-helper.html",
   "first": false,
-  "index": 5,
+  "index": 6,
   "isCurrentPage": false,
   "last": false,
   "middle": true,
-  "next": 6,
-  "number": 6,
+  "next": 7,
+  "number": 7,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n{{#markdown}}\n\n# \\{{gist}} helper\n{{gist '5193239'}}\n\n{{/markdown}}\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "gist-helper.html",
   "pagename": "gist-helper.html",
-  "prev": 4,
+  "prev": 5,
   "relativeLink": "gist-helper.html",
   "src": "test/fixtures/pages/gist-helper.hbs",
   "title": "Gist Helper"

--- a/test/actual/collections/desc/lodash.html
+++ b/test/actual/collections/desc/lodash.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="yfm.html">First</a>
     </li>
     <li class="previous">
       <a href="md-helper.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="yfm.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="md-helper.html">5</a>
+    </li>
     <li class="active pager-middle">
-      <a href="lodash.html">5</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="gist-helper.html">6</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
-    <li class="pager-middle">
-      <a href="example.html">7</a>
-    </li>
-  
     <li class="pager-middle">
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections.html">11</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-tags.html">12</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-pages.html">13</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="alert.html">14</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">15</a>
+      <a href="alert.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="example.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
     <li class="next">
       <a href="gist-helper.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="yfm.html">First</a>
     </li>
     <li class="prev">
       <a href="md-helper.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="yfm.html">1</a>
     </li>
-  
     <li>
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li>
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li>
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
+    <li>
+      <a href="md-helper.html">5</a>
+    </li>
     <li class="active">
-      <a href="lodash.html">5</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li>
-      <a href="gist-helper.html">6</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
-    <li>
-      <a href="example.html">7</a>
-    </li>
-  
     <li>
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li>
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li>
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li>
-      <a href="collections.html">11</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li>
-      <a href="collections-tags.html">12</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li>
-      <a href="collections-pages.html">13</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li>
-      <a href="alert.html">14</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li>
-      <a href="debug-helpers.html">15</a>
+      <a href="alert.html">15</a>
     </li>
-  
+    <li>
+      <a href="example.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="gist-helper.html">Next &rarr;</a>
     </li>
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yfm</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">categories</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yfm</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">categories</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">two</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">alert</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">two</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">alert</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -711,37 +480,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
-              <li><a href="example.html">example.html</a></li>
-            
               <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
               <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="example.html">example.html</a></li>
             </ul>
 
             <hr>
@@ -816,7 +570,7 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -848,7 +602,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -880,7 +634,39 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/desc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/desc/lodash.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/desc/no-yfm-data.html
+                  dirname:       test/actual/collections/desc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -912,7 +698,7 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -944,7 +730,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -976,39 +762,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="example.html">example.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/example.hbs
-                  this.dest:     test/actual/collections/desc/example.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: example.html
-                  this.pagename: example.html
-                  this.basename: example
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/desc/lodash.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/example.hbs
-                  dest:          test/actual/collections/desc/example.html
-                  dirname:       test/actual/collections/desc
-                  filename:      example.html
-                  pagename:      example.html
-                  basename:      example
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
+<li><a href="collections-categories.html">collections-categories.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1040,199 +794,7 @@
                   basename:      collections-categories
                   ext:           .html
                   -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/desc/context.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/desc/lodash.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/desc/context.html
-                  dirname:       test/actual/collections/desc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/desc/complex.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/desc/lodash.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/desc/complex.html
-                  dirname:       test/actual/collections/desc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/desc/collections.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/desc/lodash.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/desc/collections.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/desc/collections-tags.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/desc/lodash.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/desc/collections-tags.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/desc/collections-pages.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/desc/lodash.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/desc/collections-pages.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/desc/alert.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/collections/desc/lodash.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/desc/alert.html
-                  dirname:       test/actual/collections/desc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1264,7 +826,230 @@
                   basename:      debug-helpers
                   ext:           .html
                   -->
-                
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/desc/context.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/desc/lodash.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/desc/context.html
+                  dirname:       test/actual/collections/desc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/desc/complex.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/desc/lodash.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/desc/complex.html
+                  dirname:       test/actual/collections/desc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/desc/collections.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/desc/lodash.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/desc/collections.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/desc/collections-tags.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/desc/lodash.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/desc/collections-tags.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/desc/collections-pages.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/desc/lodash.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/desc/collections-pages.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/desc/alert.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/desc/lodash.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/desc/alert.html
+                  dirname:       test/actual/collections/desc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="example.html">example.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/example.hbs
+                  this.dest:     test/actual/collections/desc/example.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: example.html
+                  this.pagename: example.html
+                  this.basename: example
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/collections/desc/lodash.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/example.hbs
+                  dest:          test/actual/collections/desc/example.html
+                  dirname:       test/actual/collections/desc
+                  filename:      example.html
+                  pagename:      example.html
+                  basename:      example
+                  ext:           .html
+                  -->
               </ul>
 
               <h1>Debug Info</h1>
@@ -1296,6 +1081,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1310,16 +1096,16 @@
   },
   "filename": "lodash.html",
   "first": false,
-  "index": 4,
+  "index": 5,
   "isCurrentPage": false,
   "last": false,
   "middle": true,
-  "next": 5,
-  "number": 5,
+  "next": 6,
+  "number": 6,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n<h1>{{title}}</h1>\n<p>{{description}}</p>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "lodash.html",
   "pagename": "lodash.html",
-  "prev": 3,
+  "prev": 4,
   "relativeLink": "lodash.html",
   "src": "test/fixtures/pages/lodash.hbs",
   "title": "Assemble"

--- a/test/actual/collections/desc/md-helper.html
+++ b/test/actual/collections/desc/md-helper.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="yfm.html">First</a>
     </li>
     <li class="previous">
-      <a href="no-yfm.html">&larr; Previous</a>
+      <a href="no-yfm-data.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="yfm.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="no-yfm.html">3</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="no-yfm-data.html">4</a>
+    </li>
     <li class="active pager-middle">
-      <a href="md-helper.html">4</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="lodash.html">5</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="gist-helper.html">6</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
-    <li class="pager-middle">
-      <a href="example.html">7</a>
-    </li>
-  
     <li class="pager-middle">
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections.html">11</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-tags.html">12</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-pages.html">13</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="alert.html">14</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">15</a>
+      <a href="alert.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="example.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
     <li class="next">
       <a href="lodash.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="yfm.html">First</a>
     </li>
     <li class="prev">
-      <a href="no-yfm.html">&larr; Previous</a>
+      <a href="no-yfm-data.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="yfm.html">1</a>
     </li>
-  
     <li>
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li>
       <a href="no-yfm.html">3</a>
     </li>
-  
+    <li>
+      <a href="no-yfm-data.html">4</a>
+    </li>
     <li class="active">
-      <a href="md-helper.html">4</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li>
-      <a href="lodash.html">5</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li>
-      <a href="gist-helper.html">6</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
-    <li>
-      <a href="example.html">7</a>
-    </li>
-  
     <li>
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li>
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li>
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li>
-      <a href="collections.html">11</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li>
-      <a href="collections-tags.html">12</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li>
-      <a href="collections-pages.html">13</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li>
-      <a href="alert.html">14</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li>
-      <a href="debug-helpers.html">15</a>
+      <a href="alert.html">15</a>
     </li>
-  
+    <li>
+      <a href="example.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="lodash.html">Next &rarr;</a>
     </li>
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,488 +187,288 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">2</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">helper</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yfm</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">categories</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">2</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">helper</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yfm</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">categories</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">markdown</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">two</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">alert</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">markdown</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">two</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">alert</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -738,37 +500,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
-              <li><a href="example.html">example.html</a></li>
-            
               <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
               <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="example.html">example.html</a></li>
             </ul>
 
             <hr>
@@ -843,7 +590,7 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -875,7 +622,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -907,7 +654,39 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/desc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/desc/md-helper.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/desc/no-yfm-data.html
+                  dirname:       test/actual/collections/desc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -939,7 +718,7 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -971,7 +750,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1003,39 +782,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="example.html">example.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/example.hbs
-                  this.dest:     test/actual/collections/desc/example.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: example.html
-                  this.pagename: example.html
-                  this.basename: example
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/desc/md-helper.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/example.hbs
-                  dest:          test/actual/collections/desc/example.html
-                  dirname:       test/actual/collections/desc
-                  filename:      example.html
-                  pagename:      example.html
-                  basename:      example
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
+<li><a href="collections-categories.html">collections-categories.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1067,199 +814,7 @@
                   basename:      collections-categories
                   ext:           .html
                   -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/desc/context.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/desc/md-helper.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/desc/context.html
-                  dirname:       test/actual/collections/desc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/desc/complex.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/desc/md-helper.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/desc/complex.html
-                  dirname:       test/actual/collections/desc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/desc/collections.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/desc/md-helper.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/desc/collections.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/desc/collections-tags.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/desc/md-helper.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/desc/collections-tags.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/desc/collections-pages.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/desc/md-helper.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/desc/collections-pages.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/desc/alert.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/collections/desc/md-helper.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/desc/alert.html
-                  dirname:       test/actual/collections/desc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1291,7 +846,230 @@
                   basename:      debug-helpers
                   ext:           .html
                   -->
-                
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/desc/context.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/desc/md-helper.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/desc/context.html
+                  dirname:       test/actual/collections/desc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/desc/complex.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/desc/md-helper.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/desc/complex.html
+                  dirname:       test/actual/collections/desc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/desc/collections.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/desc/md-helper.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/desc/collections.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/desc/collections-tags.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/desc/md-helper.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/desc/collections-tags.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/desc/collections-pages.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/desc/md-helper.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/desc/collections-pages.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/desc/alert.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/desc/md-helper.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/desc/alert.html
+                  dirname:       test/actual/collections/desc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="example.html">example.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/example.hbs
+                  this.dest:     test/actual/collections/desc/example.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: example.html
+                  this.pagename: example.html
+                  this.basename: example
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/collections/desc/md-helper.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/example.hbs
+                  dest:          test/actual/collections/desc/example.html
+                  dirname:       test/actual/collections/desc
+                  filename:      example.html
+                  pagename:      example.html
+                  basename:      example
+                  ext:           .html
+                  -->
               </ul>
 
               <h1>Debug Info</h1>
@@ -1340,6 +1118,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1354,7 +1133,7 @@
   },
   "filename": "md-helper.html",
   "first": false,
-  "index": 3,
+  "index": 4,
   "isCurrentPage": false,
   "items": [
     "gamma",
@@ -1362,12 +1141,12 @@
   ],
   "last": false,
   "middle": true,
-  "next": 4,
-  "number": 4,
+  "next": 5,
+  "number": 5,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n\n<div class=\"page-header\">\n  <h1>{{title}}</h1>\n  <p class=\"lead\">{{description}}</p>\n</div>\n\n<p> {{{md './test/fixtures/pages/md.md'}}} </p>\n\n\n\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "md-helper.html",
   "pagename": "md-helper.html",
-  "prev": 2,
+  "prev": 3,
   "relativeLink": "md-helper.html",
   "src": "test/fixtures/pages/md-helper.hbs",
   "tags": [

--- a/test/actual/collections/desc/no-yfm-data.html
+++ b/test/actual/collections/desc/no-yfm-data.html
@@ -1,0 +1,1121 @@
+<!DOCTYPE html>
+  <html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Layout filename: ''</title>
+    <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../../assets/validation.css">
+  </head>
+  <body style="padding-top: 60px;">
+    <div class="container">
+
+      <!-- validate assets path -->
+      <section id="validate"></section>
+      <div class="docs-section">
+        <div class="docs-header" id="content">
+          <h4><strong class="text-muted">test/fixtures/pages/no-yfm-data.hbs</strong> &#x2192; <strong class="text-success">test/actual/collections/desc/no-yfm-data.html</strong></h4>
+        </div>
+        <hr>
+      </div>
+
+      <ul class="pager">
+
+
+    <li class="previous">
+      <a href="yfm.html">First</a>
+    </li>
+    <li class="previous">
+      <a href="no-yfm.html">&larr; Previous</a>
+    </li>
+
+    <li class="pager-middle">
+      <a href="yfm.html">1</a>
+    </li>
+    <li class="pager-middle">
+      <a href="yfm-context.html">2</a>
+    </li>
+    <li class="pager-middle">
+      <a href="no-yfm.html">3</a>
+    </li>
+    <li class="active pager-middle">
+      <a href="no-yfm-data.html">4</a>
+    </li>
+    <li class="pager-middle">
+      <a href="md-helper.html">5</a>
+    </li>
+    <li class="pager-middle">
+      <a href="lodash.html">6</a>
+    </li>
+    <li class="pager-middle">
+      <a href="gist-helper.html">7</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections-categories.html">8</a>
+    </li>
+    <li class="pager-middle">
+      <a href="debug-helpers.html">9</a>
+    </li>
+    <li class="pager-middle">
+      <a href="context.html">10</a>
+    </li>
+    <li class="pager-middle">
+      <a href="complex.html">11</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections.html">12</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections-tags.html">13</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections-pages.html">14</a>
+    </li>
+    <li class="pager-middle">
+      <a href="alert.html">15</a>
+    </li>
+    <li class="pager-middle">
+      <a href="example.html">16</a>
+    </li>
+
+    <li class="next">
+      <a href="example.html">Last</a>
+    </li>
+    <li class="next">
+      <a href="md-helper.html">Next &rarr;</a>
+    </li>
+
+
+</ul><style>
+.unselectable {
+  -webkit-touch-callout: none;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+}
+</style>
+      <hr>
+
+      <div class="row">
+        <!-- Column: sidebar -->
+        <div class="col-md-3">
+          <div class="bs-sidebar hidden-print" role="complementary">
+            <!-- pagination -->
+            <ul class="nav nav-pills nav-stacked">
+
+
+    <li class="prev">
+      <a href="yfm.html">First</a>
+    </li>
+    <li class="prev">
+      <a href="no-yfm.html">&larr; Previous</a>
+    </li>
+
+    <li>
+      <a href="yfm.html">1</a>
+    </li>
+    <li>
+      <a href="yfm-context.html">2</a>
+    </li>
+    <li>
+      <a href="no-yfm.html">3</a>
+    </li>
+    <li class="active">
+      <a href="no-yfm-data.html">4</a>
+    </li>
+    <li>
+      <a href="md-helper.html">5</a>
+    </li>
+    <li>
+      <a href="lodash.html">6</a>
+    </li>
+    <li>
+      <a href="gist-helper.html">7</a>
+    </li>
+    <li>
+      <a href="collections-categories.html">8</a>
+    </li>
+    <li>
+      <a href="debug-helpers.html">9</a>
+    </li>
+    <li>
+      <a href="context.html">10</a>
+    </li>
+    <li>
+      <a href="complex.html">11</a>
+    </li>
+    <li>
+      <a href="collections.html">12</a>
+    </li>
+    <li>
+      <a href="collections-tags.html">13</a>
+    </li>
+    <li>
+      <a href="collections-pages.html">14</a>
+    </li>
+    <li>
+      <a href="alert.html">15</a>
+    </li>
+    <li>
+      <a href="example.html">16</a>
+    </li>
+
+    <li class="next">
+      <a href="md-helper.html">Next &rarr;</a>
+    </li>
+    <li class="next">
+      <a href="example.html">Last</a>
+    </li>
+
+
+</ul>
+          </div>
+        </div>
+        <!-- Column: content -->
+        <div class="col-md-9" role="main">
+          <div class="docs-section">
+            <div class="docs-header" id="content">
+              <h4><strong>Page layout:</strong> default.hbs</h4>
+              <h4><strong>Page src:</strong> test/fixtures/pages/no-yfm-data.hbs</h4>
+              <h4><strong>Page dest:</strong> test/actual/collections/desc/no-yfm-data.html</h4>
+              <h4><strong>Dest filename:</strong> no-yfm-data.html</h4>
+              <h4><strong>Dest basename:</strong> no-yfm-data</h4>
+              <h4><strong>Page title:</strong> (no title defined)</h4>
+            </div>
+
+            <hr>
+            <div class="row">
+              <div class="col-md-6">
+                <!-- Categories Collection -->
+                  
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yfm</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">categories</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
+              </div>
+              <div class="col-md-6">
+                  
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">two</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">alert</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
+              </div>
+            </div>
+
+            <hr>
+
+            There is no YAML front matter in this page.
+
+<ul>
+  <li>first</li>
+  <li>second</li>
+  <li>third</li>
+  <li>globalData1</li>
+</ul>
+
+
+            <div class="docs-header" id="content">
+              <h1>Content</h1>
+            </div>
+            <ul>
+              <li><a href="yfm.html">yfm.html</a></li>
+              <li><a href="yfm-context.html">yfm-context.html</a></li>
+              <li><a href="no-yfm.html">no-yfm.html</a></li>
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+              <li><a href="md-helper.html">md-helper.html</a></li>
+              <li><a href="lodash.html">lodash.html</a></li>
+              <li><a href="gist-helper.html">gist-helper.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="example.html">example.html</a></li>
+            </ul>
+
+            <hr>
+            <div style="display: none">
+
+              <h1>Page</h1>
+              <!--
+              "this"
+              ===============================
+              this.src:      
+              this.dest:     
+              this.layout:   
+              this.dirname:  test/actual/collections/desc
+              this.filename: no-yfm-data.html
+              this.pagename: no-yfm-data.html
+              this.basename: no-yfm-data
+              this.ext:      .html
+
+              "page"
+              ===============================
+              page.src:        test/fixtures/pages/no-yfm-data.hbs
+              page.dest:       test/actual/collections/desc/no-yfm-data.html
+              page.layout:     
+              page.dirname:    test/actual/collections/desc
+              page.filename:   no-yfm-data.html
+              page.pagename:   no-yfm-data.html
+              page.basename:   no-yfm-data
+              page.ext:        .html
+
+              "root"
+              ===============================
+              src:           
+              dest:          
+              layout:        
+              dirname:       test/actual/collections/desc
+              filename:      no-yfm-data.html
+              pagename:      no-yfm-data.html
+              basename:      no-yfm-data
+              ext:           .html
+              -->
+              <h1>Each pages</h1>
+              <ul>
+                <li><a href="yfm.html">yfm.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/yfm.hbs
+                  this.dest:     test/actual/collections/desc/yfm.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: yfm.html
+                  this.pagename: yfm.html
+                  this.basename: yfm
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/yfm.hbs
+                  dest:          test/actual/collections/desc/yfm.html
+                  dirname:       test/actual/collections/desc
+                  filename:      yfm.html
+                  pagename:      yfm.html
+                  basename:      yfm
+                  ext:           .html
+                  -->
+<li><a href="yfm-context.html">yfm-context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/yfm-context.hbs
+                  this.dest:     test/actual/collections/desc/yfm-context.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: yfm-context.html
+                  this.pagename: yfm-context.html
+                  this.basename: yfm-context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/yfm-context.hbs
+                  dest:          test/actual/collections/desc/yfm-context.html
+                  dirname:       test/actual/collections/desc
+                  filename:      yfm-context.html
+                  pagename:      yfm-context.html
+                  basename:      yfm-context
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm.hbs
+                  this.dest:     test/actual/collections/desc/no-yfm.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: no-yfm.html
+                  this.pagename: no-yfm.html
+                  this.basename: no-yfm
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm.hbs
+                  dest:          test/actual/collections/desc/no-yfm.html
+                  dirname:       test/actual/collections/desc
+                  filename:      no-yfm.html
+                  pagename:      no-yfm.html
+                  basename:      no-yfm
+                  ext:           .html
+                  -->
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/desc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/desc/no-yfm-data.html
+                  dirname:       test/actual/collections/desc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="md-helper.html">md-helper.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/md-helper.hbs
+                  this.dest:     test/actual/collections/desc/md-helper.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: md-helper.html
+                  this.pagename: md-helper.html
+                  this.basename: md-helper
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/md-helper.hbs
+                  dest:          test/actual/collections/desc/md-helper.html
+                  dirname:       test/actual/collections/desc
+                  filename:      md-helper.html
+                  pagename:      md-helper.html
+                  basename:      md-helper
+                  ext:           .html
+                  -->
+<li><a href="lodash.html">lodash.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/lodash.hbs
+                  this.dest:     test/actual/collections/desc/lodash.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: lodash.html
+                  this.pagename: lodash.html
+                  this.basename: lodash
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/lodash.hbs
+                  dest:          test/actual/collections/desc/lodash.html
+                  dirname:       test/actual/collections/desc
+                  filename:      lodash.html
+                  pagename:      lodash.html
+                  basename:      lodash
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/gist-helper.hbs
+                  this.dest:     test/actual/collections/desc/gist-helper.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: gist-helper.html
+                  this.pagename: gist-helper.html
+                  this.basename: gist-helper
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/gist-helper.hbs
+                  dest:          test/actual/collections/desc/gist-helper.html
+                  dirname:       test/actual/collections/desc
+                  filename:      gist-helper.html
+                  pagename:      gist-helper.html
+                  basename:      gist-helper
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/collections/desc/collections-categories.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/collections/desc/collections-categories.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/collections/desc/debug-helpers.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/collections/desc/debug-helpers.html
+                  dirname:       test/actual/collections/desc
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/desc/context.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/desc/context.html
+                  dirname:       test/actual/collections/desc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/desc/complex.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/desc/complex.html
+                  dirname:       test/actual/collections/desc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/desc/collections.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/desc/collections.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/desc/collections-tags.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/desc/collections-tags.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/desc/collections-pages.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/desc/collections-pages.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/desc/alert.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/desc/alert.html
+                  dirname:       test/actual/collections/desc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="example.html">example.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/example.hbs
+                  this.dest:     test/actual/collections/desc/example.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: example.html
+                  this.pagename: example.html
+                  this.basename: example
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm-data.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/example.hbs
+                  dest:          test/actual/collections/desc/example.html
+                  dirname:       test/actual/collections/desc
+                  filename:      example.html
+                  pagename:      example.html
+                  basename:      example
+                  ext:           .html
+                  -->
+              </ul>
+
+              <h1>Debug Info</h1>
+              <pre><code class="json">
+{
+  "_page": "all",
+  "assets": "../../../assets",
+  "basename": "no-yfm-data",
+  "data": {},
+  "dest": "test/actual/collections/desc/no-yfm-data.html",
+  "dirname": "test/actual/collections/desc",
+  "ext": ".html",
+  "extname": ".html",
+  "filePair": {
+    "src": [
+      "test/fixtures/pages/alert.hbs",
+      "test/fixtures/pages/collections-categories.hbs",
+      "test/fixtures/pages/collections-pages.hbs",
+      "test/fixtures/pages/collections-tags.hbs",
+      "test/fixtures/pages/collections.hbs",
+      "test/fixtures/pages/complex.hbs",
+      "test/fixtures/pages/context.hbs",
+      "test/fixtures/pages/debug-helpers.hbs",
+      "test/fixtures/pages/example.hbs",
+      "test/fixtures/pages/gist-helper.hbs",
+      "test/fixtures/pages/lodash.hbs",
+      "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
+      "test/fixtures/pages/no-yfm.hbs",
+      "test/fixtures/pages/yfm-context.hbs",
+      "test/fixtures/pages/yfm.hbs"
+    ],
+    "dest": "test/actual/collections/desc/",
+    "orig": {
+      "src": [
+        "test/fixtures/pages/*.hbs"
+      ],
+      "dest": "test/actual/collections/desc/"
+    }
+  },
+  "filename": "no-yfm-data.html",
+  "first": false,
+  "index": 3,
+  "isCurrentPage": false,
+  "last": false,
+  "middle": true,
+  "next": 4,
+  "number": 4,
+  "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            There is no YAML front matter in this page.\n\n<ul>\n  <li>{{one}}</li>\n  <li>{{two}}</li>\n  <li>{{three}}</li>\n  <li>{{global1}}</li>\n</ul>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
+  "pageName": "no-yfm-data.html",
+  "pagename": "no-yfm-data.html",
+  "prev": 2,
+  "relativeLink": "no-yfm-data.html",
+  "src": "test/fixtures/pages/no-yfm-data.hbs"
+}
+</code></pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script src="../../../assets/validation.js"></script>
+  </body>
+</html>

--- a/test/actual/collections/desc/no-yfm.html
+++ b/test/actual/collections/desc/no-yfm.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="yfm.html">First</a>
     </li>
     <li class="previous">
       <a href="yfm-context.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="yfm.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">7</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections.html">11</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-tags.html">12</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-pages.html">13</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="alert.html">14</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">15</a>
+      <a href="alert.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="example.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
     <li class="next">
-      <a href="md-helper.html">Next &rarr;</a>
+      <a href="no-yfm-data.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="yfm.html">First</a>
     </li>
     <li class="prev">
       <a href="yfm-context.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="yfm.html">1</a>
     </li>
-  
     <li>
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li class="active">
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li>
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li>
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li>
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li>
-      <a href="example.html">7</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li>
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li>
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li>
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li>
-      <a href="collections.html">11</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li>
-      <a href="collections-tags.html">12</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li>
-      <a href="collections-pages.html">13</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li>
-      <a href="alert.html">14</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li>
-      <a href="debug-helpers.html">15</a>
+      <a href="alert.html">15</a>
     </li>
-  
+    <li>
+      <a href="example.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="md-helper.html">Next &rarr;</a>
+      <a href="no-yfm-data.html">Next &rarr;</a>
     </li>
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yfm</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">categories</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yfm</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">categories</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">two</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">alert</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">two</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">alert</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -704,8 +473,8 @@
 
             There is no YAML front matter in this page.
 
-<div></div>
-<div></div>
+<div>Variable number one</div>
+<div>Variable number two</div>
 
 
 
@@ -714,37 +483,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
-              <li><a href="example.html">example.html</a></li>
-            
               <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
               <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="example.html">example.html</a></li>
             </ul>
 
             <hr>
@@ -819,7 +573,7 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -851,7 +605,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -883,7 +637,39 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/desc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/desc/no-yfm-data.html
+                  dirname:       test/actual/collections/desc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -915,7 +701,7 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -947,7 +733,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -979,39 +765,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="example.html">example.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/example.hbs
-                  this.dest:     test/actual/collections/desc/example.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: example.html
-                  this.pagename: example.html
-                  this.basename: example
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/desc/no-yfm.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/example.hbs
-                  dest:          test/actual/collections/desc/example.html
-                  dirname:       test/actual/collections/desc
-                  filename:      example.html
-                  pagename:      example.html
-                  basename:      example
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
+<li><a href="collections-categories.html">collections-categories.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1043,199 +797,7 @@
                   basename:      collections-categories
                   ext:           .html
                   -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/desc/context.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/desc/no-yfm.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/desc/context.html
-                  dirname:       test/actual/collections/desc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/desc/complex.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/desc/no-yfm.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/desc/complex.html
-                  dirname:       test/actual/collections/desc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/desc/collections.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/desc/no-yfm.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/desc/collections.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/desc/collections-tags.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/desc/no-yfm.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/desc/collections-tags.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/desc/collections-pages.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/desc/no-yfm.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/desc/collections-pages.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/desc/alert.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/collections/desc/no-yfm.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/desc/alert.html
-                  dirname:       test/actual/collections/desc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1267,7 +829,230 @@
                   basename:      debug-helpers
                   ext:           .html
                   -->
-                
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/desc/context.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/desc/context.html
+                  dirname:       test/actual/collections/desc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/desc/complex.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/desc/complex.html
+                  dirname:       test/actual/collections/desc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/desc/collections.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/desc/collections.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/desc/collections-tags.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/desc/collections-tags.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/desc/collections-pages.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/desc/collections-pages.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/desc/alert.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/desc/alert.html
+                  dirname:       test/actual/collections/desc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="example.html">example.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/example.hbs
+                  this.dest:     test/actual/collections/desc/example.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: example.html
+                  this.pagename: example.html
+                  this.basename: example
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/collections/desc/no-yfm.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/example.hbs
+                  dest:          test/actual/collections/desc/example.html
+                  dirname:       test/actual/collections/desc
+                  filename:      example.html
+                  pagename:      example.html
+                  basename:      example
+                  ext:           .html
+                  -->
               </ul>
 
               <h1>Debug Info</h1>
@@ -1295,6 +1080,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/desc/yfm-context.html
+++ b/test/actual/collections/desc/yfm-context.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="yfm.html">First</a>
     </li>
     <li class="previous">
       <a href="yfm.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="yfm.html">1</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">7</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections.html">11</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-tags.html">12</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-pages.html">13</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="alert.html">14</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">15</a>
+      <a href="alert.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="example.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
     <li class="next">
       <a href="no-yfm.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="yfm.html">First</a>
     </li>
     <li class="prev">
       <a href="yfm.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="yfm.html">1</a>
     </li>
-  
     <li class="active">
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li>
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li>
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li>
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li>
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li>
-      <a href="example.html">7</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li>
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li>
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li>
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li>
-      <a href="collections.html">11</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li>
-      <a href="collections-tags.html">12</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li>
-      <a href="collections-pages.html">13</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li>
-      <a href="alert.html">14</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li>
-      <a href="debug-helpers.html">15</a>
+      <a href="alert.html">15</a>
     </li>
-  
+    <li>
+      <a href="example.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="no-yfm.html">Next &rarr;</a>
     </li>
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yfm</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">context</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yfm</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">categories</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yfm</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">context</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yfm</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">categories</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">two</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">alert</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">two</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">alert</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -711,8 +476,8 @@
             
 
 <div class="page-header">
-  <h1>Title from home.json didn't render.</h1>
-  <p class="lead">Description from home.json didn't render.</p>
+  <h1>This title is from a JSON file.</h1>
+  <p class="lead">This description is from a JSON file.</p>
 </div>
 
 <hr>
@@ -736,37 +501,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
-              <li><a href="example.html">example.html</a></li>
-            
               <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
               <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="example.html">example.html</a></li>
             </ul>
 
             <hr>
@@ -841,7 +591,7 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -873,7 +623,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -905,7 +655,39 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/desc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/desc/yfm-context.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/desc/no-yfm-data.html
+                  dirname:       test/actual/collections/desc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -937,7 +719,7 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -969,7 +751,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1001,39 +783,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="example.html">example.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/example.hbs
-                  this.dest:     test/actual/collections/desc/example.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: example.html
-                  this.pagename: example.html
-                  this.basename: example
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/desc/yfm-context.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/example.hbs
-                  dest:          test/actual/collections/desc/example.html
-                  dirname:       test/actual/collections/desc
-                  filename:      example.html
-                  pagename:      example.html
-                  basename:      example
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
+<li><a href="collections-categories.html">collections-categories.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1065,199 +815,7 @@
                   basename:      collections-categories
                   ext:           .html
                   -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/desc/context.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/desc/yfm-context.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/desc/context.html
-                  dirname:       test/actual/collections/desc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/desc/complex.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/desc/yfm-context.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/desc/complex.html
-                  dirname:       test/actual/collections/desc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/desc/collections.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/desc/yfm-context.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/desc/collections.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/desc/collections-tags.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/desc/yfm-context.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/desc/collections-tags.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/desc/collections-pages.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/desc/yfm-context.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/desc/collections-pages.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/desc/alert.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/collections/desc/yfm-context.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/desc/alert.html
-                  dirname:       test/actual/collections/desc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1289,7 +847,230 @@
                   basename:      debug-helpers
                   ext:           .html
                   -->
-                
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/desc/context.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/desc/yfm-context.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/desc/context.html
+                  dirname:       test/actual/collections/desc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/desc/complex.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/desc/yfm-context.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/desc/complex.html
+                  dirname:       test/actual/collections/desc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/desc/collections.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/desc/yfm-context.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/desc/collections.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/desc/collections-tags.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/desc/yfm-context.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/desc/collections-tags.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/desc/collections-pages.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/desc/yfm-context.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/desc/collections-pages.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/desc/alert.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/desc/yfm-context.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/desc/alert.html
+                  dirname:       test/actual/collections/desc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="example.html">example.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/example.hbs
+                  this.dest:     test/actual/collections/desc/example.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: example.html
+                  this.pagename: example.html
+                  this.basename: example
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/collections/desc/yfm-context.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/example.hbs
+                  dest:          test/actual/collections/desc/example.html
+                  dirname:       test/actual/collections/desc
+                  filename:      example.html
+                  pagename:      example.html
+                  basename:      example
+                  ext:           .html
+                  -->
               </ul>
 
               <h1>Debug Info</h1>
@@ -1331,6 +1112,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/collections/desc/yfm.html
+++ b/test/actual/collections/desc/yfm.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">First</a>
     </li>
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">&larr; Previous</a>
     </li>
-  
 
-  
 
-  
     <li class="active pager-middle">
       <a href="yfm.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">7</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections.html">11</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-tags.html">12</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-pages.html">13</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="alert.html">14</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">15</a>
+      <a href="alert.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="example.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
     <li class="next">
       <a href="yfm-context.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
     <li class="prev disabled">
       <a unselectable="on" class="unselectable">First</a>
     </li>
     <li class="prev disabled">
       <a unselectable="on" class="unselectable">&larr; Previous</a>
     </li>
-  
 
-  
 
-  
     <li class="active">
       <a href="yfm.html">1</a>
     </li>
-  
     <li>
       <a href="yfm-context.html">2</a>
     </li>
-  
     <li>
       <a href="no-yfm.html">3</a>
     </li>
-  
     <li>
-      <a href="md-helper.html">4</a>
+      <a href="no-yfm-data.html">4</a>
     </li>
-  
     <li>
-      <a href="lodash.html">5</a>
+      <a href="md-helper.html">5</a>
     </li>
-  
     <li>
-      <a href="gist-helper.html">6</a>
+      <a href="lodash.html">6</a>
     </li>
-  
     <li>
-      <a href="example.html">7</a>
+      <a href="gist-helper.html">7</a>
     </li>
-  
     <li>
       <a href="collections-categories.html">8</a>
     </li>
-  
     <li>
-      <a href="context.html">9</a>
+      <a href="debug-helpers.html">9</a>
     </li>
-  
     <li>
-      <a href="complex.html">10</a>
+      <a href="context.html">10</a>
     </li>
-  
     <li>
-      <a href="collections.html">11</a>
+      <a href="complex.html">11</a>
     </li>
-  
     <li>
-      <a href="collections-tags.html">12</a>
+      <a href="collections.html">12</a>
     </li>
-  
     <li>
-      <a href="collections-pages.html">13</a>
+      <a href="collections-tags.html">13</a>
     </li>
-  
     <li>
-      <a href="alert.html">14</a>
+      <a href="collections-pages.html">14</a>
     </li>
-  
     <li>
-      <a href="debug-helpers.html">15</a>
+      <a href="alert.html">15</a>
     </li>
-  
+    <li>
+      <a href="example.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm-context.html">Next &rarr;</a>
     </li>
     <li class="next">
-      <a href="debug-helpers.html">Last</a>
+      <a href="example.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yfm</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">categories</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yfm</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">categories</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">two</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">alert</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">two</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">alert</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -711,37 +480,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
-              <li><a href="example.html">example.html</a></li>
-            
               <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
               <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="example.html">example.html</a></li>
             </ul>
 
             <hr>
@@ -816,7 +570,7 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -848,7 +602,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -880,7 +634,39 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/collections/desc/no-yfm-data.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/desc/yfm.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/collections/desc/no-yfm-data.html
+                  dirname:       test/actual/collections/desc
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -912,7 +698,7 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -944,7 +730,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -976,39 +762,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="example.html">example.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/example.hbs
-                  this.dest:     test/actual/collections/desc/example.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: example.html
-                  this.pagename: example.html
-                  this.basename: example
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/desc/yfm.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/example.hbs
-                  dest:          test/actual/collections/desc/example.html
-                  dirname:       test/actual/collections/desc
-                  filename:      example.html
-                  pagename:      example.html
-                  basename:      example
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
+<li><a href="collections-categories.html">collections-categories.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1040,199 +794,7 @@
                   basename:      collections-categories
                   ext:           .html
                   -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/collections/desc/context.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/desc/yfm.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/collections/desc/context.html
-                  dirname:       test/actual/collections/desc
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/collections/desc/complex.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/desc/yfm.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/collections/desc/complex.html
-                  dirname:       test/actual/collections/desc
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/collections/desc/collections.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/desc/yfm.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/collections/desc/collections.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/collections/desc/collections-tags.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/desc/yfm.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/collections/desc/collections-tags.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/collections/desc/collections-pages.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/desc/yfm.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/collections/desc/collections-pages.html
-                  dirname:       test/actual/collections/desc
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/collections/desc/alert.html
-                  this.dirname:  test/actual/collections/desc
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/collections/desc/yfm.html
-                  page.dirname:  test/actual/collections/desc
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/collections/desc/alert.html
-                  dirname:       test/actual/collections/desc
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1264,7 +826,230 @@
                   basename:      debug-helpers
                   ext:           .html
                   -->
-                
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/collections/desc/context.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/desc/yfm.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/collections/desc/context.html
+                  dirname:       test/actual/collections/desc
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/collections/desc/complex.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/desc/yfm.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/collections/desc/complex.html
+                  dirname:       test/actual/collections/desc
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/collections/desc/collections.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/desc/yfm.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/collections/desc/collections.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/collections/desc/collections-tags.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/desc/yfm.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/collections/desc/collections-tags.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/collections/desc/collections-pages.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/desc/yfm.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/collections/desc/collections-pages.html
+                  dirname:       test/actual/collections/desc
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/collections/desc/alert.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/desc/yfm.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/collections/desc/alert.html
+                  dirname:       test/actual/collections/desc
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="example.html">example.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/example.hbs
+                  this.dest:     test/actual/collections/desc/example.html
+                  this.dirname:  test/actual/collections/desc
+                  this.filename: example.html
+                  this.pagename: example.html
+                  this.basename: example
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/collections/desc/yfm.html
+                  page.dirname:  test/actual/collections/desc
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/example.hbs
+                  dest:          test/actual/collections/desc/example.html
+                  dirname:       test/actual/collections/desc
+                  filename:      example.html
+                  pagename:      example.html
+                  basename:      example
+                  ext:           .html
+                  -->
               </ul>
 
               <h1>Debug Info</h1>
@@ -1299,6 +1084,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/layout_ext/layoutext.html
+++ b/test/actual/layout_ext/layoutext.html
@@ -16,33 +16,25 @@
             <!-- pagination -->
             <ul class="pager">
 
-  
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">First</a>
     </li>
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">&larr; Previous</a>
     </li>
-  
 
-  
 
-  
     <li class="active pager-middle">
       <a href="layoutext.html">1</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
-  
 
 </ul><style>
 .unselectable {

--- a/test/actual/noyfm/no-yfm-data.html
+++ b/test/actual/noyfm/no-yfm-data.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+  <html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Layout filename: ''</title>
+    <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../assets/validation.css">
+  </head>
+  <body style="padding-top: 60px;">
+    <div class="container">
+
+      <!-- validate assets path -->
+      <section id="validate"></section>
+      <div class="docs-section">
+        <div class="docs-header" id="content">
+          <h4><strong class="text-muted">test/fixtures/pages/no-yfm-data.hbs</strong> &#x2192; <strong class="text-success">test/actual/noyfm/no-yfm-data.html</strong></h4>
+        </div>
+        <hr>
+      </div>
+
+      <ul class="pager">
+
+    <li class="previous disabled">
+      <a unselectable="on" class="unselectable">First</a>
+    </li>
+    <li class="previous disabled">
+      <a unselectable="on" class="unselectable">&larr; Previous</a>
+    </li>
+
+
+    <li class="active pager-middle">
+      <a href="no-yfm-data.html">1</a>
+    </li>
+
+
+    <li class="next disabled">
+      <a unselectable="on" class="unselectable">Last</a>
+    </li>
+    <li class="next disabled">
+      <a unselectable="on" class="unselectable">Next &rarr;</a>
+    </li>
+
+</ul><style>
+.unselectable {
+  -webkit-touch-callout: none;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+}
+</style>
+      <hr>
+
+      <div class="row">
+        <!-- Column: sidebar -->
+        <div class="col-md-3">
+          <div class="bs-sidebar hidden-print" role="complementary">
+            <!-- pagination -->
+            <ul class="nav nav-pills nav-stacked">
+
+    <li class="prev disabled">
+      <a unselectable="on" class="unselectable">First</a>
+    </li>
+    <li class="prev disabled">
+      <a unselectable="on" class="unselectable">&larr; Previous</a>
+    </li>
+
+
+    <li class="active">
+      <a href="no-yfm-data.html">1</a>
+    </li>
+
+
+    <li class="next disabled">
+      <a unselectable="on" class="unselectable">Next &rarr;</a>
+    </li>
+    <li class="next disabled">
+      <a unselectable="on" class="unselectable">Last</a>
+    </li>
+
+</ul>
+          </div>
+        </div>
+        <!-- Column: content -->
+        <div class="col-md-9" role="main">
+          <div class="docs-section">
+            <div class="docs-header" id="content">
+              <h4><strong>Page layout:</strong> default.hbs</h4>
+              <h4><strong>Page src:</strong> test/fixtures/pages/no-yfm-data.hbs</h4>
+              <h4><strong>Page dest:</strong> test/actual/noyfm/no-yfm-data.html</h4>
+              <h4><strong>Dest filename:</strong> no-yfm-data.html</h4>
+              <h4><strong>Dest basename:</strong> no-yfm-data</h4>
+              <h4><strong>Page title:</strong> (no title defined)</h4>
+            </div>
+
+            <hr>
+            <div class="row">
+              <div class="col-md-6">
+                <!-- Categories Collection -->
+              </div>
+              <div class="col-md-6">
+              </div>
+            </div>
+
+            <hr>
+
+            There is no YAML front matter in this page.
+
+<ul>
+  <li>1-one</li>
+  <li>2-two</li>
+  <li>3-three</li>
+  <li>override global1 data via task option</li>
+</ul>
+
+
+            <div class="docs-header" id="content">
+              <h1>Content</h1>
+            </div>
+            <ul>
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+            </ul>
+
+            <hr>
+            <div style="display: none">
+
+              <h1>Page</h1>
+              <!--
+              "this"
+              ===============================
+              this.src:      
+              this.dest:     
+              this.layout:   
+              this.dirname:  test/actual/noyfm
+              this.filename: no-yfm-data.html
+              this.pagename: no-yfm-data.html
+              this.basename: no-yfm-data
+              this.ext:      .html
+
+              "page"
+              ===============================
+              page.src:        test/fixtures/pages/no-yfm-data.hbs
+              page.dest:       test/actual/noyfm/no-yfm-data.html
+              page.layout:     
+              page.dirname:    test/actual/noyfm
+              page.filename:   no-yfm-data.html
+              page.pagename:   no-yfm-data.html
+              page.basename:   no-yfm-data
+              page.ext:        .html
+
+              "root"
+              ===============================
+              src:           
+              dest:          
+              layout:        
+              dirname:       test/actual/noyfm
+              filename:      no-yfm-data.html
+              pagename:      no-yfm-data.html
+              basename:      no-yfm-data
+              ext:           .html
+              -->
+              <h1>Each pages</h1>
+              <ul>
+                <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/noyfm/no-yfm-data.html
+                  this.dirname:  test/actual/noyfm
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/noyfm/no-yfm-data.html
+                  page.dirname:  test/actual/noyfm
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/noyfm/no-yfm-data.html
+                  dirname:       test/actual/noyfm
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+              </ul>
+
+              <h1>Debug Info</h1>
+              <pre><code class="json">
+{
+  "_page": "all",
+  "assets": "../../assets",
+  "basename": "no-yfm-data",
+  "data": {},
+  "dest": "test/actual/noyfm/no-yfm-data.html",
+  "dirname": "test/actual/noyfm",
+  "ext": ".html",
+  "extname": ".html",
+  "filePair": {
+    "src": [
+      "test/fixtures/pages/no-yfm-data.hbs"
+    ],
+    "dest": "test/actual/noyfm/no-yfm-data.html",
+    "orig": {
+      "src": [
+        "test/fixtures/pages/no-yfm-data.hbs"
+      ],
+      "dest": "test/actual/noyfm/no-yfm-data.html"
+    }
+  },
+  "filename": "no-yfm-data.html",
+  "first": true,
+  "index": 0,
+  "last": true,
+  "middle": false,
+  "number": 1,
+  "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            There is no YAML front matter in this page.\n\n<ul>\n  <li>{{one}}</li>\n  <li>{{two}}</li>\n  <li>{{three}}</li>\n  <li>{{global1}}</li>\n</ul>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
+  "pageName": "no-yfm-data.html",
+  "pagename": "no-yfm-data.html",
+  "src": "test/fixtures/pages/no-yfm-data.hbs"
+}
+</code></pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script src="../../assets/validation.js"></script>
+  </body>
+</html>

--- a/test/actual/noyfm/no-yfm-datafile.html
+++ b/test/actual/noyfm/no-yfm-datafile.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+  <html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Layout filename: ''</title>
+    <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../assets/validation.css">
+  </head>
+  <body style="padding-top: 60px;">
+    <div class="container">
+
+      <!-- validate assets path -->
+      <section id="validate"></section>
+      <div class="docs-section">
+        <div class="docs-header" id="content">
+          <h4><strong class="text-muted">test/fixtures/pages/no-yfm-data.hbs</strong> &#x2192; <strong class="text-success">test/actual/noyfm/no-yfm-datafile.html</strong></h4>
+        </div>
+        <hr>
+      </div>
+
+      <ul class="pager">
+
+    <li class="previous disabled">
+      <a unselectable="on" class="unselectable">First</a>
+    </li>
+    <li class="previous disabled">
+      <a unselectable="on" class="unselectable">&larr; Previous</a>
+    </li>
+
+
+    <li class="active pager-middle">
+      <a href="no-yfm-datafile.html">1</a>
+    </li>
+
+
+    <li class="next disabled">
+      <a unselectable="on" class="unselectable">Last</a>
+    </li>
+    <li class="next disabled">
+      <a unselectable="on" class="unselectable">Next &rarr;</a>
+    </li>
+
+</ul><style>
+.unselectable {
+  -webkit-touch-callout: none;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+}
+</style>
+      <hr>
+
+      <div class="row">
+        <!-- Column: sidebar -->
+        <div class="col-md-3">
+          <div class="bs-sidebar hidden-print" role="complementary">
+            <!-- pagination -->
+            <ul class="nav nav-pills nav-stacked">
+
+    <li class="prev disabled">
+      <a unselectable="on" class="unselectable">First</a>
+    </li>
+    <li class="prev disabled">
+      <a unselectable="on" class="unselectable">&larr; Previous</a>
+    </li>
+
+
+    <li class="active">
+      <a href="no-yfm-datafile.html">1</a>
+    </li>
+
+
+    <li class="next disabled">
+      <a unselectable="on" class="unselectable">Next &rarr;</a>
+    </li>
+    <li class="next disabled">
+      <a unselectable="on" class="unselectable">Last</a>
+    </li>
+
+</ul>
+          </div>
+        </div>
+        <!-- Column: content -->
+        <div class="col-md-9" role="main">
+          <div class="docs-section">
+            <div class="docs-header" id="content">
+              <h4><strong>Page layout:</strong> default.hbs</h4>
+              <h4><strong>Page src:</strong> test/fixtures/pages/no-yfm-data.hbs</h4>
+              <h4><strong>Page dest:</strong> test/actual/noyfm/no-yfm-datafile.html</h4>
+              <h4><strong>Dest filename:</strong> no-yfm-datafile.html</h4>
+              <h4><strong>Dest basename:</strong> no-yfm-data</h4>
+              <h4><strong>Page title:</strong> (no title defined)</h4>
+            </div>
+
+            <hr>
+            <div class="row">
+              <div class="col-md-6">
+                <!-- Categories Collection -->
+              </div>
+              <div class="col-md-6">
+              </div>
+            </div>
+
+            <hr>
+
+            There is no YAML front matter in this page.
+
+<ul>
+  <li>first</li>
+  <li>second</li>
+  <li>third</li>
+  <li>globalData1</li>
+</ul>
+
+
+            <div class="docs-header" id="content">
+              <h1>Content</h1>
+            </div>
+            <ul>
+              <li><a href="no-yfm-datafile.html">no-yfm-datafile.html</a></li>
+            </ul>
+
+            <hr>
+            <div style="display: none">
+
+              <h1>Page</h1>
+              <!--
+              "this"
+              ===============================
+              this.src:      
+              this.dest:     
+              this.layout:   
+              this.dirname:  test/actual/noyfm
+              this.filename: no-yfm-datafile.html
+              this.pagename: no-yfm-datafile.html
+              this.basename: no-yfm-data
+              this.ext:      .html
+
+              "page"
+              ===============================
+              page.src:        test/fixtures/pages/no-yfm-data.hbs
+              page.dest:       test/actual/noyfm/no-yfm-datafile.html
+              page.layout:     
+              page.dirname:    test/actual/noyfm
+              page.filename:   no-yfm-datafile.html
+              page.pagename:   no-yfm-datafile.html
+              page.basename:   no-yfm-data
+              page.ext:        .html
+
+              "root"
+              ===============================
+              src:           
+              dest:          
+              layout:        
+              dirname:       test/actual/noyfm
+              filename:      no-yfm-datafile.html
+              pagename:      no-yfm-datafile.html
+              basename:      no-yfm-data
+              ext:           .html
+              -->
+              <h1>Each pages</h1>
+              <ul>
+                <li><a href="no-yfm-datafile.html">no-yfm-datafile.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/noyfm/no-yfm-datafile.html
+                  this.dirname:  test/actual/noyfm
+                  this.filename: no-yfm-datafile.html
+                  this.pagename: no-yfm-datafile.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/noyfm/no-yfm-datafile.html
+                  page.dirname:  test/actual/noyfm
+                  page.filename: no-yfm-datafile.html
+                  page.pagename: no-yfm-datafile.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/noyfm/no-yfm-datafile.html
+                  dirname:       test/actual/noyfm
+                  filename:      no-yfm-datafile.html
+                  pagename:      no-yfm-datafile.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+              </ul>
+
+              <h1>Debug Info</h1>
+              <pre><code class="json">
+{
+  "_page": "all",
+  "assets": "../../assets",
+  "basename": "no-yfm-data",
+  "data": {},
+  "dest": "test/actual/noyfm/no-yfm-datafile.html",
+  "dirname": "test/actual/noyfm",
+  "ext": ".html",
+  "extname": ".html",
+  "filePair": {
+    "src": [
+      "test/fixtures/pages/no-yfm-data.hbs"
+    ],
+    "dest": "test/actual/noyfm/no-yfm-datafile.html",
+    "orig": {
+      "src": [
+        "test/fixtures/pages/no-yfm-data.hbs"
+      ],
+      "dest": "test/actual/noyfm/no-yfm-datafile.html"
+    }
+  },
+  "filename": "no-yfm-datafile.html",
+  "first": true,
+  "index": 0,
+  "last": true,
+  "middle": false,
+  "number": 1,
+  "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            There is no YAML front matter in this page.\n\n<ul>\n  <li>{{one}}</li>\n  <li>{{two}}</li>\n  <li>{{three}}</li>\n  <li>{{global1}}</li>\n</ul>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
+  "pageName": "no-yfm-datafile.html",
+  "pagename": "no-yfm-datafile.html",
+  "src": "test/fixtures/pages/no-yfm-data.hbs"
+}
+</code></pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script src="../../assets/validation.js"></script>
+  </body>
+</html>

--- a/test/actual/noyfm/no-yfm.html
+++ b/test/actual/noyfm/no-yfm.html
@@ -20,33 +20,25 @@
 
       <ul class="pager">
 
-  
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">First</a>
     </li>
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">&larr; Previous</a>
     </li>
-  
 
-  
 
-  
     <li class="active pager-middle">
       <a href="no-yfm.html">1</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
-  
 
 </ul><style>
 .unselectable {
@@ -66,33 +58,25 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
     <li class="prev disabled">
       <a unselectable="on" class="unselectable">First</a>
     </li>
     <li class="prev disabled">
       <a unselectable="on" class="unselectable">&larr; Previous</a>
     </li>
-  
 
-  
 
-  
     <li class="active">
       <a href="no-yfm.html">1</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
-  
 
 </ul>
           </div>
@@ -113,10 +97,8 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
               </div>
               <div class="col-md-6">
-                
               </div>
             </div>
 
@@ -134,9 +116,7 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -211,7 +191,6 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>

--- a/test/actual/pages_array/index.html
+++ b/test/actual/pages_array/index.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="author" content="Jon Schlinkert">
-    <title>Layout name: 'test/fixtures/pages/blog/index.hbs' | Layout: </title>
+    <title>Layout name: 'test/fixtures/pages/blog/index.hbs' | Layout: false</title>
     <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css">
     <link href="../../assets/validation.css" rel="stylesheet">
     <link href="../../assets/gist.css" rel="stylesheet">
@@ -19,45 +19,34 @@
             <!-- pagination -->
             <ul class="pager">
 
-  
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">First</a>
     </li>
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">&larr; Previous</a>
     </li>
-  
 
-  
 
-  
     <li class="active pager-middle">
       <a href="index.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="post1.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="post2.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="post3.html">4</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="post3.html">Last</a>
     </li>
     <li class="next">
       <a href="post1.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -75,46 +64,27 @@
           <div class="docs-section">
             <div class="docs-header" id="content">
               <h3>Template: test/fixtures/pages/blog/index.hbs</h3>
-              <h3>Layout: </h3>
+              <h3>Layout: false</h3>
             </div>
-            
-              
-            
-              
                 <div class="docs-section">
                   <div class="docs-header" id="content">
                     <h1>Blog Post #1</h1>
                   </div>
-                  
-                    <script src="https://gist.github.com/5898072.js"></script>
-                  
+                    &lt;script src=&quot;https://gist.github.com/5898072.js&quot;&gt;&lt;/script&gt;
                 </div>
-              
-            
-              
                 <div class="docs-section">
                   <div class="docs-header" id="content">
                     <h1>Blog Post #2</h1>
                   </div>
-                  
-                    <script src="https://gist.github.com/5898077.js"></script>
-                  
-                    <script src="https://gist.github.com/5898078.js"></script>
-                  
+                    &lt;script src=&quot;https://gist.github.com/5898077.js&quot;&gt;&lt;/script&gt;
+                    &lt;script src=&quot;https://gist.github.com/5898078.js&quot;&gt;&lt;/script&gt;
                 </div>
-              
-            
-              
                 <div class="docs-section">
                   <div class="docs-header" id="content">
                     <h1>Blog Post #3</h1>
                   </div>
-                  
-                    <script src="https://gist.github.com/5909393.js"></script>
-                  
+                    &lt;script src=&quot;https://gist.github.com/5909393.js&quot;&gt;&lt;/script&gt;
                 </div>
-              
-            
           </div>
         </div>
       </div>

--- a/test/actual/pages_array/post1.html
+++ b/test/actual/pages_array/post1.html
@@ -17,45 +17,34 @@
             <!-- pagination -->
             <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="index.html">First</a>
     </li>
     <li class="previous">
       <a href="index.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="index.html">1</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="post1.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="post2.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="post3.html">4</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="post3.html">Last</a>
     </li>
     <li class="next">
       <a href="post2.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -75,9 +64,7 @@
               <h3>Layout: No layout was used.</h3>
               <h3>Template: post1</h3>
             </div>
-            
-              <script src="https://gist.github.com/5898072.js"></script>
-            
+              &lt;script src=&quot;https://gist.github.com/5898072.js&quot;&gt;&lt;/script&gt;
             This "content" property is optional and would get passed into the `body` tag. But if you only need to pass the page"s metadata to the layout then the content property is unnecessary.
           </div>
         </div>

--- a/test/actual/pages_array/post2.html
+++ b/test/actual/pages_array/post2.html
@@ -17,45 +17,34 @@
             <!-- pagination -->
             <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="index.html">First</a>
     </li>
     <li class="previous">
       <a href="post1.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="index.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="post1.html">2</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="post2.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="post3.html">4</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="post3.html">Last</a>
     </li>
     <li class="next">
       <a href="post3.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -75,11 +64,8 @@
               <h3>Layout: No layout was used.</h3>
               <h3>Template: post2</h3>
             </div>
-            
-              <script src="https://gist.github.com/5898077.js"></script>
-            
-              <script src="https://gist.github.com/5898078.js"></script>
-            
+              &lt;script src=&quot;https://gist.github.com/5898077.js&quot;&gt;&lt;/script&gt;
+              &lt;script src=&quot;https://gist.github.com/5898078.js&quot;&gt;&lt;/script&gt;
             <h1>Blog Post #2 | A Blog</h1>
  <div class="alert"><strong>ALERT!</strong> This is an alert message. ></div> This project is brought to you by grunt-assemble.
           </div>

--- a/test/actual/pages_array/post3.html
+++ b/test/actual/pages_array/post3.html
@@ -17,45 +17,34 @@
             <!-- pagination -->
             <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="index.html">First</a>
     </li>
     <li class="previous">
       <a href="post2.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="index.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="post1.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="post2.html">3</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="post3.html">4</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
-  
 
 </ul><style>
 .unselectable {
@@ -75,10 +64,7 @@
               <h3>Layout: No layout was used.</h3>
               <h3>Template: post3</h3>
             </div>
-            
-              <script src="https://gist.github.com/5909393.js"></script>
-            
-            
+              &lt;script src=&quot;https://gist.github.com/5909393.js&quot;&gt;&lt;/script&gt;
           </div>
         </div>
       </div>

--- a/test/actual/pages_metadata/index.html
+++ b/test/actual/pages_metadata/index.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="author" content="Brian Woodward">
-    <title>Layout name: 'test/fixtures/pages/blog/index.hbs' | Layout: </title>
+    <title>Layout name: 'test/fixtures/pages/blog/index.hbs' | Layout: false</title>
     <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css">
     <link href="../../assets/validation.css" rel="stylesheet">
     <link href="../../assets/gist.css" rel="stylesheet">
@@ -19,45 +19,34 @@
             <!-- pagination -->
             <ul class="pager">
 
-  
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">First</a>
     </li>
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">&larr; Previous</a>
     </li>
-  
 
-  
 
-  
     <li class="active pager-middle">
       <a href="index.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="meta-sweet-blog-post-1.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="meta-awesome-blog-post-2.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="meta-super-sweet-and-awesome-blog-post-3.html">4</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="meta-super-sweet-and-awesome-blog-post-3.html">Last</a>
     </li>
     <li class="next">
       <a href="meta-sweet-blog-post-1.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -75,46 +64,27 @@
           <div class="docs-section">
             <div class="docs-header" id="content">
               <h3>Template: test/fixtures/pages/blog/index.hbs</h3>
-              <h3>Layout: </h3>
+              <h3>Layout: false</h3>
             </div>
-            
-              
-            
-              
                 <div class="docs-section">
                   <div class="docs-header" id="content">
                     <h1>Sweet Blog Post #1</h1>
                   </div>
-                  
-                    <script src="https://gist.github.com/5898072.js"></script>
-                  
+                    &lt;script src=&quot;https://gist.github.com/5898072.js&quot;&gt;&lt;/script&gt;
                 </div>
-              
-            
-              
                 <div class="docs-section">
                   <div class="docs-header" id="content">
                     <h1>Awesome Blog Post #2</h1>
                   </div>
-                  
-                    <script src="https://gist.github.com/5898077.js"></script>
-                  
-                    <script src="https://gist.github.com/5898078.js"></script>
-                  
+                    &lt;script src=&quot;https://gist.github.com/5898077.js&quot;&gt;&lt;/script&gt;
+                    &lt;script src=&quot;https://gist.github.com/5898078.js&quot;&gt;&lt;/script&gt;
                 </div>
-              
-            
-              
                 <div class="docs-section">
                   <div class="docs-header" id="content">
                     <h1>Super Sweet and Awesome Blog Post #3</h1>
                   </div>
-                  
-                    <script src="https://gist.github.com/5898072.js"></script>
-                  
+                    &lt;script src=&quot;https://gist.github.com/5898072.js&quot;&gt;&lt;/script&gt;
                 </div>
-              
-            
           </div>
         </div>
       </div>

--- a/test/actual/pages_metadata/meta-awesome-blog-post-2.html
+++ b/test/actual/pages_metadata/meta-awesome-blog-post-2.html
@@ -17,45 +17,34 @@
             <!-- pagination -->
             <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="index.html">First</a>
     </li>
     <li class="previous">
       <a href="meta-sweet-blog-post-1.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="index.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="meta-sweet-blog-post-1.html">2</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="meta-awesome-blog-post-2.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="meta-super-sweet-and-awesome-blog-post-3.html">4</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="meta-super-sweet-and-awesome-blog-post-3.html">Last</a>
     </li>
     <li class="next">
       <a href="meta-super-sweet-and-awesome-blog-post-3.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -75,11 +64,8 @@
               <h3>Layout: No layout was used.</h3>
               <h3>Template: meta-awesome-blog-post-2</h3>
             </div>
-            
-              <script src="https://gist.github.com/5898077.js"></script>
-            
-              <script src="https://gist.github.com/5898078.js"></script>
-            
+              &lt;script src=&quot;https://gist.github.com/5898077.js&quot;&gt;&lt;/script&gt;
+              &lt;script src=&quot;https://gist.github.com/5898078.js&quot;&gt;&lt;/script&gt;
             <h1>Awesome Blog Post #2 | Another Blog with Meta</h1>
  <div class="alert"><strong>ALERT!</strong> This is an alert message. ></div> This project is brought to you by grunt-assemble.
           </div>

--- a/test/actual/pages_metadata/meta-super-sweet-and-awesome-blog-post-3.html
+++ b/test/actual/pages_metadata/meta-super-sweet-and-awesome-blog-post-3.html
@@ -17,45 +17,34 @@
             <!-- pagination -->
             <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="index.html">First</a>
     </li>
     <li class="previous">
       <a href="meta-awesome-blog-post-2.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="index.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="meta-sweet-blog-post-1.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="meta-awesome-blog-post-2.html">3</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="meta-super-sweet-and-awesome-blog-post-3.html">4</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
-  
 
 </ul><style>
 .unselectable {
@@ -75,10 +64,7 @@
               <h3>Layout: No layout was used.</h3>
               <h3>Template: meta-super-sweet-and-awesome-blog-post-3</h3>
             </div>
-            
-              <script src="https://gist.github.com/5898072.js"></script>
-            
-            
+              &lt;script src=&quot;https://gist.github.com/5898072.js&quot;&gt;&lt;/script&gt;
           </div>
         </div>
       </div>

--- a/test/actual/pages_metadata/meta-sweet-blog-post-1.html
+++ b/test/actual/pages_metadata/meta-sweet-blog-post-1.html
@@ -17,45 +17,34 @@
             <!-- pagination -->
             <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="index.html">First</a>
     </li>
     <li class="previous">
       <a href="index.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="index.html">1</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="meta-sweet-blog-post-1.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="meta-awesome-blog-post-2.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="meta-super-sweet-and-awesome-blog-post-3.html">4</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="meta-super-sweet-and-awesome-blog-post-3.html">Last</a>
     </li>
     <li class="next">
       <a href="meta-awesome-blog-post-2.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -75,9 +64,7 @@
               <h3>Layout: No layout was used.</h3>
               <h3>Template: meta-sweet-blog-post-1</h3>
             </div>
-            
-              <script src="https://gist.github.com/5898072.js"></script>
-            
+              &lt;script src=&quot;https://gist.github.com/5898072.js&quot;&gt;&lt;/script&gt;
             This 'content' property is optional and would get passed into the `body` tag. But if you only need to pass the page"s metadata to the layout then the content property is unnecessary.
           </div>
         </div>

--- a/test/actual/pages_object/awesome-blog-post-2.html
+++ b/test/actual/pages_object/awesome-blog-post-2.html
@@ -17,45 +17,34 @@
             <!-- pagination -->
             <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="index.html">First</a>
     </li>
     <li class="previous">
       <a href="sweet-blog-post-1.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="index.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="sweet-blog-post-1.html">2</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="awesome-blog-post-2.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="super-sweet-and-awesome-blog-post-3.html">4</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="super-sweet-and-awesome-blog-post-3.html">Last</a>
     </li>
     <li class="next">
       <a href="super-sweet-and-awesome-blog-post-3.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -75,11 +64,8 @@
               <h3>Layout: No layout was used.</h3>
               <h3>Template: awesome-blog-post-2</h3>
             </div>
-            
-              <script src="https://gist.github.com/5898077.js"></script>
-            
-              <script src="https://gist.github.com/5898078.js"></script>
-            
+              &lt;script src=&quot;https://gist.github.com/5898077.js&quot;&gt;&lt;/script&gt;
+              &lt;script src=&quot;https://gist.github.com/5898078.js&quot;&gt;&lt;/script&gt;
             <h1>Awesome Blog Post #2 | Another Blog</h1>
  <div class="alert"><strong>ALERT!</strong> This is an alert message. ></div> This project is brought to you by grunt-assemble.
           </div>

--- a/test/actual/pages_object/index.html
+++ b/test/actual/pages_object/index.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="author" content="Brian Woodward">
-    <title>Layout name: 'test/fixtures/pages/blog/index.hbs' | Layout: </title>
+    <title>Layout name: 'test/fixtures/pages/blog/index.hbs' | Layout: false</title>
     <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css">
     <link href="../../assets/validation.css" rel="stylesheet">
     <link href="../../assets/gist.css" rel="stylesheet">
@@ -19,45 +19,34 @@
             <!-- pagination -->
             <ul class="pager">
 
-  
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">First</a>
     </li>
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">&larr; Previous</a>
     </li>
-  
 
-  
 
-  
     <li class="active pager-middle">
       <a href="index.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="sweet-blog-post-1.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="awesome-blog-post-2.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="super-sweet-and-awesome-blog-post-3.html">4</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="super-sweet-and-awesome-blog-post-3.html">Last</a>
     </li>
     <li class="next">
       <a href="sweet-blog-post-1.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -75,46 +64,27 @@
           <div class="docs-section">
             <div class="docs-header" id="content">
               <h3>Template: test/fixtures/pages/blog/index.hbs</h3>
-              <h3>Layout: </h3>
+              <h3>Layout: false</h3>
             </div>
-            
-              
-            
-              
                 <div class="docs-section">
                   <div class="docs-header" id="content">
                     <h1>Sweet Blog Post #1</h1>
                   </div>
-                  
-                    <script src="https://gist.github.com/5898072.js"></script>
-                  
+                    &lt;script src=&quot;https://gist.github.com/5898072.js&quot;&gt;&lt;/script&gt;
                 </div>
-              
-            
-              
                 <div class="docs-section">
                   <div class="docs-header" id="content">
                     <h1>Awesome Blog Post #2</h1>
                   </div>
-                  
-                    <script src="https://gist.github.com/5898077.js"></script>
-                  
-                    <script src="https://gist.github.com/5898078.js"></script>
-                  
+                    &lt;script src=&quot;https://gist.github.com/5898077.js&quot;&gt;&lt;/script&gt;
+                    &lt;script src=&quot;https://gist.github.com/5898078.js&quot;&gt;&lt;/script&gt;
                 </div>
-              
-            
-              
                 <div class="docs-section">
                   <div class="docs-header" id="content">
                     <h1>Super Sweet and Awesome Blog Post #3</h1>
                   </div>
-                  
-                    <script src="https://gist.github.com/5898072.js"></script>
-                  
+                    &lt;script src=&quot;https://gist.github.com/5898072.js&quot;&gt;&lt;/script&gt;
                 </div>
-              
-            
           </div>
         </div>
       </div>

--- a/test/actual/pages_object/super-sweet-and-awesome-blog-post-3.html
+++ b/test/actual/pages_object/super-sweet-and-awesome-blog-post-3.html
@@ -17,45 +17,34 @@
             <!-- pagination -->
             <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="index.html">First</a>
     </li>
     <li class="previous">
       <a href="awesome-blog-post-2.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="index.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="sweet-blog-post-1.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="awesome-blog-post-2.html">3</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="super-sweet-and-awesome-blog-post-3.html">4</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
-  
 
 </ul><style>
 .unselectable {
@@ -75,10 +64,7 @@
               <h3>Layout: No layout was used.</h3>
               <h3>Template: super-sweet-and-awesome-blog-post-3</h3>
             </div>
-            
-              <script src="https://gist.github.com/5898072.js"></script>
-            
-            
+              &lt;script src=&quot;https://gist.github.com/5898072.js&quot;&gt;&lt;/script&gt;
           </div>
         </div>
       </div>

--- a/test/actual/pages_object/sweet-blog-post-1.html
+++ b/test/actual/pages_object/sweet-blog-post-1.html
@@ -17,45 +17,34 @@
             <!-- pagination -->
             <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="index.html">First</a>
     </li>
     <li class="previous">
       <a href="index.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="index.html">1</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="sweet-blog-post-1.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="awesome-blog-post-2.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="super-sweet-and-awesome-blog-post-3.html">4</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="super-sweet-and-awesome-blog-post-3.html">Last</a>
     </li>
     <li class="next">
       <a href="awesome-blog-post-2.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -75,9 +64,7 @@
               <h3>Layout: No layout was used.</h3>
               <h3>Template: sweet-blog-post-1</h3>
             </div>
-            
-              <script src="https://gist.github.com/5898072.js"></script>
-            
+              &lt;script src=&quot;https://gist.github.com/5898072.js&quot;&gt;&lt;/script&gt;
             This 'content' property is optional and would get passed into the `body` tag. But if you only need to pass the page"s metadata to the layout then the content property is unnecessary.
           </div>
         </div>

--- a/test/actual/paths/alert.html
+++ b/test/actual/paths/alert.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
-      <a href="debug-helpers.html">&larr; Previous</a>
+      <a href="example.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="collections-pages.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
-      <a href="debug-helpers.html">&larr; Previous</a>
+      <a href="example.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="active">
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="collections-pages.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,286 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">components</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">components</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">2</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">2</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -718,37 +482,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -791,262 +540,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/paths/debug-helpers.html
-                  this.dirname:  test/actual/paths
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/paths/alert.html
-                  page.dirname:  test/actual/paths
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/paths/debug-helpers.html
-                  dirname:       test/actual/paths
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/paths/alert.html
-                  this.dirname:  test/actual/paths
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/paths/alert.html
-                  page.dirname:  test/actual/paths
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/paths/alert.html
-                  dirname:       test/actual/paths
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/paths/collections-pages.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/paths/alert.html
-                  page.dirname:  test/actual/paths
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/paths/collections-pages.html
-                  dirname:       test/actual/paths
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/paths/collections-tags.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/paths/alert.html
-                  page.dirname:  test/actual/paths
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/paths/collections-tags.html
-                  dirname:       test/actual/paths
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/paths/collections.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/paths/alert.html
-                  page.dirname:  test/actual/paths
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/paths/collections.html
-                  dirname:       test/actual/paths
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/paths/complex.html
-                  this.dirname:  test/actual/paths
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/paths/alert.html
-                  page.dirname:  test/actual/paths
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/paths/complex.html
-                  dirname:       test/actual/paths
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/paths/context.html
-                  this.dirname:  test/actual/paths
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/paths/alert.html
-                  page.dirname:  test/actual/paths
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/paths/context.html
-                  dirname:       test/actual/paths
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/paths/collections-categories.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/alert.hbs
-                  page.dest:     test/actual/paths/alert.html
-                  page.dirname:  test/actual/paths
-                  page.filename: alert.html
-                  page.pagename: alert.html
-                  page.basename: alert
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/paths/collections-categories.html
-                  dirname:       test/actual/paths
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1079,7 +572,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/paths/alert.html
+                  this.dirname:  test/actual/paths
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/paths/alert.html
+                  page.dirname:  test/actual/paths
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/paths/alert.html
+                  dirname:       test/actual/paths
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/paths/collections-pages.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/paths/alert.html
+                  page.dirname:  test/actual/paths
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/paths/collections-pages.html
+                  dirname:       test/actual/paths
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/paths/collections-tags.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/paths/alert.html
+                  page.dirname:  test/actual/paths
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/paths/collections-tags.html
+                  dirname:       test/actual/paths
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/paths/collections.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/paths/alert.html
+                  page.dirname:  test/actual/paths
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/paths/collections.html
+                  dirname:       test/actual/paths
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/paths/complex.html
+                  this.dirname:  test/actual/paths
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/paths/alert.html
+                  page.dirname:  test/actual/paths
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/paths/complex.html
+                  dirname:       test/actual/paths
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/paths/context.html
+                  this.dirname:  test/actual/paths
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/paths/alert.html
+                  page.dirname:  test/actual/paths
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/paths/context.html
+                  dirname:       test/actual/paths
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/paths/debug-helpers.html
+                  this.dirname:  test/actual/paths
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/paths/alert.html
+                  page.dirname:  test/actual/paths
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/paths/debug-helpers.html
+                  dirname:       test/actual/paths
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/paths/collections-categories.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/paths/alert.html
+                  page.dirname:  test/actual/paths
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/paths/collections-categories.html
+                  dirname:       test/actual/paths
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1111,7 +860,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1143,7 +892,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1175,7 +924,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/paths/no-yfm-data.html
+                  this.dirname:  test/actual/paths
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/alert.hbs
+                  page.dest:     test/actual/paths/alert.html
+                  page.dirname:  test/actual/paths
+                  page.filename: alert.html
+                  page.pagename: alert.html
+                  page.basename: alert
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/paths/no-yfm-data.html
+                  dirname:       test/actual/paths
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1207,7 +988,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1239,7 +1020,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1271,7 +1052,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1318,6 +1098,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/paths/collections-categories.html
+++ b/test/actual/paths/collections-categories.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
-      <a href="context.html">&larr; Previous</a>
+      <a href="debug-helpers.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
-    <li class="active pager-middle">
-      <a href="collections-categories.html">8</a>
-    </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
+    <li class="active pager-middle">
+      <a href="collections-categories.html">9</a>
+    </li>
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="example.html">Next &rarr;</a>
+      <a href="gist-helper.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
-      <a href="context.html">&larr; Previous</a>
+      <a href="debug-helpers.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
-    <li class="active">
-      <a href="collections-categories.html">8</a>
-    </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
+    <li class="active">
+      <a href="collections-categories.html">9</a>
+    </li>
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="example.html">Next &rarr;</a>
+      <a href="gist-helper.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,496 +187,292 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">5</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">three</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">5</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">three</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">4</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">categories</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">pages</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">4</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">categories</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">pages</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -726,33 +484,19 @@
     <h4>Categories</h4>
   </div>
   <div class="panel-body">
-  
     <span class="label label-info">categories</span>
-  
     <span class="label label-info">collections</span>
-  
     <span class="label label-info">components</span>
-  
     <span class="label label-info">context</span>
-  
     <span class="label label-info">fixtures</span>
-  
     <span class="label label-info">helper</span>
-  
     <span class="label label-info">markdown</span>
-  
     <span class="label label-info">one</span>
-  
     <span class="label label-info">pages</span>
-  
     <span class="label label-info">three</span>
-  
     <span class="label label-info">two</span>
-  
     <span class="label label-info">yaml</span>
-  
     <span class="label label-info">yfm</span>
-  
   </div>
 </div>
 
@@ -760,37 +504,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -833,262 +562,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/paths/debug-helpers.html
-                  this.dirname:  test/actual/paths
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/paths/collections-categories.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/paths/debug-helpers.html
-                  dirname:       test/actual/paths
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/paths/alert.html
-                  this.dirname:  test/actual/paths
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/paths/collections-categories.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/paths/alert.html
-                  dirname:       test/actual/paths
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/paths/collections-pages.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/paths/collections-categories.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/paths/collections-pages.html
-                  dirname:       test/actual/paths
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/paths/collections-tags.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/paths/collections-categories.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/paths/collections-tags.html
-                  dirname:       test/actual/paths
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/paths/collections.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/paths/collections-categories.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/paths/collections.html
-                  dirname:       test/actual/paths
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/paths/complex.html
-                  this.dirname:  test/actual/paths
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/paths/collections-categories.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/paths/complex.html
-                  dirname:       test/actual/paths
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/paths/context.html
-                  this.dirname:  test/actual/paths
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/paths/collections-categories.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/paths/context.html
-                  dirname:       test/actual/paths
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/paths/collections-categories.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-categories.hbs
-                  page.dest:     test/actual/paths/collections-categories.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-categories.html
-                  page.pagename: collections-categories.html
-                  page.basename: collections-categories
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/paths/collections-categories.html
-                  dirname:       test/actual/paths
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1121,7 +594,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/paths/alert.html
+                  this.dirname:  test/actual/paths
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/paths/collections-categories.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/paths/alert.html
+                  dirname:       test/actual/paths
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/paths/collections-pages.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/paths/collections-categories.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/paths/collections-pages.html
+                  dirname:       test/actual/paths
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/paths/collections-tags.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/paths/collections-categories.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/paths/collections-tags.html
+                  dirname:       test/actual/paths
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/paths/collections.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/paths/collections-categories.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/paths/collections.html
+                  dirname:       test/actual/paths
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/paths/complex.html
+                  this.dirname:  test/actual/paths
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/paths/collections-categories.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/paths/complex.html
+                  dirname:       test/actual/paths
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/paths/context.html
+                  this.dirname:  test/actual/paths
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/paths/collections-categories.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/paths/context.html
+                  dirname:       test/actual/paths
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/paths/debug-helpers.html
+                  this.dirname:  test/actual/paths
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/paths/collections-categories.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/paths/debug-helpers.html
+                  dirname:       test/actual/paths
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/paths/collections-categories.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/paths/collections-categories.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/paths/collections-categories.html
+                  dirname:       test/actual/paths
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1153,7 +882,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1185,7 +914,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1217,7 +946,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/paths/no-yfm-data.html
+                  this.dirname:  test/actual/paths
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-categories.hbs
+                  page.dest:     test/actual/paths/collections-categories.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-categories.html
+                  page.pagename: collections-categories.html
+                  page.basename: collections-categories
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/paths/no-yfm-data.html
+                  dirname:       test/actual/paths
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1249,7 +1010,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1281,7 +1042,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1313,7 +1074,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1358,6 +1118,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1372,16 +1133,16 @@
   },
   "filename": "collections-categories.html",
   "first": false,
-  "index": 7,
+  "index": 8,
   "isCurrentPage": false,
   "last": false,
   "middle": true,
-  "next": 8,
-  "number": 8,
+  "next": 9,
+  "number": 9,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n<div class=\"panel panel-info\">\n  <div class=\"panel-heading\">\n    <h4>Categories</h4>\n  </div>\n  <div class=\"panel-body\">\n  {{#categories}}\n    <span class=\"label label-info\">{{category}}</span>\n  {{/categories}}\n  </div>\n</div>\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "collections-categories.html",
   "pagename": "collections-categories.html",
-  "prev": 6,
+  "prev": 7,
   "relativeLink": "collections-categories.html",
   "src": "test/fixtures/pages/collections-categories.hbs",
   "tags": [

--- a/test/actual/paths/collections-pages.html
+++ b/test/actual/paths/collections-pages.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="alert.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="collections-tags.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="alert.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li class="active">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="collections-tags.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,480 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">pages</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">pages</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -710,37 +477,22 @@
     <h4>Pages Collection</h4>
   </div>
   <div class="panel-body">
-    
-      <a href="#">Debug Helper</a>
-    
-      <a href="#">Title for "alert.hbs"</a>
-    
-      <a href="#">Pages Collection</a>
-    
-      <a href="#">Tags Test</a>
-    
-      <a href="#">Collections</a>
-    
-      <a href="#">Complex YFM</a>
-    
-      <a href="#">Context</a>
-    
-      <a href="#">Collections Categories</a>
-    
       <a href="#">Title from YFM of "example.hbs"</a>
-    
+      <a href="#">Title for "alert.hbs"</a>
+      <a href="#">Pages Collection</a>
+      <a href="#">Tags Test</a>
+      <a href="#">Collections</a>
+      <a href="#">Complex YFM</a>
+      <a href="#">Context</a>
+      <a href="#">Debug Helper</a>
+      <a href="#">Collections Categories</a>
       <a href="#">Gist Helper</a>
-    
       <a href="#"><%= site.title %></a>
-    
       <a href="#">md helper</a>
-    
       <a href="#"></a>
-    
+      <a href="#"></a>
       <a href="#">This title is from the YFM of the current page</a>
-    
       <a href="#">YFM</a>
-    
   </div>
 </div>
 
@@ -748,37 +500,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -821,262 +558,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/paths/debug-helpers.html
-                  this.dirname:  test/actual/paths
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/paths/collections-pages.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/paths/debug-helpers.html
-                  dirname:       test/actual/paths
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/paths/alert.html
-                  this.dirname:  test/actual/paths
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/paths/collections-pages.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/paths/alert.html
-                  dirname:       test/actual/paths
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/paths/collections-pages.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/paths/collections-pages.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/paths/collections-pages.html
-                  dirname:       test/actual/paths
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/paths/collections-tags.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/paths/collections-pages.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/paths/collections-tags.html
-                  dirname:       test/actual/paths
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/paths/collections.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/paths/collections-pages.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/paths/collections.html
-                  dirname:       test/actual/paths
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/paths/complex.html
-                  this.dirname:  test/actual/paths
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/paths/collections-pages.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/paths/complex.html
-                  dirname:       test/actual/paths
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/paths/context.html
-                  this.dirname:  test/actual/paths
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/paths/collections-pages.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/paths/context.html
-                  dirname:       test/actual/paths
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/paths/collections-categories.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-pages.hbs
-                  page.dest:     test/actual/paths/collections-pages.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-pages.html
-                  page.pagename: collections-pages.html
-                  page.basename: collections-pages
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/paths/collections-categories.html
-                  dirname:       test/actual/paths
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1109,7 +590,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/paths/alert.html
+                  this.dirname:  test/actual/paths
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/paths/collections-pages.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/paths/alert.html
+                  dirname:       test/actual/paths
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/paths/collections-pages.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/paths/collections-pages.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/paths/collections-pages.html
+                  dirname:       test/actual/paths
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/paths/collections-tags.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/paths/collections-pages.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/paths/collections-tags.html
+                  dirname:       test/actual/paths
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/paths/collections.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/paths/collections-pages.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/paths/collections.html
+                  dirname:       test/actual/paths
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/paths/complex.html
+                  this.dirname:  test/actual/paths
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/paths/collections-pages.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/paths/complex.html
+                  dirname:       test/actual/paths
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/paths/context.html
+                  this.dirname:  test/actual/paths
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/paths/collections-pages.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/paths/context.html
+                  dirname:       test/actual/paths
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/paths/debug-helpers.html
+                  this.dirname:  test/actual/paths
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/paths/collections-pages.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/paths/debug-helpers.html
+                  dirname:       test/actual/paths
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/paths/collections-categories.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/paths/collections-pages.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/paths/collections-categories.html
+                  dirname:       test/actual/paths
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1141,7 +878,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1173,7 +910,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1205,7 +942,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/paths/no-yfm-data.html
+                  this.dirname:  test/actual/paths
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-pages.hbs
+                  page.dest:     test/actual/paths/collections-pages.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-pages.html
+                  page.pagename: collections-pages.html
+                  page.basename: collections-pages
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/paths/no-yfm-data.html
+                  dirname:       test/actual/paths
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1237,7 +1006,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1269,7 +1038,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1301,7 +1070,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1334,6 +1102,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/paths/collections-tags.html
+++ b/test/actual/paths/collections-tags.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="collections-pages.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="collections.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="collections-pages.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="active">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="collections.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,488 +187,289 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">5</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">two</span>
-    
-      <span class="label label-success">three</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">5</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">two</span>
+                        <span class="label label-success">three</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -718,37 +481,21 @@
     <h4>Tags</h4>
   </div>
   <div class="panel-body">
-  
     <span class="label label-success">alert</span>
-  
     <span class="label label-success">bootstrap</span>
-  
     <span class="label label-success">collections</span>
-  
     <span class="label label-success">complex</span>
-  
     <span class="label label-success">example</span>
-  
     <span class="label label-success">examples</span>
-  
     <span class="label label-success">markdown</span>
-  
     <span class="label label-success">md</span>
-  
     <span class="label label-success">one</span>
-  
     <span class="label label-success">pages</span>
-  
     <span class="label label-success">tags</span>
-  
     <span class="label label-success">test</span>
-  
     <span class="label label-success">tests</span>
-  
     <span class="label label-success">three</span>
-  
     <span class="label label-success">two</span>
-  
   </div>
 </div>
 
@@ -756,37 +503,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -829,262 +561,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/paths/debug-helpers.html
-                  this.dirname:  test/actual/paths
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/paths/collections-tags.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/paths/debug-helpers.html
-                  dirname:       test/actual/paths
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/paths/alert.html
-                  this.dirname:  test/actual/paths
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/paths/collections-tags.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/paths/alert.html
-                  dirname:       test/actual/paths
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/paths/collections-pages.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/paths/collections-tags.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/paths/collections-pages.html
-                  dirname:       test/actual/paths
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/paths/collections-tags.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/paths/collections-tags.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/paths/collections-tags.html
-                  dirname:       test/actual/paths
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/paths/collections.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/paths/collections-tags.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/paths/collections.html
-                  dirname:       test/actual/paths
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/paths/complex.html
-                  this.dirname:  test/actual/paths
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/paths/collections-tags.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/paths/complex.html
-                  dirname:       test/actual/paths
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/paths/context.html
-                  this.dirname:  test/actual/paths
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/paths/collections-tags.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/paths/context.html
-                  dirname:       test/actual/paths
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/paths/collections-categories.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections-tags.hbs
-                  page.dest:     test/actual/paths/collections-tags.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections-tags.html
-                  page.pagename: collections-tags.html
-                  page.basename: collections-tags
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/paths/collections-categories.html
-                  dirname:       test/actual/paths
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1117,7 +593,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/paths/alert.html
+                  this.dirname:  test/actual/paths
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/paths/collections-tags.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/paths/alert.html
+                  dirname:       test/actual/paths
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/paths/collections-pages.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/paths/collections-tags.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/paths/collections-pages.html
+                  dirname:       test/actual/paths
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/paths/collections-tags.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/paths/collections-tags.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/paths/collections-tags.html
+                  dirname:       test/actual/paths
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/paths/collections.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/paths/collections-tags.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/paths/collections.html
+                  dirname:       test/actual/paths
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/paths/complex.html
+                  this.dirname:  test/actual/paths
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/paths/collections-tags.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/paths/complex.html
+                  dirname:       test/actual/paths
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/paths/context.html
+                  this.dirname:  test/actual/paths
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/paths/collections-tags.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/paths/context.html
+                  dirname:       test/actual/paths
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/paths/debug-helpers.html
+                  this.dirname:  test/actual/paths
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/paths/collections-tags.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/paths/debug-helpers.html
+                  dirname:       test/actual/paths
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/paths/collections-categories.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/paths/collections-tags.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/paths/collections-categories.html
+                  dirname:       test/actual/paths
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1149,7 +881,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1181,7 +913,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1213,7 +945,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/paths/no-yfm-data.html
+                  this.dirname:  test/actual/paths
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections-tags.hbs
+                  page.dest:     test/actual/paths/collections-tags.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections-tags.html
+                  page.pagename: collections-tags.html
+                  page.basename: collections-tags
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/paths/no-yfm-data.html
+                  dirname:       test/actual/paths
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1245,7 +1009,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1277,7 +1041,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1309,7 +1073,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1347,6 +1110,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/paths/collections.html
+++ b/test/actual/paths/collections.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="collections-tags.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="complex.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="collections-tags.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="active">
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="complex.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">one</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li class="active">
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li class="active">
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li class="active">
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">one</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li class="active">
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li class="active">
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li class="active">
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -711,101 +476,56 @@
             
 Collections
 <ul class="tags">
-
   <li>alert</li>
-
   <li>bootstrap</li>
-
   <li>collections</li>
-
   <li>complex</li>
-
   <li>example</li>
-
   <li>examples</li>
-
   <li>markdown</li>
-
   <li>md</li>
-
   <li>one</li>
-
   <li>pages</li>
-
   <li>tags</li>
-
   <li>test</li>
-
   <li>tests</li>
-
   <li>three</li>
-
   <li>two</li>
-
 </ul>
 
 <ul class="categories">
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
 </ul>
 
 <ul class="pages">
-
-	<li>debug-helpers</li>
-
-	<li>alert</li>
-
-	<li>collections-pages</li>
-
-	<li>collections-tags</li>
-
-	<li>collections</li>
-
-	<li>complex</li>
-
-	<li>context</li>
-
-	<li>collections-categories</li>
-
 	<li>example</li>
-
+	<li>alert</li>
+	<li>collections-pages</li>
+	<li>collections-tags</li>
+	<li>collections</li>
+	<li>complex</li>
+	<li>context</li>
+	<li>debug-helpers</li>
+	<li>collections-categories</li>
 	<li>gist-helper</li>
-
 	<li>lodash</li>
-
 	<li>md-helper</li>
-
+	<li>no-yfm-data</li>
 	<li>no-yfm</li>
-
 	<li>yfm-context</li>
-
 	<li>yfm</li>
-
 </ul>
 
 
@@ -813,37 +533,22 @@ Collections
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -886,262 +591,6 @@ Collections
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/paths/debug-helpers.html
-                  this.dirname:  test/actual/paths
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/paths/collections.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/paths/debug-helpers.html
-                  dirname:       test/actual/paths
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/paths/alert.html
-                  this.dirname:  test/actual/paths
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/paths/collections.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/paths/alert.html
-                  dirname:       test/actual/paths
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/paths/collections-pages.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/paths/collections.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/paths/collections-pages.html
-                  dirname:       test/actual/paths
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/paths/collections-tags.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/paths/collections.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/paths/collections-tags.html
-                  dirname:       test/actual/paths
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/paths/collections.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/paths/collections.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/paths/collections.html
-                  dirname:       test/actual/paths
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/paths/complex.html
-                  this.dirname:  test/actual/paths
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/paths/collections.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/paths/complex.html
-                  dirname:       test/actual/paths
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/paths/context.html
-                  this.dirname:  test/actual/paths
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/paths/collections.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/paths/context.html
-                  dirname:       test/actual/paths
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/paths/collections-categories.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/collections.hbs
-                  page.dest:     test/actual/paths/collections.html
-                  page.dirname:  test/actual/paths
-                  page.filename: collections.html
-                  page.pagename: collections.html
-                  page.basename: collections
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/paths/collections-categories.html
-                  dirname:       test/actual/paths
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1174,7 +623,263 @@ Collections
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/paths/alert.html
+                  this.dirname:  test/actual/paths
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/paths/collections.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/paths/alert.html
+                  dirname:       test/actual/paths
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/paths/collections-pages.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/paths/collections.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/paths/collections-pages.html
+                  dirname:       test/actual/paths
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/paths/collections-tags.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/paths/collections.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/paths/collections-tags.html
+                  dirname:       test/actual/paths
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/paths/collections.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/paths/collections.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/paths/collections.html
+                  dirname:       test/actual/paths
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/paths/complex.html
+                  this.dirname:  test/actual/paths
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/paths/collections.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/paths/complex.html
+                  dirname:       test/actual/paths
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/paths/context.html
+                  this.dirname:  test/actual/paths
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/paths/collections.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/paths/context.html
+                  dirname:       test/actual/paths
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/paths/debug-helpers.html
+                  this.dirname:  test/actual/paths
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/paths/collections.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/paths/debug-helpers.html
+                  dirname:       test/actual/paths
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/paths/collections-categories.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/paths/collections.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/paths/collections-categories.html
+                  dirname:       test/actual/paths
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1206,7 +911,7 @@ Collections
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1238,7 +943,7 @@ Collections
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1270,7 +975,39 @@ Collections
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/paths/no-yfm-data.html
+                  this.dirname:  test/actual/paths
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/collections.hbs
+                  page.dest:     test/actual/paths/collections.html
+                  page.dirname:  test/actual/paths
+                  page.filename: collections.html
+                  page.pagename: collections.html
+                  page.basename: collections
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/paths/no-yfm-data.html
+                  dirname:       test/actual/paths
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1302,7 +1039,7 @@ Collections
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1334,7 +1071,7 @@ Collections
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1366,7 +1103,6 @@ Collections
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1405,6 +1141,7 @@ Collections
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/paths/complex.html
+++ b/test/actual/paths/complex.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="collections.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="context.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="collections.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li class="active">
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="context.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,486 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">pages</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">pages</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">complex</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">complex</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -719,37 +482,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -792,262 +540,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/paths/debug-helpers.html
-                  this.dirname:  test/actual/paths
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/paths/complex.html
-                  page.dirname:  test/actual/paths
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/paths/debug-helpers.html
-                  dirname:       test/actual/paths
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/paths/alert.html
-                  this.dirname:  test/actual/paths
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/paths/complex.html
-                  page.dirname:  test/actual/paths
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/paths/alert.html
-                  dirname:       test/actual/paths
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/paths/collections-pages.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/paths/complex.html
-                  page.dirname:  test/actual/paths
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/paths/collections-pages.html
-                  dirname:       test/actual/paths
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/paths/collections-tags.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/paths/complex.html
-                  page.dirname:  test/actual/paths
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/paths/collections-tags.html
-                  dirname:       test/actual/paths
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/paths/collections.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/paths/complex.html
-                  page.dirname:  test/actual/paths
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/paths/collections.html
-                  dirname:       test/actual/paths
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/paths/complex.html
-                  this.dirname:  test/actual/paths
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/paths/complex.html
-                  page.dirname:  test/actual/paths
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/paths/complex.html
-                  dirname:       test/actual/paths
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/paths/context.html
-                  this.dirname:  test/actual/paths
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/paths/complex.html
-                  page.dirname:  test/actual/paths
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/paths/context.html
-                  dirname:       test/actual/paths
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/paths/collections-categories.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/complex.hbs
-                  page.dest:     test/actual/paths/complex.html
-                  page.dirname:  test/actual/paths
-                  page.filename: complex.html
-                  page.pagename: complex.html
-                  page.basename: complex
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/paths/collections-categories.html
-                  dirname:       test/actual/paths
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1080,7 +572,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/paths/alert.html
+                  this.dirname:  test/actual/paths
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/paths/complex.html
+                  page.dirname:  test/actual/paths
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/paths/alert.html
+                  dirname:       test/actual/paths
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/paths/collections-pages.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/paths/complex.html
+                  page.dirname:  test/actual/paths
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/paths/collections-pages.html
+                  dirname:       test/actual/paths
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/paths/collections-tags.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/paths/complex.html
+                  page.dirname:  test/actual/paths
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/paths/collections-tags.html
+                  dirname:       test/actual/paths
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/paths/collections.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/paths/complex.html
+                  page.dirname:  test/actual/paths
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/paths/collections.html
+                  dirname:       test/actual/paths
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/paths/complex.html
+                  this.dirname:  test/actual/paths
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/paths/complex.html
+                  page.dirname:  test/actual/paths
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/paths/complex.html
+                  dirname:       test/actual/paths
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/paths/context.html
+                  this.dirname:  test/actual/paths
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/paths/complex.html
+                  page.dirname:  test/actual/paths
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/paths/context.html
+                  dirname:       test/actual/paths
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/paths/debug-helpers.html
+                  this.dirname:  test/actual/paths
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/paths/complex.html
+                  page.dirname:  test/actual/paths
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/paths/debug-helpers.html
+                  dirname:       test/actual/paths
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/paths/collections-categories.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/paths/complex.html
+                  page.dirname:  test/actual/paths
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/paths/collections-categories.html
+                  dirname:       test/actual/paths
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1112,7 +860,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1144,7 +892,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1176,7 +924,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/paths/no-yfm-data.html
+                  this.dirname:  test/actual/paths
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/complex.hbs
+                  page.dest:     test/actual/paths/complex.html
+                  page.dirname:  test/actual/paths
+                  page.filename: complex.html
+                  page.pagename: complex.html
+                  page.basename: complex
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/paths/no-yfm-data.html
+                  dirname:       test/actual/paths
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1208,7 +988,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1240,7 +1020,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1272,7 +1052,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1319,6 +1098,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/paths/context.html
+++ b/test/actual/paths/context.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="complex.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="collections-categories.html">Next &rarr;</a>
+      <a href="debug-helpers.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="complex.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li class="active">
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="collections-categories.html">Next &rarr;</a>
+      <a href="debug-helpers.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">fixtures</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -753,193 +518,171 @@
 <hr>
 
 <ul class="context-test">
-
-  <li><a href="#" data-context="basename">debug-helpers</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">debug-helpers</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">alert</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">alert</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections-pages</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections-pages</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections-tags</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections-tags</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">complex</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">complex</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">context</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">context</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections-categories</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections-categories</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">example</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">example</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
+  <li><a href="#" data-context="basename">alert</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">alert</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections-pages</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections-pages</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections-tags</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections-tags</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">complex</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">complex</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">context</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">context</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">debug-helpers</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">debug-helpers</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections-categories</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections-categories</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
   <li><a href="#" data-context="basename">gist-helper</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">gist-helper</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">lodash</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">lodash</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">md-helper</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">md-helper</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
+  <li><a href="#" data-context="basename">no-yfm-data</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">no-yfm-data</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
   <li><a href="#" data-context="basename">no-yfm</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">no-yfm</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">yfm-context</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">yfm-context</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">yfm</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">yfm</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
 </ul>
 
 <hr>
 
 <ul class="context-test">
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Debug Helper</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Title for &quot;alert.hbs&quot;</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Pages Collection</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Tags Test</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Collections</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Complex YFM</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Context</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Collections Categories</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">Title from YFM of &quot;example.hbs&quot;</a></li>
-
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Title for &quot;alert.hbs&quot;</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Pages Collection</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Tags Test</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Collections</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Complex YFM</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Context</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Debug Helper</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Collections Categories</a></li>
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">Gist Helper</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">&lt;%= site.title %&gt;</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">md helper</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title"></a></li>
-
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title"></a></li>
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">This title is from the YFM of the current page</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">YFM</a></li>
-
 </ul>
 
 
@@ -947,37 +690,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -1020,262 +748,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/paths/debug-helpers.html
-                  this.dirname:  test/actual/paths
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/paths/context.html
-                  page.dirname:  test/actual/paths
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/paths/debug-helpers.html
-                  dirname:       test/actual/paths
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/paths/alert.html
-                  this.dirname:  test/actual/paths
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/paths/context.html
-                  page.dirname:  test/actual/paths
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/paths/alert.html
-                  dirname:       test/actual/paths
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/paths/collections-pages.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/paths/context.html
-                  page.dirname:  test/actual/paths
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/paths/collections-pages.html
-                  dirname:       test/actual/paths
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/paths/collections-tags.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/paths/context.html
-                  page.dirname:  test/actual/paths
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/paths/collections-tags.html
-                  dirname:       test/actual/paths
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/paths/collections.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/paths/context.html
-                  page.dirname:  test/actual/paths
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/paths/collections.html
-                  dirname:       test/actual/paths
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/paths/complex.html
-                  this.dirname:  test/actual/paths
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/paths/context.html
-                  page.dirname:  test/actual/paths
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/paths/complex.html
-                  dirname:       test/actual/paths
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/paths/context.html
-                  this.dirname:  test/actual/paths
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/paths/context.html
-                  page.dirname:  test/actual/paths
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/paths/context.html
-                  dirname:       test/actual/paths
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/paths/collections-categories.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/context.hbs
-                  page.dest:     test/actual/paths/context.html
-                  page.dirname:  test/actual/paths
-                  page.filename: context.html
-                  page.pagename: context.html
-                  page.basename: context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/paths/collections-categories.html
-                  dirname:       test/actual/paths
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1308,7 +780,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/paths/alert.html
+                  this.dirname:  test/actual/paths
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/paths/context.html
+                  page.dirname:  test/actual/paths
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/paths/alert.html
+                  dirname:       test/actual/paths
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/paths/collections-pages.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/paths/context.html
+                  page.dirname:  test/actual/paths
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/paths/collections-pages.html
+                  dirname:       test/actual/paths
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/paths/collections-tags.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/paths/context.html
+                  page.dirname:  test/actual/paths
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/paths/collections-tags.html
+                  dirname:       test/actual/paths
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/paths/collections.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/paths/context.html
+                  page.dirname:  test/actual/paths
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/paths/collections.html
+                  dirname:       test/actual/paths
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/paths/complex.html
+                  this.dirname:  test/actual/paths
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/paths/context.html
+                  page.dirname:  test/actual/paths
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/paths/complex.html
+                  dirname:       test/actual/paths
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/paths/context.html
+                  this.dirname:  test/actual/paths
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/paths/context.html
+                  page.dirname:  test/actual/paths
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/paths/context.html
+                  dirname:       test/actual/paths
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/paths/debug-helpers.html
+                  this.dirname:  test/actual/paths
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/paths/context.html
+                  page.dirname:  test/actual/paths
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/paths/debug-helpers.html
+                  dirname:       test/actual/paths
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/paths/collections-categories.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/paths/context.html
+                  page.dirname:  test/actual/paths
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/paths/collections-categories.html
+                  dirname:       test/actual/paths
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1340,7 +1068,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1372,7 +1100,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1404,7 +1132,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/paths/no-yfm-data.html
+                  this.dirname:  test/actual/paths
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/context.hbs
+                  page.dest:     test/actual/paths/context.html
+                  page.dirname:  test/actual/paths
+                  page.filename: context.html
+                  page.pagename: context.html
+                  page.basename: context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/paths/no-yfm-data.html
+                  dirname:       test/actual/paths
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1436,7 +1196,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1468,7 +1228,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1500,7 +1260,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1546,6 +1305,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/paths/debug-helpers.html
+++ b/test/actual/paths/debug-helpers.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
-    <li class="previous disabled">
-      <a unselectable="on" class="unselectable">First</a>
-    </li>
-    <li class="previous disabled">
-      <a unselectable="on" class="unselectable">&larr; Previous</a>
-    </li>
-  
 
-  
-
-  
-    <li class="active pager-middle">
-      <a href="debug-helpers.html">1</a>
+    <li class="previous">
+      <a href="example.html">First</a>
     </li>
-  
+    <li class="previous">
+      <a href="context.html">&larr; Previous</a>
+    </li>
+
+    <li class="pager-middle">
+      <a href="example.html">1</a>
+    </li>
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
-    <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+    <li class="active pager-middle">
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="alert.html">Next &rarr;</a>
+      <a href="collections-categories.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
-    <li class="prev disabled">
-      <a unselectable="on" class="unselectable">First</a>
-    </li>
-    <li class="prev disabled">
-      <a unselectable="on" class="unselectable">&larr; Previous</a>
-    </li>
-  
 
-  
-
-  
-    <li class="active">
-      <a href="debug-helpers.html">1</a>
+    <li class="prev">
+      <a href="example.html">First</a>
     </li>
-  
+    <li class="prev">
+      <a href="context.html">&larr; Previous</a>
+    </li>
+
+    <li>
+      <a href="example.html">1</a>
+    </li>
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
-    <li>
-      <a href="collections-categories.html">8</a>
+    <li class="active">
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="alert.html">Next &rarr;</a>
+      <a href="collections-categories.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -707,42 +476,26 @@
 <p>Uncomment the <code>debug</code> helper below, run <code>grunt assemble</code>, and watch the output in the command line to see how it works.</p>
 
 
-
             <div class="docs-header" id="content">
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -785,262 +538,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/paths/debug-helpers.html
-                  this.dirname:  test/actual/paths
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/paths/debug-helpers.html
-                  page.dirname:  test/actual/paths
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/paths/debug-helpers.html
-                  dirname:       test/actual/paths
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/paths/alert.html
-                  this.dirname:  test/actual/paths
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/paths/debug-helpers.html
-                  page.dirname:  test/actual/paths
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/paths/alert.html
-                  dirname:       test/actual/paths
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/paths/collections-pages.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/paths/debug-helpers.html
-                  page.dirname:  test/actual/paths
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/paths/collections-pages.html
-                  dirname:       test/actual/paths
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/paths/collections-tags.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/paths/debug-helpers.html
-                  page.dirname:  test/actual/paths
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/paths/collections-tags.html
-                  dirname:       test/actual/paths
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/paths/collections.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/paths/debug-helpers.html
-                  page.dirname:  test/actual/paths
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/paths/collections.html
-                  dirname:       test/actual/paths
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/paths/complex.html
-                  this.dirname:  test/actual/paths
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/paths/debug-helpers.html
-                  page.dirname:  test/actual/paths
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/paths/complex.html
-                  dirname:       test/actual/paths
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/paths/context.html
-                  this.dirname:  test/actual/paths
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/paths/debug-helpers.html
-                  page.dirname:  test/actual/paths
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/paths/context.html
-                  dirname:       test/actual/paths
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/paths/collections-categories.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/debug-helpers.hbs
-                  page.dest:     test/actual/paths/debug-helpers.html
-                  page.dirname:  test/actual/paths
-                  page.filename: debug-helpers.html
-                  page.pagename: debug-helpers.html
-                  page.basename: debug-helpers
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/paths/collections-categories.html
-                  dirname:       test/actual/paths
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1073,7 +570,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/paths/alert.html
+                  this.dirname:  test/actual/paths
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/paths/debug-helpers.html
+                  page.dirname:  test/actual/paths
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/paths/alert.html
+                  dirname:       test/actual/paths
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/paths/collections-pages.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/paths/debug-helpers.html
+                  page.dirname:  test/actual/paths
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/paths/collections-pages.html
+                  dirname:       test/actual/paths
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/paths/collections-tags.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/paths/debug-helpers.html
+                  page.dirname:  test/actual/paths
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/paths/collections-tags.html
+                  dirname:       test/actual/paths
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/paths/collections.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/paths/debug-helpers.html
+                  page.dirname:  test/actual/paths
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/paths/collections.html
+                  dirname:       test/actual/paths
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/paths/complex.html
+                  this.dirname:  test/actual/paths
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/paths/debug-helpers.html
+                  page.dirname:  test/actual/paths
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/paths/complex.html
+                  dirname:       test/actual/paths
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/paths/context.html
+                  this.dirname:  test/actual/paths
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/paths/debug-helpers.html
+                  page.dirname:  test/actual/paths
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/paths/context.html
+                  dirname:       test/actual/paths
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/paths/debug-helpers.html
+                  this.dirname:  test/actual/paths
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/paths/debug-helpers.html
+                  page.dirname:  test/actual/paths
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/paths/debug-helpers.html
+                  dirname:       test/actual/paths
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/paths/collections-categories.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/paths/debug-helpers.html
+                  page.dirname:  test/actual/paths
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/paths/collections-categories.html
+                  dirname:       test/actual/paths
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1105,7 +858,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1137,7 +890,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1169,7 +922,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/paths/no-yfm-data.html
+                  this.dirname:  test/actual/paths
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/debug-helpers.hbs
+                  page.dest:     test/actual/paths/debug-helpers.html
+                  page.dirname:  test/actual/paths
+                  page.filename: debug-helpers.html
+                  page.pagename: debug-helpers.html
+                  page.basename: debug-helpers
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/paths/no-yfm-data.html
+                  dirname:       test/actual/paths
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1201,7 +986,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1233,7 +1018,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1265,7 +1050,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1295,6 +1079,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1308,15 +1093,18 @@
     }
   },
   "filename": "debug-helpers.html",
-  "first": true,
-  "index": 0,
+  "first": false,
+  "index": 7,
+  "isCurrentPage": false,
   "last": false,
-  "middle": false,
-  "next": 1,
-  "number": 1,
+  "middle": true,
+  "next": 8,
+  "number": 8,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n{{#markdown}}\n\n### \\{{debug}} helper\nUncomment the `debug` helper below, run `grunt assemble`, and watch the output in the command line to see how it works.\n{{!debug text}}\n\n{{/markdown}}\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "debug-helpers.html",
   "pagename": "debug-helpers.html",
+  "prev": 6,
+  "relativeLink": "debug-helpers.html",
   "src": "test/fixtures/pages/debug-helpers.hbs",
   "title": "Debug Helper"
 }

--- a/test/actual/paths/example.html
+++ b/test/actual/paths/example.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
+    <li class="previous disabled">
+      <a unselectable="on" class="unselectable">First</a>
+    </li>
+    <li class="previous disabled">
+      <a unselectable="on" class="unselectable">&larr; Previous</a>
+    </li>
 
-  
-    <li class="previous">
-      <a href="debug-helpers.html">First</a>
-    </li>
-    <li class="previous">
-      <a href="collections-categories.html">&larr; Previous</a>
-    </li>
-  
 
-  
-    <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+    <li class="active pager-middle">
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
-    <li class="active pager-middle">
-      <a href="example.html">9</a>
+    <li class="pager-middle">
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="gist-helper.html">Next &rarr;</a>
+      <a href="alert.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
+    <li class="prev disabled">
+      <a unselectable="on" class="unselectable">First</a>
+    </li>
+    <li class="prev disabled">
+      <a unselectable="on" class="unselectable">&larr; Previous</a>
+    </li>
 
-  
-    <li class="prev">
-      <a href="debug-helpers.html">First</a>
-    </li>
-    <li class="prev">
-      <a href="collections-categories.html">&larr; Previous</a>
-    </li>
-  
 
-  
-    <li>
-      <a href="debug-helpers.html">1</a>
+    <li class="active">
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
-    <li class="active">
-      <a href="example.html">9</a>
+    <li>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="gist-helper.html">Next &rarr;</a>
+      <a href="alert.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,286 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">2</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">2</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">example</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">example</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -726,37 +490,22 @@ This example shows that the properties from "example.json" and "example.hbs" are
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -799,262 +548,6 @@ This example shows that the properties from "example.json" and "example.hbs" are
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/paths/debug-helpers.html
-                  this.dirname:  test/actual/paths
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/paths/example.html
-                  page.dirname:  test/actual/paths
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/paths/debug-helpers.html
-                  dirname:       test/actual/paths
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/paths/alert.html
-                  this.dirname:  test/actual/paths
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/paths/example.html
-                  page.dirname:  test/actual/paths
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/paths/alert.html
-                  dirname:       test/actual/paths
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/paths/collections-pages.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/paths/example.html
-                  page.dirname:  test/actual/paths
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/paths/collections-pages.html
-                  dirname:       test/actual/paths
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/paths/collections-tags.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/paths/example.html
-                  page.dirname:  test/actual/paths
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/paths/collections-tags.html
-                  dirname:       test/actual/paths
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/paths/collections.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/paths/example.html
-                  page.dirname:  test/actual/paths
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/paths/collections.html
-                  dirname:       test/actual/paths
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/paths/complex.html
-                  this.dirname:  test/actual/paths
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/paths/example.html
-                  page.dirname:  test/actual/paths
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/paths/complex.html
-                  dirname:       test/actual/paths
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/paths/context.html
-                  this.dirname:  test/actual/paths
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/paths/example.html
-                  page.dirname:  test/actual/paths
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/paths/context.html
-                  dirname:       test/actual/paths
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/paths/collections-categories.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/example.hbs
-                  page.dest:     test/actual/paths/example.html
-                  page.dirname:  test/actual/paths
-                  page.filename: example.html
-                  page.pagename: example.html
-                  page.basename: example
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/paths/collections-categories.html
-                  dirname:       test/actual/paths
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1087,7 +580,263 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/paths/alert.html
+                  this.dirname:  test/actual/paths
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/paths/example.html
+                  page.dirname:  test/actual/paths
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/paths/alert.html
+                  dirname:       test/actual/paths
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/paths/collections-pages.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/paths/example.html
+                  page.dirname:  test/actual/paths
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/paths/collections-pages.html
+                  dirname:       test/actual/paths
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/paths/collections-tags.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/paths/example.html
+                  page.dirname:  test/actual/paths
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/paths/collections-tags.html
+                  dirname:       test/actual/paths
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/paths/collections.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/paths/example.html
+                  page.dirname:  test/actual/paths
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/paths/collections.html
+                  dirname:       test/actual/paths
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/paths/complex.html
+                  this.dirname:  test/actual/paths
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/paths/example.html
+                  page.dirname:  test/actual/paths
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/paths/complex.html
+                  dirname:       test/actual/paths
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/paths/context.html
+                  this.dirname:  test/actual/paths
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/paths/example.html
+                  page.dirname:  test/actual/paths
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/paths/context.html
+                  dirname:       test/actual/paths
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/paths/debug-helpers.html
+                  this.dirname:  test/actual/paths
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/paths/example.html
+                  page.dirname:  test/actual/paths
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/paths/debug-helpers.html
+                  dirname:       test/actual/paths
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/paths/collections-categories.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/paths/example.html
+                  page.dirname:  test/actual/paths
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/paths/collections-categories.html
+                  dirname:       test/actual/paths
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1119,7 +868,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1151,7 +900,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1183,7 +932,39 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/paths/no-yfm-data.html
+                  this.dirname:  test/actual/paths
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/example.hbs
+                  page.dest:     test/actual/paths/example.html
+                  page.dirname:  test/actual/paths
+                  page.filename: example.html
+                  page.pagename: example.html
+                  page.basename: example
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/paths/no-yfm-data.html
+                  dirname:       test/actual/paths
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1215,7 +996,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1247,7 +1028,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1279,7 +1060,6 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1324,6 +1104,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1337,23 +1118,20 @@ This example shows that the properties from "example.json" and "example.hbs" are
     }
   },
   "filename": "example.html",
-  "first": false,
-  "index": 8,
+  "first": true,
+  "index": 0,
   "info": "Congratulations! This is data from example.yml.",
-  "isCurrentPage": false,
   "items": [
     "omega",
     "gamma"
   ],
   "last": false,
-  "middle": true,
-  "next": 9,
-  "number": 9,
+  "middle": false,
+  "next": 1,
+  "number": 1,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n\nThis example shows that the properties from \"example.json\" and \"example.hbs\" are on the page object.\n\n<hr>\n\n<div>{{page.title}}</div>\n<div>{{page.text}}</div>\n\n<hr>\n\n<div>{{title}}</div>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "example.html",
   "pagename": "example.html",
-  "prev": 7,
-  "relativeLink": "example.html",
   "src": "test/fixtures/pages/example.hbs",
   "tags": [
     "example"

--- a/test/actual/paths/gist-helper.html
+++ b/test/actual/paths/gist-helper.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
-      <a href="example.html">&larr; Previous</a>
+      <a href="collections-categories.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="lodash.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
-      <a href="example.html">&larr; Previous</a>
+      <a href="collections-categories.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="active">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="lodash.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -704,45 +473,28 @@
 
             
 <h1 id="-gist-helper">{{gist}} helper</h1>
-<script src="https://gist.github.com/5193239.js"></script>
-
-
+<p>&lt;script src=&quot;<a href="https://gist.github.com/5193239.js&quot;&gt;&lt;/script&amp;gt">https://gist.github.com/5193239.js&quot;&gt;&lt;/script&amp;gt</a>;</p>
 
             <div class="docs-header" id="content">
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -785,262 +537,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/paths/debug-helpers.html
-                  this.dirname:  test/actual/paths
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/paths/gist-helper.html
-                  page.dirname:  test/actual/paths
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/paths/debug-helpers.html
-                  dirname:       test/actual/paths
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/paths/alert.html
-                  this.dirname:  test/actual/paths
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/paths/gist-helper.html
-                  page.dirname:  test/actual/paths
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/paths/alert.html
-                  dirname:       test/actual/paths
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/paths/collections-pages.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/paths/gist-helper.html
-                  page.dirname:  test/actual/paths
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/paths/collections-pages.html
-                  dirname:       test/actual/paths
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/paths/collections-tags.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/paths/gist-helper.html
-                  page.dirname:  test/actual/paths
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/paths/collections-tags.html
-                  dirname:       test/actual/paths
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/paths/collections.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/paths/gist-helper.html
-                  page.dirname:  test/actual/paths
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/paths/collections.html
-                  dirname:       test/actual/paths
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/paths/complex.html
-                  this.dirname:  test/actual/paths
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/paths/gist-helper.html
-                  page.dirname:  test/actual/paths
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/paths/complex.html
-                  dirname:       test/actual/paths
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/paths/context.html
-                  this.dirname:  test/actual/paths
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/paths/gist-helper.html
-                  page.dirname:  test/actual/paths
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/paths/context.html
-                  dirname:       test/actual/paths
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/paths/collections-categories.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/gist-helper.hbs
-                  page.dest:     test/actual/paths/gist-helper.html
-                  page.dirname:  test/actual/paths
-                  page.filename: gist-helper.html
-                  page.pagename: gist-helper.html
-                  page.basename: gist-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/paths/collections-categories.html
-                  dirname:       test/actual/paths
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1073,7 +569,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/paths/alert.html
+                  this.dirname:  test/actual/paths
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/paths/gist-helper.html
+                  page.dirname:  test/actual/paths
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/paths/alert.html
+                  dirname:       test/actual/paths
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/paths/collections-pages.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/paths/gist-helper.html
+                  page.dirname:  test/actual/paths
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/paths/collections-pages.html
+                  dirname:       test/actual/paths
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/paths/collections-tags.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/paths/gist-helper.html
+                  page.dirname:  test/actual/paths
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/paths/collections-tags.html
+                  dirname:       test/actual/paths
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/paths/collections.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/paths/gist-helper.html
+                  page.dirname:  test/actual/paths
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/paths/collections.html
+                  dirname:       test/actual/paths
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/paths/complex.html
+                  this.dirname:  test/actual/paths
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/paths/gist-helper.html
+                  page.dirname:  test/actual/paths
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/paths/complex.html
+                  dirname:       test/actual/paths
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/paths/context.html
+                  this.dirname:  test/actual/paths
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/paths/gist-helper.html
+                  page.dirname:  test/actual/paths
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/paths/context.html
+                  dirname:       test/actual/paths
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/paths/debug-helpers.html
+                  this.dirname:  test/actual/paths
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/paths/gist-helper.html
+                  page.dirname:  test/actual/paths
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/paths/debug-helpers.html
+                  dirname:       test/actual/paths
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/paths/collections-categories.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/paths/gist-helper.html
+                  page.dirname:  test/actual/paths
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/paths/collections-categories.html
+                  dirname:       test/actual/paths
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1105,7 +857,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1137,7 +889,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1169,7 +921,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/paths/no-yfm-data.html
+                  this.dirname:  test/actual/paths
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/gist-helper.hbs
+                  page.dest:     test/actual/paths/gist-helper.html
+                  page.dirname:  test/actual/paths
+                  page.filename: gist-helper.html
+                  page.pagename: gist-helper.html
+                  page.basename: gist-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/paths/no-yfm-data.html
+                  dirname:       test/actual/paths
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1201,7 +985,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1233,7 +1017,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1265,7 +1049,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1295,6 +1078,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/paths/lodash.html
+++ b/test/actual/paths/lodash.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="gist-helper.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="md-helper.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="gist-helper.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="active">
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="md-helper.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -711,37 +480,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -784,262 +538,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/paths/debug-helpers.html
-                  this.dirname:  test/actual/paths
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/paths/lodash.html
-                  page.dirname:  test/actual/paths
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/paths/debug-helpers.html
-                  dirname:       test/actual/paths
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/paths/alert.html
-                  this.dirname:  test/actual/paths
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/paths/lodash.html
-                  page.dirname:  test/actual/paths
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/paths/alert.html
-                  dirname:       test/actual/paths
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/paths/collections-pages.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/paths/lodash.html
-                  page.dirname:  test/actual/paths
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/paths/collections-pages.html
-                  dirname:       test/actual/paths
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/paths/collections-tags.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/paths/lodash.html
-                  page.dirname:  test/actual/paths
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/paths/collections-tags.html
-                  dirname:       test/actual/paths
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/paths/collections.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/paths/lodash.html
-                  page.dirname:  test/actual/paths
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/paths/collections.html
-                  dirname:       test/actual/paths
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/paths/complex.html
-                  this.dirname:  test/actual/paths
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/paths/lodash.html
-                  page.dirname:  test/actual/paths
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/paths/complex.html
-                  dirname:       test/actual/paths
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/paths/context.html
-                  this.dirname:  test/actual/paths
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/paths/lodash.html
-                  page.dirname:  test/actual/paths
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/paths/context.html
-                  dirname:       test/actual/paths
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/paths/collections-categories.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/lodash.hbs
-                  page.dest:     test/actual/paths/lodash.html
-                  page.dirname:  test/actual/paths
-                  page.filename: lodash.html
-                  page.pagename: lodash.html
-                  page.basename: lodash
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/paths/collections-categories.html
-                  dirname:       test/actual/paths
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1072,7 +570,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/paths/alert.html
+                  this.dirname:  test/actual/paths
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/paths/lodash.html
+                  page.dirname:  test/actual/paths
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/paths/alert.html
+                  dirname:       test/actual/paths
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/paths/collections-pages.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/paths/lodash.html
+                  page.dirname:  test/actual/paths
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/paths/collections-pages.html
+                  dirname:       test/actual/paths
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/paths/collections-tags.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/paths/lodash.html
+                  page.dirname:  test/actual/paths
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/paths/collections-tags.html
+                  dirname:       test/actual/paths
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/paths/collections.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/paths/lodash.html
+                  page.dirname:  test/actual/paths
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/paths/collections.html
+                  dirname:       test/actual/paths
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/paths/complex.html
+                  this.dirname:  test/actual/paths
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/paths/lodash.html
+                  page.dirname:  test/actual/paths
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/paths/complex.html
+                  dirname:       test/actual/paths
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/paths/context.html
+                  this.dirname:  test/actual/paths
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/paths/lodash.html
+                  page.dirname:  test/actual/paths
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/paths/context.html
+                  dirname:       test/actual/paths
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/paths/debug-helpers.html
+                  this.dirname:  test/actual/paths
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/paths/lodash.html
+                  page.dirname:  test/actual/paths
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/paths/debug-helpers.html
+                  dirname:       test/actual/paths
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/paths/collections-categories.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/paths/lodash.html
+                  page.dirname:  test/actual/paths
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/paths/collections-categories.html
+                  dirname:       test/actual/paths
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1104,7 +858,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1136,7 +890,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1168,7 +922,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/paths/no-yfm-data.html
+                  this.dirname:  test/actual/paths
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/lodash.hbs
+                  page.dest:     test/actual/paths/lodash.html
+                  page.dirname:  test/actual/paths
+                  page.filename: lodash.html
+                  page.pagename: lodash.html
+                  page.basename: lodash
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/paths/no-yfm-data.html
+                  dirname:       test/actual/paths
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1200,7 +986,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1232,7 +1018,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1264,7 +1050,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1296,6 +1081,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/paths/md-helper.html
+++ b/test/actual/paths/md-helper.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="lodash.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="no-yfm.html">Next &rarr;</a>
+      <a href="no-yfm-data.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="lodash.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="active">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="no-yfm.html">Next &rarr;</a>
+      <a href="no-yfm-data.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,488 +187,288 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">2</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">helper</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">2</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">helper</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">markdown</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">markdown</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -738,37 +500,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -811,262 +558,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/paths/debug-helpers.html
-                  this.dirname:  test/actual/paths
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/paths/md-helper.html
-                  page.dirname:  test/actual/paths
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/paths/debug-helpers.html
-                  dirname:       test/actual/paths
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/paths/alert.html
-                  this.dirname:  test/actual/paths
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/paths/md-helper.html
-                  page.dirname:  test/actual/paths
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/paths/alert.html
-                  dirname:       test/actual/paths
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/paths/collections-pages.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/paths/md-helper.html
-                  page.dirname:  test/actual/paths
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/paths/collections-pages.html
-                  dirname:       test/actual/paths
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/paths/collections-tags.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/paths/md-helper.html
-                  page.dirname:  test/actual/paths
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/paths/collections-tags.html
-                  dirname:       test/actual/paths
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/paths/collections.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/paths/md-helper.html
-                  page.dirname:  test/actual/paths
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/paths/collections.html
-                  dirname:       test/actual/paths
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/paths/complex.html
-                  this.dirname:  test/actual/paths
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/paths/md-helper.html
-                  page.dirname:  test/actual/paths
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/paths/complex.html
-                  dirname:       test/actual/paths
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/paths/context.html
-                  this.dirname:  test/actual/paths
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/paths/md-helper.html
-                  page.dirname:  test/actual/paths
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/paths/context.html
-                  dirname:       test/actual/paths
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/paths/collections-categories.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/md-helper.hbs
-                  page.dest:     test/actual/paths/md-helper.html
-                  page.dirname:  test/actual/paths
-                  page.filename: md-helper.html
-                  page.pagename: md-helper.html
-                  page.basename: md-helper
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/paths/collections-categories.html
-                  dirname:       test/actual/paths
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1099,7 +590,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/paths/alert.html
+                  this.dirname:  test/actual/paths
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/paths/md-helper.html
+                  page.dirname:  test/actual/paths
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/paths/alert.html
+                  dirname:       test/actual/paths
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/paths/collections-pages.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/paths/md-helper.html
+                  page.dirname:  test/actual/paths
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/paths/collections-pages.html
+                  dirname:       test/actual/paths
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/paths/collections-tags.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/paths/md-helper.html
+                  page.dirname:  test/actual/paths
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/paths/collections-tags.html
+                  dirname:       test/actual/paths
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/paths/collections.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/paths/md-helper.html
+                  page.dirname:  test/actual/paths
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/paths/collections.html
+                  dirname:       test/actual/paths
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/paths/complex.html
+                  this.dirname:  test/actual/paths
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/paths/md-helper.html
+                  page.dirname:  test/actual/paths
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/paths/complex.html
+                  dirname:       test/actual/paths
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/paths/context.html
+                  this.dirname:  test/actual/paths
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/paths/md-helper.html
+                  page.dirname:  test/actual/paths
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/paths/context.html
+                  dirname:       test/actual/paths
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/paths/debug-helpers.html
+                  this.dirname:  test/actual/paths
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/paths/md-helper.html
+                  page.dirname:  test/actual/paths
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/paths/debug-helpers.html
+                  dirname:       test/actual/paths
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/paths/collections-categories.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/paths/md-helper.html
+                  page.dirname:  test/actual/paths
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/paths/collections-categories.html
+                  dirname:       test/actual/paths
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1131,7 +878,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1163,7 +910,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1195,7 +942,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/paths/no-yfm-data.html
+                  this.dirname:  test/actual/paths
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/md-helper.hbs
+                  page.dest:     test/actual/paths/md-helper.html
+                  page.dirname:  test/actual/paths
+                  page.filename: md-helper.html
+                  page.pagename: md-helper.html
+                  page.basename: md-helper
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/paths/no-yfm-data.html
+                  dirname:       test/actual/paths
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1227,7 +1006,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1259,7 +1038,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1291,7 +1070,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1340,6 +1118,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/paths/no-yfm-data.html
+++ b/test/actual/paths/no-yfm-data.html
@@ -1,0 +1,1121 @@
+<!DOCTYPE html>
+  <html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Layout filename: ''</title>
+    <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../assets/validation.css">
+  </head>
+  <body style="padding-top: 60px;">
+    <div class="container">
+
+      <!-- validate assets path -->
+      <section id="validate"></section>
+      <div class="docs-section">
+        <div class="docs-header" id="content">
+          <h4><strong class="text-muted">test/fixtures/pages/no-yfm-data.hbs</strong> &#x2192; <strong class="text-success">test/actual/paths/no-yfm-data.html</strong></h4>
+        </div>
+        <hr>
+      </div>
+
+      <ul class="pager">
+
+
+    <li class="previous">
+      <a href="example.html">First</a>
+    </li>
+    <li class="previous">
+      <a href="md-helper.html">&larr; Previous</a>
+    </li>
+
+    <li class="pager-middle">
+      <a href="example.html">1</a>
+    </li>
+    <li class="pager-middle">
+      <a href="alert.html">2</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections-pages.html">3</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections-tags.html">4</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections.html">5</a>
+    </li>
+    <li class="pager-middle">
+      <a href="complex.html">6</a>
+    </li>
+    <li class="pager-middle">
+      <a href="context.html">7</a>
+    </li>
+    <li class="pager-middle">
+      <a href="debug-helpers.html">8</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections-categories.html">9</a>
+    </li>
+    <li class="pager-middle">
+      <a href="gist-helper.html">10</a>
+    </li>
+    <li class="pager-middle">
+      <a href="lodash.html">11</a>
+    </li>
+    <li class="pager-middle">
+      <a href="md-helper.html">12</a>
+    </li>
+    <li class="active pager-middle">
+      <a href="no-yfm-data.html">13</a>
+    </li>
+    <li class="pager-middle">
+      <a href="no-yfm.html">14</a>
+    </li>
+    <li class="pager-middle">
+      <a href="yfm-context.html">15</a>
+    </li>
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
+
+    <li class="next">
+      <a href="yfm.html">Last</a>
+    </li>
+    <li class="next">
+      <a href="no-yfm.html">Next &rarr;</a>
+    </li>
+
+
+</ul><style>
+.unselectable {
+  -webkit-touch-callout: none;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+}
+</style>
+      <hr>
+
+      <div class="row">
+        <!-- Column: sidebar -->
+        <div class="col-md-3">
+          <div class="bs-sidebar hidden-print" role="complementary">
+            <!-- pagination -->
+            <ul class="nav nav-pills nav-stacked">
+
+
+    <li class="prev">
+      <a href="example.html">First</a>
+    </li>
+    <li class="prev">
+      <a href="md-helper.html">&larr; Previous</a>
+    </li>
+
+    <li>
+      <a href="example.html">1</a>
+    </li>
+    <li>
+      <a href="alert.html">2</a>
+    </li>
+    <li>
+      <a href="collections-pages.html">3</a>
+    </li>
+    <li>
+      <a href="collections-tags.html">4</a>
+    </li>
+    <li>
+      <a href="collections.html">5</a>
+    </li>
+    <li>
+      <a href="complex.html">6</a>
+    </li>
+    <li>
+      <a href="context.html">7</a>
+    </li>
+    <li>
+      <a href="debug-helpers.html">8</a>
+    </li>
+    <li>
+      <a href="collections-categories.html">9</a>
+    </li>
+    <li>
+      <a href="gist-helper.html">10</a>
+    </li>
+    <li>
+      <a href="lodash.html">11</a>
+    </li>
+    <li>
+      <a href="md-helper.html">12</a>
+    </li>
+    <li class="active">
+      <a href="no-yfm-data.html">13</a>
+    </li>
+    <li>
+      <a href="no-yfm.html">14</a>
+    </li>
+    <li>
+      <a href="yfm-context.html">15</a>
+    </li>
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
+
+    <li class="next">
+      <a href="no-yfm.html">Next &rarr;</a>
+    </li>
+    <li class="next">
+      <a href="yfm.html">Last</a>
+    </li>
+
+
+</ul>
+          </div>
+        </div>
+        <!-- Column: content -->
+        <div class="col-md-9" role="main">
+          <div class="docs-section">
+            <div class="docs-header" id="content">
+              <h4><strong>Page layout:</strong> default.hbs</h4>
+              <h4><strong>Page src:</strong> test/fixtures/pages/no-yfm-data.hbs</h4>
+              <h4><strong>Page dest:</strong> test/actual/paths/no-yfm-data.html</h4>
+              <h4><strong>Dest filename:</strong> no-yfm-data.html</h4>
+              <h4><strong>Dest basename:</strong> no-yfm-data</h4>
+              <h4><strong>Page title:</strong> (no title defined)</h4>
+            </div>
+
+            <hr>
+            <div class="row">
+              <div class="col-md-6">
+                <!-- Categories Collection -->
+                  
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
+              </div>
+              <div class="col-md-6">
+                  
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
+              </div>
+            </div>
+
+            <hr>
+
+            There is no YAML front matter in this page.
+
+<ul>
+  <li>first</li>
+  <li>second</li>
+  <li>third</li>
+  <li>globalData1</li>
+</ul>
+
+
+            <div class="docs-header" id="content">
+              <h1>Content</h1>
+            </div>
+            <ul>
+              <li><a href="example.html">example.html</a></li>
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
+              <li><a href="gist-helper.html">gist-helper.html</a></li>
+              <li><a href="lodash.html">lodash.html</a></li>
+              <li><a href="md-helper.html">md-helper.html</a></li>
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+              <li><a href="no-yfm.html">no-yfm.html</a></li>
+              <li><a href="yfm-context.html">yfm-context.html</a></li>
+              <li><a href="yfm.html">yfm.html</a></li>
+            </ul>
+
+            <hr>
+            <div style="display: none">
+
+              <h1>Page</h1>
+              <!--
+              "this"
+              ===============================
+              this.src:      
+              this.dest:     
+              this.layout:   
+              this.dirname:  test/actual/paths
+              this.filename: no-yfm-data.html
+              this.pagename: no-yfm-data.html
+              this.basename: no-yfm-data
+              this.ext:      .html
+
+              "page"
+              ===============================
+              page.src:        test/fixtures/pages/no-yfm-data.hbs
+              page.dest:       test/actual/paths/no-yfm-data.html
+              page.layout:     
+              page.dirname:    test/actual/paths
+              page.filename:   no-yfm-data.html
+              page.pagename:   no-yfm-data.html
+              page.basename:   no-yfm-data
+              page.ext:        .html
+
+              "root"
+              ===============================
+              src:           
+              dest:          
+              layout:        
+              dirname:       test/actual/paths
+              filename:      no-yfm-data.html
+              pagename:      no-yfm-data.html
+              basename:      no-yfm-data
+              ext:           .html
+              -->
+              <h1>Each pages</h1>
+              <ul>
+                <li><a href="example.html">example.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/example.hbs
+                  this.dest:     test/actual/paths/example.html
+                  this.dirname:  test/actual/paths
+                  this.filename: example.html
+                  this.pagename: example.html
+                  this.basename: example
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/paths/no-yfm-data.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/example.hbs
+                  dest:          test/actual/paths/example.html
+                  dirname:       test/actual/paths
+                  filename:      example.html
+                  pagename:      example.html
+                  basename:      example
+                  ext:           .html
+                  -->
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/paths/alert.html
+                  this.dirname:  test/actual/paths
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/paths/no-yfm-data.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/paths/alert.html
+                  dirname:       test/actual/paths
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/paths/collections-pages.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/paths/no-yfm-data.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/paths/collections-pages.html
+                  dirname:       test/actual/paths
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/paths/collections-tags.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/paths/no-yfm-data.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/paths/collections-tags.html
+                  dirname:       test/actual/paths
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/paths/collections.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/paths/no-yfm-data.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/paths/collections.html
+                  dirname:       test/actual/paths
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/paths/complex.html
+                  this.dirname:  test/actual/paths
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/paths/no-yfm-data.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/paths/complex.html
+                  dirname:       test/actual/paths
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/paths/context.html
+                  this.dirname:  test/actual/paths
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/paths/no-yfm-data.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/paths/context.html
+                  dirname:       test/actual/paths
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/paths/debug-helpers.html
+                  this.dirname:  test/actual/paths
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/paths/no-yfm-data.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/paths/debug-helpers.html
+                  dirname:       test/actual/paths
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/paths/collections-categories.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/paths/no-yfm-data.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/paths/collections-categories.html
+                  dirname:       test/actual/paths
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/gist-helper.hbs
+                  this.dest:     test/actual/paths/gist-helper.html
+                  this.dirname:  test/actual/paths
+                  this.filename: gist-helper.html
+                  this.pagename: gist-helper.html
+                  this.basename: gist-helper
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/paths/no-yfm-data.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/gist-helper.hbs
+                  dest:          test/actual/paths/gist-helper.html
+                  dirname:       test/actual/paths
+                  filename:      gist-helper.html
+                  pagename:      gist-helper.html
+                  basename:      gist-helper
+                  ext:           .html
+                  -->
+<li><a href="lodash.html">lodash.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/lodash.hbs
+                  this.dest:     test/actual/paths/lodash.html
+                  this.dirname:  test/actual/paths
+                  this.filename: lodash.html
+                  this.pagename: lodash.html
+                  this.basename: lodash
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/paths/no-yfm-data.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/lodash.hbs
+                  dest:          test/actual/paths/lodash.html
+                  dirname:       test/actual/paths
+                  filename:      lodash.html
+                  pagename:      lodash.html
+                  basename:      lodash
+                  ext:           .html
+                  -->
+<li><a href="md-helper.html">md-helper.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/md-helper.hbs
+                  this.dest:     test/actual/paths/md-helper.html
+                  this.dirname:  test/actual/paths
+                  this.filename: md-helper.html
+                  this.pagename: md-helper.html
+                  this.basename: md-helper
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/paths/no-yfm-data.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/md-helper.hbs
+                  dest:          test/actual/paths/md-helper.html
+                  dirname:       test/actual/paths
+                  filename:      md-helper.html
+                  pagename:      md-helper.html
+                  basename:      md-helper
+                  ext:           .html
+                  -->
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/paths/no-yfm-data.html
+                  this.dirname:  test/actual/paths
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/paths/no-yfm-data.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/paths/no-yfm-data.html
+                  dirname:       test/actual/paths
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm.hbs
+                  this.dest:     test/actual/paths/no-yfm.html
+                  this.dirname:  test/actual/paths
+                  this.filename: no-yfm.html
+                  this.pagename: no-yfm.html
+                  this.basename: no-yfm
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/paths/no-yfm-data.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm.hbs
+                  dest:          test/actual/paths/no-yfm.html
+                  dirname:       test/actual/paths
+                  filename:      no-yfm.html
+                  pagename:      no-yfm.html
+                  basename:      no-yfm
+                  ext:           .html
+                  -->
+<li><a href="yfm-context.html">yfm-context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/yfm-context.hbs
+                  this.dest:     test/actual/paths/yfm-context.html
+                  this.dirname:  test/actual/paths
+                  this.filename: yfm-context.html
+                  this.pagename: yfm-context.html
+                  this.basename: yfm-context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/paths/no-yfm-data.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/yfm-context.hbs
+                  dest:          test/actual/paths/yfm-context.html
+                  dirname:       test/actual/paths
+                  filename:      yfm-context.html
+                  pagename:      yfm-context.html
+                  basename:      yfm-context
+                  ext:           .html
+                  -->
+<li><a href="yfm.html">yfm.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/yfm.hbs
+                  this.dest:     test/actual/paths/yfm.html
+                  this.dirname:  test/actual/paths
+                  this.filename: yfm.html
+                  this.pagename: yfm.html
+                  this.basename: yfm
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:     test/actual/paths/no-yfm-data.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm-data.html
+                  page.pagename: no-yfm-data.html
+                  page.basename: no-yfm-data
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/yfm.hbs
+                  dest:          test/actual/paths/yfm.html
+                  dirname:       test/actual/paths
+                  filename:      yfm.html
+                  pagename:      yfm.html
+                  basename:      yfm
+                  ext:           .html
+                  -->
+              </ul>
+
+              <h1>Debug Info</h1>
+              <pre><code class="json">
+{
+  "_page": "all",
+  "assets": "../../assets",
+  "basename": "no-yfm-data",
+  "data": {},
+  "dest": "test/actual/paths/no-yfm-data.html",
+  "dirname": "test/actual/paths",
+  "ext": ".html",
+  "extname": ".html",
+  "filePair": {
+    "src": [
+      "test/fixtures/pages/alert.hbs",
+      "test/fixtures/pages/collections-categories.hbs",
+      "test/fixtures/pages/collections-pages.hbs",
+      "test/fixtures/pages/collections-tags.hbs",
+      "test/fixtures/pages/collections.hbs",
+      "test/fixtures/pages/complex.hbs",
+      "test/fixtures/pages/context.hbs",
+      "test/fixtures/pages/debug-helpers.hbs",
+      "test/fixtures/pages/example.hbs",
+      "test/fixtures/pages/gist-helper.hbs",
+      "test/fixtures/pages/lodash.hbs",
+      "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
+      "test/fixtures/pages/no-yfm.hbs",
+      "test/fixtures/pages/yfm-context.hbs",
+      "test/fixtures/pages/yfm.hbs"
+    ],
+    "dest": "test/actual/paths/",
+    "orig": {
+      "src": [
+        "test/fixtures/pages/*.hbs"
+      ],
+      "dest": "test/actual/paths/"
+    }
+  },
+  "filename": "no-yfm-data.html",
+  "first": false,
+  "index": 12,
+  "isCurrentPage": false,
+  "last": false,
+  "middle": true,
+  "next": 13,
+  "number": 13,
+  "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            There is no YAML front matter in this page.\n\n<ul>\n  <li>{{one}}</li>\n  <li>{{two}}</li>\n  <li>{{three}}</li>\n  <li>{{global1}}</li>\n</ul>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
+  "pageName": "no-yfm-data.html",
+  "pagename": "no-yfm-data.html",
+  "prev": 11,
+  "relativeLink": "no-yfm-data.html",
+  "src": "test/fixtures/pages/no-yfm-data.hbs"
+}
+</code></pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script src="../../assets/validation.js"></script>
+  </body>
+</html>

--- a/test/actual/paths/no-yfm.html
+++ b/test/actual/paths/no-yfm.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
-      <a href="md-helper.html">&larr; Previous</a>
+      <a href="no-yfm-data.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="no-yfm-data.html">13</a>
+    </li>
     <li class="active pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="yfm-context.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
-      <a href="md-helper.html">&larr; Previous</a>
+      <a href="no-yfm-data.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
+    <li>
+      <a href="no-yfm-data.html">13</a>
+    </li>
     <li class="active">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="yfm-context.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -714,37 +483,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -787,262 +541,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/paths/debug-helpers.html
-                  this.dirname:  test/actual/paths
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/paths/no-yfm.html
-                  page.dirname:  test/actual/paths
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/paths/debug-helpers.html
-                  dirname:       test/actual/paths
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/paths/alert.html
-                  this.dirname:  test/actual/paths
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/paths/no-yfm.html
-                  page.dirname:  test/actual/paths
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/paths/alert.html
-                  dirname:       test/actual/paths
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/paths/collections-pages.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/paths/no-yfm.html
-                  page.dirname:  test/actual/paths
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/paths/collections-pages.html
-                  dirname:       test/actual/paths
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/paths/collections-tags.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/paths/no-yfm.html
-                  page.dirname:  test/actual/paths
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/paths/collections-tags.html
-                  dirname:       test/actual/paths
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/paths/collections.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/paths/no-yfm.html
-                  page.dirname:  test/actual/paths
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/paths/collections.html
-                  dirname:       test/actual/paths
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/paths/complex.html
-                  this.dirname:  test/actual/paths
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/paths/no-yfm.html
-                  page.dirname:  test/actual/paths
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/paths/complex.html
-                  dirname:       test/actual/paths
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/paths/context.html
-                  this.dirname:  test/actual/paths
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/paths/no-yfm.html
-                  page.dirname:  test/actual/paths
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/paths/context.html
-                  dirname:       test/actual/paths
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/paths/collections-categories.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/no-yfm.hbs
-                  page.dest:     test/actual/paths/no-yfm.html
-                  page.dirname:  test/actual/paths
-                  page.filename: no-yfm.html
-                  page.pagename: no-yfm.html
-                  page.basename: no-yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/paths/collections-categories.html
-                  dirname:       test/actual/paths
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1075,7 +573,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/paths/alert.html
+                  this.dirname:  test/actual/paths
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/paths/no-yfm.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/paths/alert.html
+                  dirname:       test/actual/paths
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/paths/collections-pages.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/paths/no-yfm.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/paths/collections-pages.html
+                  dirname:       test/actual/paths
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/paths/collections-tags.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/paths/no-yfm.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/paths/collections-tags.html
+                  dirname:       test/actual/paths
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/paths/collections.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/paths/no-yfm.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/paths/collections.html
+                  dirname:       test/actual/paths
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/paths/complex.html
+                  this.dirname:  test/actual/paths
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/paths/no-yfm.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/paths/complex.html
+                  dirname:       test/actual/paths
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/paths/context.html
+                  this.dirname:  test/actual/paths
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/paths/no-yfm.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/paths/context.html
+                  dirname:       test/actual/paths
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/paths/debug-helpers.html
+                  this.dirname:  test/actual/paths
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/paths/no-yfm.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/paths/debug-helpers.html
+                  dirname:       test/actual/paths
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/paths/collections-categories.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/paths/no-yfm.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/paths/collections-categories.html
+                  dirname:       test/actual/paths
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1107,7 +861,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1139,7 +893,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1171,7 +925,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/paths/no-yfm-data.html
+                  this.dirname:  test/actual/paths
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/no-yfm.hbs
+                  page.dest:     test/actual/paths/no-yfm.html
+                  page.dirname:  test/actual/paths
+                  page.filename: no-yfm.html
+                  page.pagename: no-yfm.html
+                  page.basename: no-yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/paths/no-yfm-data.html
+                  dirname:       test/actual/paths
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1203,7 +989,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1235,7 +1021,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1267,7 +1053,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1295,6 +1080,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1309,16 +1095,16 @@
   },
   "filename": "no-yfm.html",
   "first": false,
-  "index": 12,
+  "index": 13,
   "isCurrentPage": false,
   "last": false,
   "middle": true,
-  "next": 13,
-  "number": 13,
+  "next": 14,
+  "number": 14,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            There is no YAML front matter in this page.\n\n<div>{{noyfm.one}}</div>\n<div>{{noyfm.two}}</div>\n\n\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "no-yfm.html",
   "pagename": "no-yfm.html",
-  "prev": 11,
+  "prev": 12,
   "relativeLink": "no-yfm.html",
   "src": "test/fixtures/pages/no-yfm.hbs"
 }

--- a/test/actual/paths/yfm-context.html
+++ b/test/actual/paths/yfm-context.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="no-yfm.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="no-yfm.html">14</a>
+    </li>
     <li class="active pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="yfm.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="no-yfm.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
+    <li>
+      <a href="no-yfm.html">14</a>
+    </li>
     <li class="active">
-      <a href="yfm-context.html">14</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="yfm.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yfm</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">context</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yfm</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">context</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -736,37 +501,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -809,262 +559,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/paths/debug-helpers.html
-                  this.dirname:  test/actual/paths
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/paths/yfm-context.html
-                  page.dirname:  test/actual/paths
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/paths/debug-helpers.html
-                  dirname:       test/actual/paths
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/paths/alert.html
-                  this.dirname:  test/actual/paths
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/paths/yfm-context.html
-                  page.dirname:  test/actual/paths
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/paths/alert.html
-                  dirname:       test/actual/paths
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/paths/collections-pages.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/paths/yfm-context.html
-                  page.dirname:  test/actual/paths
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/paths/collections-pages.html
-                  dirname:       test/actual/paths
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/paths/collections-tags.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/paths/yfm-context.html
-                  page.dirname:  test/actual/paths
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/paths/collections-tags.html
-                  dirname:       test/actual/paths
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/paths/collections.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/paths/yfm-context.html
-                  page.dirname:  test/actual/paths
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/paths/collections.html
-                  dirname:       test/actual/paths
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/paths/complex.html
-                  this.dirname:  test/actual/paths
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/paths/yfm-context.html
-                  page.dirname:  test/actual/paths
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/paths/complex.html
-                  dirname:       test/actual/paths
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/paths/context.html
-                  this.dirname:  test/actual/paths
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/paths/yfm-context.html
-                  page.dirname:  test/actual/paths
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/paths/context.html
-                  dirname:       test/actual/paths
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/paths/collections-categories.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm-context.hbs
-                  page.dest:     test/actual/paths/yfm-context.html
-                  page.dirname:  test/actual/paths
-                  page.filename: yfm-context.html
-                  page.pagename: yfm-context.html
-                  page.basename: yfm-context
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/paths/collections-categories.html
-                  dirname:       test/actual/paths
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1097,7 +591,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/paths/alert.html
+                  this.dirname:  test/actual/paths
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/paths/yfm-context.html
+                  page.dirname:  test/actual/paths
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/paths/alert.html
+                  dirname:       test/actual/paths
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/paths/collections-pages.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/paths/yfm-context.html
+                  page.dirname:  test/actual/paths
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/paths/collections-pages.html
+                  dirname:       test/actual/paths
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/paths/collections-tags.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/paths/yfm-context.html
+                  page.dirname:  test/actual/paths
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/paths/collections-tags.html
+                  dirname:       test/actual/paths
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/paths/collections.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/paths/yfm-context.html
+                  page.dirname:  test/actual/paths
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/paths/collections.html
+                  dirname:       test/actual/paths
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/paths/complex.html
+                  this.dirname:  test/actual/paths
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/paths/yfm-context.html
+                  page.dirname:  test/actual/paths
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/paths/complex.html
+                  dirname:       test/actual/paths
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/paths/context.html
+                  this.dirname:  test/actual/paths
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/paths/yfm-context.html
+                  page.dirname:  test/actual/paths
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/paths/context.html
+                  dirname:       test/actual/paths
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/paths/debug-helpers.html
+                  this.dirname:  test/actual/paths
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/paths/yfm-context.html
+                  page.dirname:  test/actual/paths
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/paths/debug-helpers.html
+                  dirname:       test/actual/paths
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/paths/collections-categories.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/paths/yfm-context.html
+                  page.dirname:  test/actual/paths
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/paths/collections-categories.html
+                  dirname:       test/actual/paths
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1129,7 +879,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1161,7 +911,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1193,7 +943,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/paths/no-yfm-data.html
+                  this.dirname:  test/actual/paths
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm-context.hbs
+                  page.dest:     test/actual/paths/yfm-context.html
+                  page.dirname:  test/actual/paths
+                  page.filename: yfm-context.html
+                  page.pagename: yfm-context.html
+                  page.basename: yfm-context
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/paths/no-yfm-data.html
+                  dirname:       test/actual/paths
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1225,7 +1007,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1257,7 +1039,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1289,7 +1071,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1331,6 +1112,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1345,16 +1127,16 @@
   },
   "filename": "yfm-context.html",
   "first": false,
-  "index": 13,
+  "index": 14,
   "isCurrentPage": false,
   "last": false,
   "middle": true,
-  "next": 14,
-  "number": 14,
+  "next": 15,
+  "number": 15,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n\n<div class=\"page-header\">\n  <h1>{{{default home.title \"Title from home.json didn't render.\"}}}</h1>\n  <p class=\"lead\">{{{default home.description \"Description from home.json didn't render.\"}}}</p>\n</div>\n\n<hr>\n\n<div class=\"page-header\">\n  <h1>{{{default page.title \"page.title didn't render.\"}}}</h1>\n  <p class=\"lead\">{{{default page.description \"page.description didn't render.\"}}}</p>\n</div>\n\n<hr>\n\n<div class=\"page-header\">\n  <h1>{{{default title \"title didn't render.\"}}}</h1>\n  <p class=\"lead\">{{{default description \"description didn't render.\"}}}</p>\n</div>\n\n\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "yfm-context.html",
   "pagename": "yfm-context.html",
-  "prev": 12,
+  "prev": 13,
   "relativeLink": "yfm-context.html",
   "src": "test/fixtures/pages/yfm-context.hbs",
   "title": "This title is from the YFM of the current page"

--- a/test/actual/paths/yfm.html
+++ b/test/actual/paths/yfm.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="yfm-context.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm-context.html">15</a>
+    </li>
     <li class="active pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="yfm-context.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
+    <li>
+      <a href="yfm-context.html">15</a>
+    </li>
     <li class="active">
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -711,37 +480,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -784,262 +538,6 @@
               -->
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/debug-helpers.hbs
-                  this.dest:     test/actual/paths/debug-helpers.html
-                  this.dirname:  test/actual/paths
-                  this.filename: debug-helpers.html
-                  this.pagename: debug-helpers.html
-                  this.basename: debug-helpers
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/paths/yfm.html
-                  page.dirname:  test/actual/paths
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/debug-helpers.hbs
-                  dest:          test/actual/paths/debug-helpers.html
-                  dirname:       test/actual/paths
-                  filename:      debug-helpers.html
-                  pagename:      debug-helpers.html
-                  basename:      debug-helpers
-                  ext:           .html
-                  -->
-                <li><a href="alert.html">alert.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/alert.hbs
-                  this.dest:     test/actual/paths/alert.html
-                  this.dirname:  test/actual/paths
-                  this.filename: alert.html
-                  this.pagename: alert.html
-                  this.basename: alert
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/paths/yfm.html
-                  page.dirname:  test/actual/paths
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/alert.hbs
-                  dest:          test/actual/paths/alert.html
-                  dirname:       test/actual/paths
-                  filename:      alert.html
-                  pagename:      alert.html
-                  basename:      alert
-                  ext:           .html
-                  -->
-                <li><a href="collections-pages.html">collections-pages.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-pages.hbs
-                  this.dest:     test/actual/paths/collections-pages.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-pages.html
-                  this.pagename: collections-pages.html
-                  this.basename: collections-pages
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/paths/yfm.html
-                  page.dirname:  test/actual/paths
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-pages.hbs
-                  dest:          test/actual/paths/collections-pages.html
-                  dirname:       test/actual/paths
-                  filename:      collections-pages.html
-                  pagename:      collections-pages.html
-                  basename:      collections-pages
-                  ext:           .html
-                  -->
-                <li><a href="collections-tags.html">collections-tags.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-tags.hbs
-                  this.dest:     test/actual/paths/collections-tags.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-tags.html
-                  this.pagename: collections-tags.html
-                  this.basename: collections-tags
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/paths/yfm.html
-                  page.dirname:  test/actual/paths
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-tags.hbs
-                  dest:          test/actual/paths/collections-tags.html
-                  dirname:       test/actual/paths
-                  filename:      collections-tags.html
-                  pagename:      collections-tags.html
-                  basename:      collections-tags
-                  ext:           .html
-                  -->
-                <li><a href="collections.html">collections.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections.hbs
-                  this.dest:     test/actual/paths/collections.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections.html
-                  this.pagename: collections.html
-                  this.basename: collections
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/paths/yfm.html
-                  page.dirname:  test/actual/paths
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections.hbs
-                  dest:          test/actual/paths/collections.html
-                  dirname:       test/actual/paths
-                  filename:      collections.html
-                  pagename:      collections.html
-                  basename:      collections
-                  ext:           .html
-                  -->
-                <li><a href="complex.html">complex.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/complex.hbs
-                  this.dest:     test/actual/paths/complex.html
-                  this.dirname:  test/actual/paths
-                  this.filename: complex.html
-                  this.pagename: complex.html
-                  this.basename: complex
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/paths/yfm.html
-                  page.dirname:  test/actual/paths
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/complex.hbs
-                  dest:          test/actual/paths/complex.html
-                  dirname:       test/actual/paths
-                  filename:      complex.html
-                  pagename:      complex.html
-                  basename:      complex
-                  ext:           .html
-                  -->
-                <li><a href="context.html">context.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/context.hbs
-                  this.dest:     test/actual/paths/context.html
-                  this.dirname:  test/actual/paths
-                  this.filename: context.html
-                  this.pagename: context.html
-                  this.basename: context
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/paths/yfm.html
-                  page.dirname:  test/actual/paths
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/context.hbs
-                  dest:          test/actual/paths/context.html
-                  dirname:       test/actual/paths
-                  filename:      context.html
-                  pagename:      context.html
-                  basename:      context
-                  ext:           .html
-                  -->
-                <li><a href="collections-categories.html">collections-categories.html</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:      test/fixtures/pages/collections-categories.hbs
-                  this.dest:     test/actual/paths/collections-categories.html
-                  this.dirname:  test/actual/paths
-                  this.filename: collections-categories.html
-                  this.pagename: collections-categories.html
-                  this.basename: collections-categories
-                  this.ext:      .html
-
-                  "page"
-                  ===============================
-                  page.src:      test/fixtures/pages/yfm.hbs
-                  page.dest:     test/actual/paths/yfm.html
-                  page.dirname:  test/actual/paths
-                  page.filename: yfm.html
-                  page.pagename: yfm.html
-                  page.basename: yfm
-                  page.ext:      .html
-
-                  "root"
-                  ===============================
-                  src:           test/fixtures/pages/collections-categories.hbs
-                  dest:          test/actual/paths/collections-categories.html
-                  dirname:       test/actual/paths
-                  filename:      collections-categories.html
-                  pagename:      collections-categories.html
-                  basename:      collections-categories
-                  ext:           .html
-                  -->
                 <li><a href="example.html">example.html</a></li>
                   <!--
                   "this"
@@ -1072,7 +570,263 @@
                   basename:      example
                   ext:           .html
                   -->
-                <li><a href="gist-helper.html">gist-helper.html</a></li>
+<li><a href="alert.html">alert.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/alert.hbs
+                  this.dest:     test/actual/paths/alert.html
+                  this.dirname:  test/actual/paths
+                  this.filename: alert.html
+                  this.pagename: alert.html
+                  this.basename: alert
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/paths/yfm.html
+                  page.dirname:  test/actual/paths
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/alert.hbs
+                  dest:          test/actual/paths/alert.html
+                  dirname:       test/actual/paths
+                  filename:      alert.html
+                  pagename:      alert.html
+                  basename:      alert
+                  ext:           .html
+                  -->
+<li><a href="collections-pages.html">collections-pages.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-pages.hbs
+                  this.dest:     test/actual/paths/collections-pages.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-pages.html
+                  this.pagename: collections-pages.html
+                  this.basename: collections-pages
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/paths/yfm.html
+                  page.dirname:  test/actual/paths
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-pages.hbs
+                  dest:          test/actual/paths/collections-pages.html
+                  dirname:       test/actual/paths
+                  filename:      collections-pages.html
+                  pagename:      collections-pages.html
+                  basename:      collections-pages
+                  ext:           .html
+                  -->
+<li><a href="collections-tags.html">collections-tags.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-tags.hbs
+                  this.dest:     test/actual/paths/collections-tags.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-tags.html
+                  this.pagename: collections-tags.html
+                  this.basename: collections-tags
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/paths/yfm.html
+                  page.dirname:  test/actual/paths
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-tags.hbs
+                  dest:          test/actual/paths/collections-tags.html
+                  dirname:       test/actual/paths
+                  filename:      collections-tags.html
+                  pagename:      collections-tags.html
+                  basename:      collections-tags
+                  ext:           .html
+                  -->
+<li><a href="collections.html">collections.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections.hbs
+                  this.dest:     test/actual/paths/collections.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections.html
+                  this.pagename: collections.html
+                  this.basename: collections
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/paths/yfm.html
+                  page.dirname:  test/actual/paths
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections.hbs
+                  dest:          test/actual/paths/collections.html
+                  dirname:       test/actual/paths
+                  filename:      collections.html
+                  pagename:      collections.html
+                  basename:      collections
+                  ext:           .html
+                  -->
+<li><a href="complex.html">complex.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/complex.hbs
+                  this.dest:     test/actual/paths/complex.html
+                  this.dirname:  test/actual/paths
+                  this.filename: complex.html
+                  this.pagename: complex.html
+                  this.basename: complex
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/paths/yfm.html
+                  page.dirname:  test/actual/paths
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/complex.hbs
+                  dest:          test/actual/paths/complex.html
+                  dirname:       test/actual/paths
+                  filename:      complex.html
+                  pagename:      complex.html
+                  basename:      complex
+                  ext:           .html
+                  -->
+<li><a href="context.html">context.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/context.hbs
+                  this.dest:     test/actual/paths/context.html
+                  this.dirname:  test/actual/paths
+                  this.filename: context.html
+                  this.pagename: context.html
+                  this.basename: context
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/paths/yfm.html
+                  page.dirname:  test/actual/paths
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/context.hbs
+                  dest:          test/actual/paths/context.html
+                  dirname:       test/actual/paths
+                  filename:      context.html
+                  pagename:      context.html
+                  basename:      context
+                  ext:           .html
+                  -->
+<li><a href="debug-helpers.html">debug-helpers.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/debug-helpers.hbs
+                  this.dest:     test/actual/paths/debug-helpers.html
+                  this.dirname:  test/actual/paths
+                  this.filename: debug-helpers.html
+                  this.pagename: debug-helpers.html
+                  this.basename: debug-helpers
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/paths/yfm.html
+                  page.dirname:  test/actual/paths
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/debug-helpers.hbs
+                  dest:          test/actual/paths/debug-helpers.html
+                  dirname:       test/actual/paths
+                  filename:      debug-helpers.html
+                  pagename:      debug-helpers.html
+                  basename:      debug-helpers
+                  ext:           .html
+                  -->
+<li><a href="collections-categories.html">collections-categories.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/collections-categories.hbs
+                  this.dest:     test/actual/paths/collections-categories.html
+                  this.dirname:  test/actual/paths
+                  this.filename: collections-categories.html
+                  this.pagename: collections-categories.html
+                  this.basename: collections-categories
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/paths/yfm.html
+                  page.dirname:  test/actual/paths
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/collections-categories.hbs
+                  dest:          test/actual/paths/collections-categories.html
+                  dirname:       test/actual/paths
+                  filename:      collections-categories.html
+                  pagename:      collections-categories.html
+                  basename:      collections-categories
+                  ext:           .html
+                  -->
+<li><a href="gist-helper.html">gist-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1104,7 +858,7 @@
                   basename:      gist-helper
                   ext:           .html
                   -->
-                <li><a href="lodash.html">lodash.html</a></li>
+<li><a href="lodash.html">lodash.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1136,7 +890,7 @@
                   basename:      lodash
                   ext:           .html
                   -->
-                <li><a href="md-helper.html">md-helper.html</a></li>
+<li><a href="md-helper.html">md-helper.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1168,7 +922,39 @@
                   basename:      md-helper
                   ext:           .html
                   -->
-                <li><a href="no-yfm.html">no-yfm.html</a></li>
+<li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:      test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:     test/actual/paths/no-yfm-data.html
+                  this.dirname:  test/actual/paths
+                  this.filename: no-yfm-data.html
+                  this.pagename: no-yfm-data.html
+                  this.basename: no-yfm-data
+                  this.ext:      .html
+
+                  "page"
+                  ===============================
+                  page.src:      test/fixtures/pages/yfm.hbs
+                  page.dest:     test/actual/paths/yfm.html
+                  page.dirname:  test/actual/paths
+                  page.filename: yfm.html
+                  page.pagename: yfm.html
+                  page.basename: yfm
+                  page.ext:      .html
+
+                  "root"
+                  ===============================
+                  src:           test/fixtures/pages/no-yfm-data.hbs
+                  dest:          test/actual/paths/no-yfm-data.html
+                  dirname:       test/actual/paths
+                  filename:      no-yfm-data.html
+                  pagename:      no-yfm-data.html
+                  basename:      no-yfm-data
+                  ext:           .html
+                  -->
+<li><a href="no-yfm.html">no-yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1200,7 +986,7 @@
                   basename:      no-yfm
                   ext:           .html
                   -->
-                <li><a href="yfm-context.html">yfm-context.html</a></li>
+<li><a href="yfm-context.html">yfm-context.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1232,7 +1018,7 @@
                   basename:      yfm-context
                   ext:           .html
                   -->
-                <li><a href="yfm.html">yfm.html</a></li>
+<li><a href="yfm.html">yfm.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1264,7 +1050,6 @@
                   basename:      yfm
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1299,6 +1084,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1314,7 +1100,7 @@
   "filename": "yfm.html",
   "first": false,
   "foo": "bar",
-  "index": 14,
+  "index": 15,
   "isCurrentPage": false,
   "items": [
     "alpha",
@@ -1322,11 +1108,11 @@
   ],
   "last": true,
   "middle": false,
-  "number": 15,
+  "number": 16,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n\n<div class=\"alert alert-info\">This is an alert</div>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "yfm.html",
   "pagename": "yfm.html",
-  "prev": 13,
+  "prev": 14,
   "relativeLink": "yfm.html",
   "src": "test/fixtures/pages/yfm.hbs",
   "title": "YFM"

--- a/test/actual/plugin_preprocess/alert.html
+++ b/test/actual/plugin_preprocess/alert.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
-      <a href="debug-helpers.html">&larr; Previous</a>
+      <a href="example.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="collections-pages.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
-      <a href="debug-helpers.html">&larr; Previous</a>
+      <a href="example.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="active">
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="collections-pages.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,286 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">components</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">components</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">2</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">2</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -718,37 +482,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -757,19 +506,19 @@
               <h1>Page</h1>
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html" class="">debug-helpers</a></li>
+                <li><a href="example.html" class="">example</a></li>
                   <!--
                   "this"
                   ===============================
-                  this.src:           test/fixtures/pages/debug-helpers.hbs
-                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  this.src:           test/fixtures/pages/example.hbs
+                  this.dest:          test/actual/plugin_preprocess/example.html
                   this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      debug-helpers.html
-                  this.pagename:      debug-helpers.html
-                  this.basename:      debug-helpers
+                  this.filename:      example.html
+                  this.pagename:      example.html
+                  this.basename:      example
                   this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  debug-helpers.html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  example.html
 
                   "page"
                   ===============================
@@ -780,22 +529,22 @@
                   page.pagename:      alert.html
                   page.basename:      alert
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  alert.html
 
                   "root"
                   ===============================
-                  src:                test/fixtures/pages/debug-helpers.hbs
-                  dest:               test/actual/plugin_preprocess/debug-helpers.html
+                  src:                test/fixtures/pages/example.hbs
+                  dest:               test/actual/plugin_preprocess/example.html
                   dirname:            test/actual/plugin_preprocess
-                  filename:           debug-helpers.html
-                  pagename:           debug-helpers.html
-                  basename:           debug-helpers
+                  filename:           example.html
+                  pagename:           example.html
+                  basename:           example
                   ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       debug-helpers.html
+                  isCurrentPage:           false
+                  relativeLink:       example.html
                   -->
-                <li><a href="alert.html" class="active">alert</a></li>
+<li><a href="alert.html" class="active">alert</a></li>
                   <!--
                   "this"
                   ===============================
@@ -818,7 +567,7 @@
                   page.pagename:      alert.html
                   page.basename:      alert
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  alert.html
 
                   "root"
@@ -833,7 +582,7 @@
                   isCurrentPage:           true
                   relativeLink:       alert.html
                   -->
-                <li><a href="collections-pages.html" class="">collections-pages</a></li>
+<li><a href="collections-pages.html" class="">collections-pages</a></li>
                   <!--
                   "this"
                   ===============================
@@ -844,7 +593,7 @@
                   this.pagename:      collections-pages.html
                   this.basename:      collections-pages
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections-pages.html
 
                   "page"
@@ -856,7 +605,7 @@
                   page.pagename:      alert.html
                   page.basename:      alert
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  alert.html
 
                   "root"
@@ -868,10 +617,10 @@
                   pagename:           collections-pages.html
                   basename:           collections-pages
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections-pages.html
                   -->
-                <li><a href="collections-tags.html" class="">collections-tags</a></li>
+<li><a href="collections-tags.html" class="">collections-tags</a></li>
                   <!--
                   "this"
                   ===============================
@@ -882,7 +631,7 @@
                   this.pagename:      collections-tags.html
                   this.basename:      collections-tags
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections-tags.html
 
                   "page"
@@ -894,7 +643,7 @@
                   page.pagename:      alert.html
                   page.basename:      alert
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  alert.html
 
                   "root"
@@ -906,10 +655,10 @@
                   pagename:           collections-tags.html
                   basename:           collections-tags
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections-tags.html
                   -->
-                <li><a href="collections.html" class="">collections</a></li>
+<li><a href="collections.html" class="">collections</a></li>
                   <!--
                   "this"
                   ===============================
@@ -920,7 +669,7 @@
                   this.pagename:      collections.html
                   this.basename:      collections
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections.html
 
                   "page"
@@ -932,7 +681,7 @@
                   page.pagename:      alert.html
                   page.basename:      alert
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  alert.html
 
                   "root"
@@ -944,10 +693,10 @@
                   pagename:           collections.html
                   basename:           collections
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections.html
                   -->
-                <li><a href="complex.html" class="">complex</a></li>
+<li><a href="complex.html" class="">complex</a></li>
                   <!--
                   "this"
                   ===============================
@@ -958,7 +707,7 @@
                   this.pagename:      complex.html
                   this.basename:      complex
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  complex.html
 
                   "page"
@@ -970,7 +719,7 @@
                   page.pagename:      alert.html
                   page.basename:      alert
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  alert.html
 
                   "root"
@@ -982,10 +731,10 @@
                   pagename:           complex.html
                   basename:           complex
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       complex.html
                   -->
-                <li><a href="context.html" class="">context</a></li>
+<li><a href="context.html" class="">context</a></li>
                   <!--
                   "this"
                   ===============================
@@ -996,7 +745,7 @@
                   this.pagename:      context.html
                   this.basename:      context
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  context.html
 
                   "page"
@@ -1008,7 +757,7 @@
                   page.pagename:      alert.html
                   page.basename:      alert
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  alert.html
 
                   "root"
@@ -1020,10 +769,48 @@
                   pagename:           context.html
                   basename:           context
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       context.html
                   -->
-                <li><a href="collections-categories.html" class="">collections-categories</a></li>
+<li><a href="debug-helpers.html" class="">debug-helpers</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/debug-helpers.hbs
+                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      debug-helpers.html
+                  this.pagename:      debug-helpers.html
+                  this.basename:      debug-helpers
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  debug-helpers.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/alert.hbs
+                  page.dest:          test/actual/plugin_preprocess/alert.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      alert.html
+                  page.pagename:      alert.html
+                  page.basename:      alert
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  alert.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/debug-helpers.hbs
+                  dest:               test/actual/plugin_preprocess/debug-helpers.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           debug-helpers.html
+                  pagename:           debug-helpers.html
+                  basename:           debug-helpers
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       debug-helpers.html
+                  -->
+<li><a href="collections-categories.html" class="">collections-categories</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1034,7 +821,7 @@
                   this.pagename:      collections-categories.html
                   this.basename:      collections-categories
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections-categories.html
 
                   "page"
@@ -1046,7 +833,7 @@
                   page.pagename:      alert.html
                   page.basename:      alert
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  alert.html
 
                   "root"
@@ -1058,48 +845,10 @@
                   pagename:           collections-categories.html
                   basename:           collections-categories
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections-categories.html
                   -->
-                <li><a href="example.html" class="">example</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/example.hbs
-                  this.dest:          test/actual/plugin_preprocess/example.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      example.html
-                  this.pagename:      example.html
-                  this.basename:      example
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  example.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/alert.hbs
-                  page.dest:          test/actual/plugin_preprocess/alert.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      alert.html
-                  page.pagename:      alert.html
-                  page.basename:      alert
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  alert.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/example.hbs
-                  dest:               test/actual/plugin_preprocess/example.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           example.html
-                  pagename:           example.html
-                  basename:           example
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       example.html
-                  -->
-                <li><a href="gist-helper.html" class="">gist-helper</a></li>
+<li><a href="gist-helper.html" class="">gist-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1110,7 +859,7 @@
                   this.pagename:      gist-helper.html
                   this.basename:      gist-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  gist-helper.html
 
                   "page"
@@ -1122,7 +871,7 @@
                   page.pagename:      alert.html
                   page.basename:      alert
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  alert.html
 
                   "root"
@@ -1134,10 +883,10 @@
                   pagename:           gist-helper.html
                   basename:           gist-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       gist-helper.html
                   -->
-                <li><a href="lodash.html" class="">lodash</a></li>
+<li><a href="lodash.html" class="">lodash</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1148,7 +897,7 @@
                   this.pagename:      lodash.html
                   this.basename:      lodash
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  lodash.html
 
                   "page"
@@ -1160,7 +909,7 @@
                   page.pagename:      alert.html
                   page.basename:      alert
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  alert.html
 
                   "root"
@@ -1172,10 +921,10 @@
                   pagename:           lodash.html
                   basename:           lodash
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       lodash.html
                   -->
-                <li><a href="md-helper.html" class="">md-helper</a></li>
+<li><a href="md-helper.html" class="">md-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1186,7 +935,7 @@
                   this.pagename:      md-helper.html
                   this.basename:      md-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  md-helper.html
 
                   "page"
@@ -1198,7 +947,7 @@
                   page.pagename:      alert.html
                   page.basename:      alert
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  alert.html
 
                   "root"
@@ -1210,10 +959,48 @@
                   pagename:           md-helper.html
                   basename:           md-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       md-helper.html
                   -->
-                <li><a href="no-yfm.html" class="">no-yfm</a></li>
+<li><a href="no-yfm-data.html" class="">no-yfm-data</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      no-yfm-data.html
+                  this.pagename:      no-yfm-data.html
+                  this.basename:      no-yfm-data
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  no-yfm-data.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/alert.hbs
+                  page.dest:          test/actual/plugin_preprocess/alert.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      alert.html
+                  page.pagename:      alert.html
+                  page.basename:      alert
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  alert.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/no-yfm-data.hbs
+                  dest:               test/actual/plugin_preprocess/no-yfm-data.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           no-yfm-data.html
+                  pagename:           no-yfm-data.html
+                  basename:           no-yfm-data
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       no-yfm-data.html
+                  -->
+<li><a href="no-yfm.html" class="">no-yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1224,7 +1011,7 @@
                   this.pagename:      no-yfm.html
                   this.basename:      no-yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  no-yfm.html
 
                   "page"
@@ -1236,7 +1023,7 @@
                   page.pagename:      alert.html
                   page.basename:      alert
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  alert.html
 
                   "root"
@@ -1248,10 +1035,10 @@
                   pagename:           no-yfm.html
                   basename:           no-yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       no-yfm.html
                   -->
-                <li><a href="yfm-context.html" class="">yfm-context</a></li>
+<li><a href="yfm-context.html" class="">yfm-context</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1262,7 +1049,7 @@
                   this.pagename:      yfm-context.html
                   this.basename:      yfm-context
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm-context.html
 
                   "page"
@@ -1274,7 +1061,7 @@
                   page.pagename:      alert.html
                   page.basename:      alert
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  alert.html
 
                   "root"
@@ -1286,10 +1073,10 @@
                   pagename:           yfm-context.html
                   basename:           yfm-context
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm-context.html
                   -->
-                <li><a href="yfm.html" class="">yfm</a></li>
+<li><a href="yfm.html" class="">yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1300,7 +1087,7 @@
                   this.pagename:      yfm.html
                   this.basename:      yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm.html
 
                   "page"
@@ -1312,7 +1099,7 @@
                   page.pagename:      alert.html
                   page.basename:      alert
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  alert.html
 
                   "root"
@@ -1324,10 +1111,9 @@
                   pagename:           yfm.html
                   basename:           yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm.html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1374,6 +1160,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/plugin_preprocess/collections-categories.html
+++ b/test/actual/plugin_preprocess/collections-categories.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
-      <a href="context.html">&larr; Previous</a>
+      <a href="debug-helpers.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
-    <li class="active pager-middle">
-      <a href="collections-categories.html">8</a>
-    </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
+    <li class="active pager-middle">
+      <a href="collections-categories.html">9</a>
+    </li>
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="example.html">Next &rarr;</a>
+      <a href="gist-helper.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
-      <a href="context.html">&larr; Previous</a>
+      <a href="debug-helpers.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
-    <li class="active">
-      <a href="collections-categories.html">8</a>
-    </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
+    <li class="active">
+      <a href="collections-categories.html">9</a>
+    </li>
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="example.html">Next &rarr;</a>
+      <a href="gist-helper.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,496 +187,292 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">5</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">three</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">5</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">three</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">4</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">categories</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">pages</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">4</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">categories</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">pages</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -726,33 +484,19 @@
     <h4>Categories</h4>
   </div>
   <div class="panel-body">
-  
     <span class="label label-info">categories</span>
-  
     <span class="label label-info">collections</span>
-  
     <span class="label label-info">components</span>
-  
     <span class="label label-info">context</span>
-  
     <span class="label label-info">fixtures</span>
-  
     <span class="label label-info">helper</span>
-  
     <span class="label label-info">markdown</span>
-  
     <span class="label label-info">one</span>
-  
     <span class="label label-info">pages</span>
-  
     <span class="label label-info">three</span>
-  
     <span class="label label-info">two</span>
-  
     <span class="label label-info">yaml</span>
-  
     <span class="label label-info">yfm</span>
-  
   </div>
 </div>
 
@@ -760,37 +504,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -799,19 +528,19 @@
               <h1>Page</h1>
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html" class="">debug-helpers</a></li>
+                <li><a href="example.html" class="">example</a></li>
                   <!--
                   "this"
                   ===============================
-                  this.src:           test/fixtures/pages/debug-helpers.hbs
-                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  this.src:           test/fixtures/pages/example.hbs
+                  this.dest:          test/actual/plugin_preprocess/example.html
                   this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      debug-helpers.html
-                  this.pagename:      debug-helpers.html
-                  this.basename:      debug-helpers
+                  this.filename:      example.html
+                  this.pagename:      example.html
+                  this.basename:      example
                   this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  debug-helpers.html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  example.html
 
                   "page"
                   ===============================
@@ -822,22 +551,22 @@
                   page.pagename:      collections-categories.html
                   page.basename:      collections-categories
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-categories.html
 
                   "root"
                   ===============================
-                  src:                test/fixtures/pages/debug-helpers.hbs
-                  dest:               test/actual/plugin_preprocess/debug-helpers.html
+                  src:                test/fixtures/pages/example.hbs
+                  dest:               test/actual/plugin_preprocess/example.html
                   dirname:            test/actual/plugin_preprocess
-                  filename:           debug-helpers.html
-                  pagename:           debug-helpers.html
-                  basename:           debug-helpers
+                  filename:           example.html
+                  pagename:           example.html
+                  basename:           example
                   ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       debug-helpers.html
+                  isCurrentPage:           false
+                  relativeLink:       example.html
                   -->
-                <li><a href="alert.html" class="">alert</a></li>
+<li><a href="alert.html" class="">alert</a></li>
                   <!--
                   "this"
                   ===============================
@@ -848,7 +577,7 @@
                   this.pagename:      alert.html
                   this.basename:      alert
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  alert.html
 
                   "page"
@@ -860,7 +589,7 @@
                   page.pagename:      collections-categories.html
                   page.basename:      collections-categories
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-categories.html
 
                   "root"
@@ -872,10 +601,10 @@
                   pagename:           alert.html
                   basename:           alert
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       alert.html
                   -->
-                <li><a href="collections-pages.html" class="">collections-pages</a></li>
+<li><a href="collections-pages.html" class="">collections-pages</a></li>
                   <!--
                   "this"
                   ===============================
@@ -886,7 +615,7 @@
                   this.pagename:      collections-pages.html
                   this.basename:      collections-pages
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections-pages.html
 
                   "page"
@@ -898,7 +627,7 @@
                   page.pagename:      collections-categories.html
                   page.basename:      collections-categories
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-categories.html
 
                   "root"
@@ -910,10 +639,10 @@
                   pagename:           collections-pages.html
                   basename:           collections-pages
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections-pages.html
                   -->
-                <li><a href="collections-tags.html" class="">collections-tags</a></li>
+<li><a href="collections-tags.html" class="">collections-tags</a></li>
                   <!--
                   "this"
                   ===============================
@@ -924,7 +653,7 @@
                   this.pagename:      collections-tags.html
                   this.basename:      collections-tags
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections-tags.html
 
                   "page"
@@ -936,7 +665,7 @@
                   page.pagename:      collections-categories.html
                   page.basename:      collections-categories
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-categories.html
 
                   "root"
@@ -948,10 +677,10 @@
                   pagename:           collections-tags.html
                   basename:           collections-tags
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections-tags.html
                   -->
-                <li><a href="collections.html" class="">collections</a></li>
+<li><a href="collections.html" class="">collections</a></li>
                   <!--
                   "this"
                   ===============================
@@ -962,7 +691,7 @@
                   this.pagename:      collections.html
                   this.basename:      collections
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections.html
 
                   "page"
@@ -974,7 +703,7 @@
                   page.pagename:      collections-categories.html
                   page.basename:      collections-categories
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-categories.html
 
                   "root"
@@ -986,10 +715,10 @@
                   pagename:           collections.html
                   basename:           collections
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections.html
                   -->
-                <li><a href="complex.html" class="">complex</a></li>
+<li><a href="complex.html" class="">complex</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1000,7 +729,7 @@
                   this.pagename:      complex.html
                   this.basename:      complex
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  complex.html
 
                   "page"
@@ -1012,7 +741,7 @@
                   page.pagename:      collections-categories.html
                   page.basename:      collections-categories
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-categories.html
 
                   "root"
@@ -1024,10 +753,10 @@
                   pagename:           complex.html
                   basename:           complex
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       complex.html
                   -->
-                <li><a href="context.html" class="">context</a></li>
+<li><a href="context.html" class="">context</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1038,7 +767,7 @@
                   this.pagename:      context.html
                   this.basename:      context
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  context.html
 
                   "page"
@@ -1050,7 +779,7 @@
                   page.pagename:      collections-categories.html
                   page.basename:      collections-categories
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-categories.html
 
                   "root"
@@ -1062,10 +791,48 @@
                   pagename:           context.html
                   basename:           context
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       context.html
                   -->
-                <li><a href="collections-categories.html" class="active">collections-categories</a></li>
+<li><a href="debug-helpers.html" class="">debug-helpers</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/debug-helpers.hbs
+                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      debug-helpers.html
+                  this.pagename:      debug-helpers.html
+                  this.basename:      debug-helpers
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  debug-helpers.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/collections-categories.hbs
+                  page.dest:          test/actual/plugin_preprocess/collections-categories.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      collections-categories.html
+                  page.pagename:      collections-categories.html
+                  page.basename:      collections-categories
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  collections-categories.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/debug-helpers.hbs
+                  dest:               test/actual/plugin_preprocess/debug-helpers.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           debug-helpers.html
+                  pagename:           debug-helpers.html
+                  basename:           debug-helpers
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       debug-helpers.html
+                  -->
+<li><a href="collections-categories.html" class="active">collections-categories</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1088,7 +855,7 @@
                   page.pagename:      collections-categories.html
                   page.basename:      collections-categories
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-categories.html
 
                   "root"
@@ -1103,45 +870,7 @@
                   isCurrentPage:           true
                   relativeLink:       collections-categories.html
                   -->
-                <li><a href="example.html" class="">example</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/example.hbs
-                  this.dest:          test/actual/plugin_preprocess/example.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      example.html
-                  this.pagename:      example.html
-                  this.basename:      example
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  example.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/collections-categories.hbs
-                  page.dest:          test/actual/plugin_preprocess/collections-categories.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      collections-categories.html
-                  page.pagename:      collections-categories.html
-                  page.basename:      collections-categories
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  collections-categories.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/example.hbs
-                  dest:               test/actual/plugin_preprocess/example.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           example.html
-                  pagename:           example.html
-                  basename:           example
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       example.html
-                  -->
-                <li><a href="gist-helper.html" class="">gist-helper</a></li>
+<li><a href="gist-helper.html" class="">gist-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1152,7 +881,7 @@
                   this.pagename:      gist-helper.html
                   this.basename:      gist-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  gist-helper.html
 
                   "page"
@@ -1164,7 +893,7 @@
                   page.pagename:      collections-categories.html
                   page.basename:      collections-categories
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-categories.html
 
                   "root"
@@ -1176,10 +905,10 @@
                   pagename:           gist-helper.html
                   basename:           gist-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       gist-helper.html
                   -->
-                <li><a href="lodash.html" class="">lodash</a></li>
+<li><a href="lodash.html" class="">lodash</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1190,7 +919,7 @@
                   this.pagename:      lodash.html
                   this.basename:      lodash
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  lodash.html
 
                   "page"
@@ -1202,7 +931,7 @@
                   page.pagename:      collections-categories.html
                   page.basename:      collections-categories
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-categories.html
 
                   "root"
@@ -1214,10 +943,10 @@
                   pagename:           lodash.html
                   basename:           lodash
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       lodash.html
                   -->
-                <li><a href="md-helper.html" class="">md-helper</a></li>
+<li><a href="md-helper.html" class="">md-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1228,7 +957,7 @@
                   this.pagename:      md-helper.html
                   this.basename:      md-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  md-helper.html
 
                   "page"
@@ -1240,7 +969,7 @@
                   page.pagename:      collections-categories.html
                   page.basename:      collections-categories
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-categories.html
 
                   "root"
@@ -1252,10 +981,48 @@
                   pagename:           md-helper.html
                   basename:           md-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       md-helper.html
                   -->
-                <li><a href="no-yfm.html" class="">no-yfm</a></li>
+<li><a href="no-yfm-data.html" class="">no-yfm-data</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      no-yfm-data.html
+                  this.pagename:      no-yfm-data.html
+                  this.basename:      no-yfm-data
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  no-yfm-data.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/collections-categories.hbs
+                  page.dest:          test/actual/plugin_preprocess/collections-categories.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      collections-categories.html
+                  page.pagename:      collections-categories.html
+                  page.basename:      collections-categories
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  collections-categories.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/no-yfm-data.hbs
+                  dest:               test/actual/plugin_preprocess/no-yfm-data.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           no-yfm-data.html
+                  pagename:           no-yfm-data.html
+                  basename:           no-yfm-data
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       no-yfm-data.html
+                  -->
+<li><a href="no-yfm.html" class="">no-yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1266,7 +1033,7 @@
                   this.pagename:      no-yfm.html
                   this.basename:      no-yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  no-yfm.html
 
                   "page"
@@ -1278,7 +1045,7 @@
                   page.pagename:      collections-categories.html
                   page.basename:      collections-categories
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-categories.html
 
                   "root"
@@ -1290,10 +1057,10 @@
                   pagename:           no-yfm.html
                   basename:           no-yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       no-yfm.html
                   -->
-                <li><a href="yfm-context.html" class="">yfm-context</a></li>
+<li><a href="yfm-context.html" class="">yfm-context</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1304,7 +1071,7 @@
                   this.pagename:      yfm-context.html
                   this.basename:      yfm-context
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm-context.html
 
                   "page"
@@ -1316,7 +1083,7 @@
                   page.pagename:      collections-categories.html
                   page.basename:      collections-categories
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-categories.html
 
                   "root"
@@ -1328,10 +1095,10 @@
                   pagename:           yfm-context.html
                   basename:           yfm-context
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm-context.html
                   -->
-                <li><a href="yfm.html" class="">yfm</a></li>
+<li><a href="yfm.html" class="">yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1342,7 +1109,7 @@
                   this.pagename:      yfm.html
                   this.basename:      yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm.html
 
                   "page"
@@ -1354,7 +1121,7 @@
                   page.pagename:      collections-categories.html
                   page.basename:      collections-categories
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-categories.html
 
                   "root"
@@ -1366,10 +1133,9 @@
                   pagename:           yfm.html
                   basename:           yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm.html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1414,6 +1180,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1428,16 +1195,16 @@
   },
   "filename": "collections-categories.html",
   "first": false,
-  "index": 7,
+  "index": 8,
   "isCurrentPage": false,
   "last": false,
   "middle": true,
-  "next": 8,
-  "number": 8,
+  "next": 9,
+  "number": 9,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n<div class=\"panel panel-info\">\n  <div class=\"panel-heading\">\n    <h4>Categories</h4>\n  </div>\n  <div class=\"panel-body\">\n  {{#categories}}\n    <span class=\"label label-info\">{{category}}</span>\n  {{/categories}}\n  </div>\n</div>\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relative ../page.dest dest}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\" class=\"{{#isCurrentPage}}active{{/isCurrentPage}}\">{{basename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:           {{this.src}}\n                  this.dest:          {{this.dest}}\n                  this.dirname:       {{this.dirname}}\n                  this.filename:      {{this.filename}}\n                  this.pagename:      {{this.pagename}}\n                  this.basename:      {{this.basename}}\n                  this.ext:           {{this.ext}}\n                  this.isCurrentPage:      {{this.isCurrentPage}}\n                  this.relativeLink:  {{this.relativeLink}}\n\n                  \"page\"\n                  ===============================\n                  page.src:           {{../page.src}}\n                  page.dest:          {{../page.dest}}\n                  page.dirname:       {{../page.dirname}}\n                  page.filename:      {{../page.filename}}\n                  page.pagename:      {{../page.pagename}}\n                  page.basename:      {{../page.basename}}\n                  page.ext:           {{../page.ext}}\n                  page.isCurrentPage:      {{../page.isCurrentPage}}\n                  page.relativeLink:  {{../page.relativeLink}}\n\n                  \"root\"\n                  ===============================\n                  src:                {{src}}\n                  dest:               {{dest}}\n                  dirname:            {{dirname}}\n                  filename:           {{filename}}\n                  pagename:           {{pagename}}\n                  basename:           {{basename}}\n                  ext:                {{ext}}\n                  isCurrentPage:           {{isCurrentPage}}\n                  relativeLink:       {{relativeLink}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "collections-categories.html",
   "pagename": "collections-categories.html",
-  "prev": 6,
+  "prev": 7,
   "relativeLink": "collections-categories.html",
   "src": "test/fixtures/pages/collections-categories.hbs",
   "tags": [

--- a/test/actual/plugin_preprocess/collections-pages.html
+++ b/test/actual/plugin_preprocess/collections-pages.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="alert.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="collections-tags.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="alert.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li class="active">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="collections-tags.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,480 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">pages</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">pages</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -710,37 +477,22 @@
     <h4>Pages Collection</h4>
   </div>
   <div class="panel-body">
-    
-      <a href="#">Debug Helper</a>
-    
-      <a href="#">Title for "alert.hbs"</a>
-    
-      <a href="#">Pages Collection</a>
-    
-      <a href="#">Tags Test</a>
-    
-      <a href="#">Collections</a>
-    
-      <a href="#">Complex YFM</a>
-    
-      <a href="#">Context</a>
-    
-      <a href="#">Collections Categories</a>
-    
       <a href="#">Title from YFM of "example.hbs"</a>
-    
+      <a href="#">Title for "alert.hbs"</a>
+      <a href="#">Pages Collection</a>
+      <a href="#">Tags Test</a>
+      <a href="#">Collections</a>
+      <a href="#">Complex YFM</a>
+      <a href="#">Context</a>
+      <a href="#">Debug Helper</a>
+      <a href="#">Collections Categories</a>
       <a href="#">Gist Helper</a>
-    
       <a href="#"><%= site.title %></a>
-    
       <a href="#">md helper</a>
-    
       <a href="#"></a>
-    
+      <a href="#"></a>
       <a href="#">This title is from the YFM of the current page</a>
-    
       <a href="#">YFM</a>
-    
   </div>
 </div>
 
@@ -748,37 +500,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -787,19 +524,19 @@
               <h1>Page</h1>
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html" class="">debug-helpers</a></li>
+                <li><a href="example.html" class="">example</a></li>
                   <!--
                   "this"
                   ===============================
-                  this.src:           test/fixtures/pages/debug-helpers.hbs
-                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  this.src:           test/fixtures/pages/example.hbs
+                  this.dest:          test/actual/plugin_preprocess/example.html
                   this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      debug-helpers.html
-                  this.pagename:      debug-helpers.html
-                  this.basename:      debug-helpers
+                  this.filename:      example.html
+                  this.pagename:      example.html
+                  this.basename:      example
                   this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  debug-helpers.html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  example.html
 
                   "page"
                   ===============================
@@ -810,22 +547,22 @@
                   page.pagename:      collections-pages.html
                   page.basename:      collections-pages
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-pages.html
 
                   "root"
                   ===============================
-                  src:                test/fixtures/pages/debug-helpers.hbs
-                  dest:               test/actual/plugin_preprocess/debug-helpers.html
+                  src:                test/fixtures/pages/example.hbs
+                  dest:               test/actual/plugin_preprocess/example.html
                   dirname:            test/actual/plugin_preprocess
-                  filename:           debug-helpers.html
-                  pagename:           debug-helpers.html
-                  basename:           debug-helpers
+                  filename:           example.html
+                  pagename:           example.html
+                  basename:           example
                   ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       debug-helpers.html
+                  isCurrentPage:           false
+                  relativeLink:       example.html
                   -->
-                <li><a href="alert.html" class="">alert</a></li>
+<li><a href="alert.html" class="">alert</a></li>
                   <!--
                   "this"
                   ===============================
@@ -836,7 +573,7 @@
                   this.pagename:      alert.html
                   this.basename:      alert
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  alert.html
 
                   "page"
@@ -848,7 +585,7 @@
                   page.pagename:      collections-pages.html
                   page.basename:      collections-pages
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-pages.html
 
                   "root"
@@ -860,10 +597,10 @@
                   pagename:           alert.html
                   basename:           alert
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       alert.html
                   -->
-                <li><a href="collections-pages.html" class="active">collections-pages</a></li>
+<li><a href="collections-pages.html" class="active">collections-pages</a></li>
                   <!--
                   "this"
                   ===============================
@@ -886,7 +623,7 @@
                   page.pagename:      collections-pages.html
                   page.basename:      collections-pages
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-pages.html
 
                   "root"
@@ -901,7 +638,7 @@
                   isCurrentPage:           true
                   relativeLink:       collections-pages.html
                   -->
-                <li><a href="collections-tags.html" class="">collections-tags</a></li>
+<li><a href="collections-tags.html" class="">collections-tags</a></li>
                   <!--
                   "this"
                   ===============================
@@ -912,7 +649,7 @@
                   this.pagename:      collections-tags.html
                   this.basename:      collections-tags
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections-tags.html
 
                   "page"
@@ -924,7 +661,7 @@
                   page.pagename:      collections-pages.html
                   page.basename:      collections-pages
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-pages.html
 
                   "root"
@@ -936,10 +673,10 @@
                   pagename:           collections-tags.html
                   basename:           collections-tags
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections-tags.html
                   -->
-                <li><a href="collections.html" class="">collections</a></li>
+<li><a href="collections.html" class="">collections</a></li>
                   <!--
                   "this"
                   ===============================
@@ -950,7 +687,7 @@
                   this.pagename:      collections.html
                   this.basename:      collections
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections.html
 
                   "page"
@@ -962,7 +699,7 @@
                   page.pagename:      collections-pages.html
                   page.basename:      collections-pages
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-pages.html
 
                   "root"
@@ -974,10 +711,10 @@
                   pagename:           collections.html
                   basename:           collections
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections.html
                   -->
-                <li><a href="complex.html" class="">complex</a></li>
+<li><a href="complex.html" class="">complex</a></li>
                   <!--
                   "this"
                   ===============================
@@ -988,7 +725,7 @@
                   this.pagename:      complex.html
                   this.basename:      complex
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  complex.html
 
                   "page"
@@ -1000,7 +737,7 @@
                   page.pagename:      collections-pages.html
                   page.basename:      collections-pages
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-pages.html
 
                   "root"
@@ -1012,10 +749,10 @@
                   pagename:           complex.html
                   basename:           complex
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       complex.html
                   -->
-                <li><a href="context.html" class="">context</a></li>
+<li><a href="context.html" class="">context</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1026,7 +763,7 @@
                   this.pagename:      context.html
                   this.basename:      context
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  context.html
 
                   "page"
@@ -1038,7 +775,7 @@
                   page.pagename:      collections-pages.html
                   page.basename:      collections-pages
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-pages.html
 
                   "root"
@@ -1050,10 +787,48 @@
                   pagename:           context.html
                   basename:           context
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       context.html
                   -->
-                <li><a href="collections-categories.html" class="">collections-categories</a></li>
+<li><a href="debug-helpers.html" class="">debug-helpers</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/debug-helpers.hbs
+                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      debug-helpers.html
+                  this.pagename:      debug-helpers.html
+                  this.basename:      debug-helpers
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  debug-helpers.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/collections-pages.hbs
+                  page.dest:          test/actual/plugin_preprocess/collections-pages.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      collections-pages.html
+                  page.pagename:      collections-pages.html
+                  page.basename:      collections-pages
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  collections-pages.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/debug-helpers.hbs
+                  dest:               test/actual/plugin_preprocess/debug-helpers.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           debug-helpers.html
+                  pagename:           debug-helpers.html
+                  basename:           debug-helpers
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       debug-helpers.html
+                  -->
+<li><a href="collections-categories.html" class="">collections-categories</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1064,7 +839,7 @@
                   this.pagename:      collections-categories.html
                   this.basename:      collections-categories
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections-categories.html
 
                   "page"
@@ -1076,7 +851,7 @@
                   page.pagename:      collections-pages.html
                   page.basename:      collections-pages
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-pages.html
 
                   "root"
@@ -1088,48 +863,10 @@
                   pagename:           collections-categories.html
                   basename:           collections-categories
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections-categories.html
                   -->
-                <li><a href="example.html" class="">example</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/example.hbs
-                  this.dest:          test/actual/plugin_preprocess/example.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      example.html
-                  this.pagename:      example.html
-                  this.basename:      example
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  example.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/collections-pages.hbs
-                  page.dest:          test/actual/plugin_preprocess/collections-pages.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      collections-pages.html
-                  page.pagename:      collections-pages.html
-                  page.basename:      collections-pages
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  collections-pages.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/example.hbs
-                  dest:               test/actual/plugin_preprocess/example.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           example.html
-                  pagename:           example.html
-                  basename:           example
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       example.html
-                  -->
-                <li><a href="gist-helper.html" class="">gist-helper</a></li>
+<li><a href="gist-helper.html" class="">gist-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1140,7 +877,7 @@
                   this.pagename:      gist-helper.html
                   this.basename:      gist-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  gist-helper.html
 
                   "page"
@@ -1152,7 +889,7 @@
                   page.pagename:      collections-pages.html
                   page.basename:      collections-pages
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-pages.html
 
                   "root"
@@ -1164,10 +901,10 @@
                   pagename:           gist-helper.html
                   basename:           gist-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       gist-helper.html
                   -->
-                <li><a href="lodash.html" class="">lodash</a></li>
+<li><a href="lodash.html" class="">lodash</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1178,7 +915,7 @@
                   this.pagename:      lodash.html
                   this.basename:      lodash
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  lodash.html
 
                   "page"
@@ -1190,7 +927,7 @@
                   page.pagename:      collections-pages.html
                   page.basename:      collections-pages
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-pages.html
 
                   "root"
@@ -1202,10 +939,10 @@
                   pagename:           lodash.html
                   basename:           lodash
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       lodash.html
                   -->
-                <li><a href="md-helper.html" class="">md-helper</a></li>
+<li><a href="md-helper.html" class="">md-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1216,7 +953,7 @@
                   this.pagename:      md-helper.html
                   this.basename:      md-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  md-helper.html
 
                   "page"
@@ -1228,7 +965,7 @@
                   page.pagename:      collections-pages.html
                   page.basename:      collections-pages
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-pages.html
 
                   "root"
@@ -1240,10 +977,48 @@
                   pagename:           md-helper.html
                   basename:           md-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       md-helper.html
                   -->
-                <li><a href="no-yfm.html" class="">no-yfm</a></li>
+<li><a href="no-yfm-data.html" class="">no-yfm-data</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      no-yfm-data.html
+                  this.pagename:      no-yfm-data.html
+                  this.basename:      no-yfm-data
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  no-yfm-data.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/collections-pages.hbs
+                  page.dest:          test/actual/plugin_preprocess/collections-pages.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      collections-pages.html
+                  page.pagename:      collections-pages.html
+                  page.basename:      collections-pages
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  collections-pages.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/no-yfm-data.hbs
+                  dest:               test/actual/plugin_preprocess/no-yfm-data.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           no-yfm-data.html
+                  pagename:           no-yfm-data.html
+                  basename:           no-yfm-data
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       no-yfm-data.html
+                  -->
+<li><a href="no-yfm.html" class="">no-yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1254,7 +1029,7 @@
                   this.pagename:      no-yfm.html
                   this.basename:      no-yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  no-yfm.html
 
                   "page"
@@ -1266,7 +1041,7 @@
                   page.pagename:      collections-pages.html
                   page.basename:      collections-pages
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-pages.html
 
                   "root"
@@ -1278,10 +1053,10 @@
                   pagename:           no-yfm.html
                   basename:           no-yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       no-yfm.html
                   -->
-                <li><a href="yfm-context.html" class="">yfm-context</a></li>
+<li><a href="yfm-context.html" class="">yfm-context</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1292,7 +1067,7 @@
                   this.pagename:      yfm-context.html
                   this.basename:      yfm-context
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm-context.html
 
                   "page"
@@ -1304,7 +1079,7 @@
                   page.pagename:      collections-pages.html
                   page.basename:      collections-pages
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-pages.html
 
                   "root"
@@ -1316,10 +1091,10 @@
                   pagename:           yfm-context.html
                   basename:           yfm-context
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm-context.html
                   -->
-                <li><a href="yfm.html" class="">yfm</a></li>
+<li><a href="yfm.html" class="">yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1330,7 +1105,7 @@
                   this.pagename:      yfm.html
                   this.basename:      yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm.html
 
                   "page"
@@ -1342,7 +1117,7 @@
                   page.pagename:      collections-pages.html
                   page.basename:      collections-pages
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-pages.html
 
                   "root"
@@ -1354,10 +1129,9 @@
                   pagename:           yfm.html
                   basename:           yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm.html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1390,6 +1164,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/plugin_preprocess/collections-tags.html
+++ b/test/actual/plugin_preprocess/collections-tags.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="collections-pages.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="collections.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="collections-pages.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="active">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="collections.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,488 +187,289 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">5</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">two</span>
-    
-      <span class="label label-success">three</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">5</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">two</span>
+                        <span class="label label-success">three</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -718,37 +481,21 @@
     <h4>Tags</h4>
   </div>
   <div class="panel-body">
-  
     <span class="label label-success">alert</span>
-  
     <span class="label label-success">bootstrap</span>
-  
     <span class="label label-success">collections</span>
-  
     <span class="label label-success">complex</span>
-  
     <span class="label label-success">example</span>
-  
     <span class="label label-success">examples</span>
-  
     <span class="label label-success">markdown</span>
-  
     <span class="label label-success">md</span>
-  
     <span class="label label-success">one</span>
-  
     <span class="label label-success">pages</span>
-  
     <span class="label label-success">tags</span>
-  
     <span class="label label-success">test</span>
-  
     <span class="label label-success">tests</span>
-  
     <span class="label label-success">three</span>
-  
     <span class="label label-success">two</span>
-  
   </div>
 </div>
 
@@ -756,37 +503,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -795,19 +527,19 @@
               <h1>Page</h1>
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html" class="">debug-helpers</a></li>
+                <li><a href="example.html" class="">example</a></li>
                   <!--
                   "this"
                   ===============================
-                  this.src:           test/fixtures/pages/debug-helpers.hbs
-                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  this.src:           test/fixtures/pages/example.hbs
+                  this.dest:          test/actual/plugin_preprocess/example.html
                   this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      debug-helpers.html
-                  this.pagename:      debug-helpers.html
-                  this.basename:      debug-helpers
+                  this.filename:      example.html
+                  this.pagename:      example.html
+                  this.basename:      example
                   this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  debug-helpers.html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  example.html
 
                   "page"
                   ===============================
@@ -818,22 +550,22 @@
                   page.pagename:      collections-tags.html
                   page.basename:      collections-tags
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-tags.html
 
                   "root"
                   ===============================
-                  src:                test/fixtures/pages/debug-helpers.hbs
-                  dest:               test/actual/plugin_preprocess/debug-helpers.html
+                  src:                test/fixtures/pages/example.hbs
+                  dest:               test/actual/plugin_preprocess/example.html
                   dirname:            test/actual/plugin_preprocess
-                  filename:           debug-helpers.html
-                  pagename:           debug-helpers.html
-                  basename:           debug-helpers
+                  filename:           example.html
+                  pagename:           example.html
+                  basename:           example
                   ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       debug-helpers.html
+                  isCurrentPage:           false
+                  relativeLink:       example.html
                   -->
-                <li><a href="alert.html" class="">alert</a></li>
+<li><a href="alert.html" class="">alert</a></li>
                   <!--
                   "this"
                   ===============================
@@ -844,7 +576,7 @@
                   this.pagename:      alert.html
                   this.basename:      alert
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  alert.html
 
                   "page"
@@ -856,7 +588,7 @@
                   page.pagename:      collections-tags.html
                   page.basename:      collections-tags
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-tags.html
 
                   "root"
@@ -868,10 +600,10 @@
                   pagename:           alert.html
                   basename:           alert
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       alert.html
                   -->
-                <li><a href="collections-pages.html" class="">collections-pages</a></li>
+<li><a href="collections-pages.html" class="">collections-pages</a></li>
                   <!--
                   "this"
                   ===============================
@@ -882,7 +614,7 @@
                   this.pagename:      collections-pages.html
                   this.basename:      collections-pages
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections-pages.html
 
                   "page"
@@ -894,7 +626,7 @@
                   page.pagename:      collections-tags.html
                   page.basename:      collections-tags
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-tags.html
 
                   "root"
@@ -906,10 +638,10 @@
                   pagename:           collections-pages.html
                   basename:           collections-pages
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections-pages.html
                   -->
-                <li><a href="collections-tags.html" class="active">collections-tags</a></li>
+<li><a href="collections-tags.html" class="active">collections-tags</a></li>
                   <!--
                   "this"
                   ===============================
@@ -932,7 +664,7 @@
                   page.pagename:      collections-tags.html
                   page.basename:      collections-tags
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-tags.html
 
                   "root"
@@ -947,7 +679,7 @@
                   isCurrentPage:           true
                   relativeLink:       collections-tags.html
                   -->
-                <li><a href="collections.html" class="">collections</a></li>
+<li><a href="collections.html" class="">collections</a></li>
                   <!--
                   "this"
                   ===============================
@@ -958,7 +690,7 @@
                   this.pagename:      collections.html
                   this.basename:      collections
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections.html
 
                   "page"
@@ -970,7 +702,7 @@
                   page.pagename:      collections-tags.html
                   page.basename:      collections-tags
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-tags.html
 
                   "root"
@@ -982,10 +714,10 @@
                   pagename:           collections.html
                   basename:           collections
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections.html
                   -->
-                <li><a href="complex.html" class="">complex</a></li>
+<li><a href="complex.html" class="">complex</a></li>
                   <!--
                   "this"
                   ===============================
@@ -996,7 +728,7 @@
                   this.pagename:      complex.html
                   this.basename:      complex
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  complex.html
 
                   "page"
@@ -1008,7 +740,7 @@
                   page.pagename:      collections-tags.html
                   page.basename:      collections-tags
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-tags.html
 
                   "root"
@@ -1020,10 +752,10 @@
                   pagename:           complex.html
                   basename:           complex
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       complex.html
                   -->
-                <li><a href="context.html" class="">context</a></li>
+<li><a href="context.html" class="">context</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1034,7 +766,7 @@
                   this.pagename:      context.html
                   this.basename:      context
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  context.html
 
                   "page"
@@ -1046,7 +778,7 @@
                   page.pagename:      collections-tags.html
                   page.basename:      collections-tags
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-tags.html
 
                   "root"
@@ -1058,10 +790,48 @@
                   pagename:           context.html
                   basename:           context
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       context.html
                   -->
-                <li><a href="collections-categories.html" class="">collections-categories</a></li>
+<li><a href="debug-helpers.html" class="">debug-helpers</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/debug-helpers.hbs
+                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      debug-helpers.html
+                  this.pagename:      debug-helpers.html
+                  this.basename:      debug-helpers
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  debug-helpers.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/collections-tags.hbs
+                  page.dest:          test/actual/plugin_preprocess/collections-tags.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      collections-tags.html
+                  page.pagename:      collections-tags.html
+                  page.basename:      collections-tags
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  collections-tags.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/debug-helpers.hbs
+                  dest:               test/actual/plugin_preprocess/debug-helpers.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           debug-helpers.html
+                  pagename:           debug-helpers.html
+                  basename:           debug-helpers
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       debug-helpers.html
+                  -->
+<li><a href="collections-categories.html" class="">collections-categories</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1072,7 +842,7 @@
                   this.pagename:      collections-categories.html
                   this.basename:      collections-categories
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections-categories.html
 
                   "page"
@@ -1084,7 +854,7 @@
                   page.pagename:      collections-tags.html
                   page.basename:      collections-tags
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-tags.html
 
                   "root"
@@ -1096,48 +866,10 @@
                   pagename:           collections-categories.html
                   basename:           collections-categories
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections-categories.html
                   -->
-                <li><a href="example.html" class="">example</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/example.hbs
-                  this.dest:          test/actual/plugin_preprocess/example.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      example.html
-                  this.pagename:      example.html
-                  this.basename:      example
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  example.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/collections-tags.hbs
-                  page.dest:          test/actual/plugin_preprocess/collections-tags.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      collections-tags.html
-                  page.pagename:      collections-tags.html
-                  page.basename:      collections-tags
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  collections-tags.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/example.hbs
-                  dest:               test/actual/plugin_preprocess/example.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           example.html
-                  pagename:           example.html
-                  basename:           example
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       example.html
-                  -->
-                <li><a href="gist-helper.html" class="">gist-helper</a></li>
+<li><a href="gist-helper.html" class="">gist-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1148,7 +880,7 @@
                   this.pagename:      gist-helper.html
                   this.basename:      gist-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  gist-helper.html
 
                   "page"
@@ -1160,7 +892,7 @@
                   page.pagename:      collections-tags.html
                   page.basename:      collections-tags
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-tags.html
 
                   "root"
@@ -1172,10 +904,10 @@
                   pagename:           gist-helper.html
                   basename:           gist-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       gist-helper.html
                   -->
-                <li><a href="lodash.html" class="">lodash</a></li>
+<li><a href="lodash.html" class="">lodash</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1186,7 +918,7 @@
                   this.pagename:      lodash.html
                   this.basename:      lodash
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  lodash.html
 
                   "page"
@@ -1198,7 +930,7 @@
                   page.pagename:      collections-tags.html
                   page.basename:      collections-tags
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-tags.html
 
                   "root"
@@ -1210,10 +942,10 @@
                   pagename:           lodash.html
                   basename:           lodash
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       lodash.html
                   -->
-                <li><a href="md-helper.html" class="">md-helper</a></li>
+<li><a href="md-helper.html" class="">md-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1224,7 +956,7 @@
                   this.pagename:      md-helper.html
                   this.basename:      md-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  md-helper.html
 
                   "page"
@@ -1236,7 +968,7 @@
                   page.pagename:      collections-tags.html
                   page.basename:      collections-tags
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-tags.html
 
                   "root"
@@ -1248,10 +980,48 @@
                   pagename:           md-helper.html
                   basename:           md-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       md-helper.html
                   -->
-                <li><a href="no-yfm.html" class="">no-yfm</a></li>
+<li><a href="no-yfm-data.html" class="">no-yfm-data</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      no-yfm-data.html
+                  this.pagename:      no-yfm-data.html
+                  this.basename:      no-yfm-data
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  no-yfm-data.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/collections-tags.hbs
+                  page.dest:          test/actual/plugin_preprocess/collections-tags.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      collections-tags.html
+                  page.pagename:      collections-tags.html
+                  page.basename:      collections-tags
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  collections-tags.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/no-yfm-data.hbs
+                  dest:               test/actual/plugin_preprocess/no-yfm-data.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           no-yfm-data.html
+                  pagename:           no-yfm-data.html
+                  basename:           no-yfm-data
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       no-yfm-data.html
+                  -->
+<li><a href="no-yfm.html" class="">no-yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1262,7 +1032,7 @@
                   this.pagename:      no-yfm.html
                   this.basename:      no-yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  no-yfm.html
 
                   "page"
@@ -1274,7 +1044,7 @@
                   page.pagename:      collections-tags.html
                   page.basename:      collections-tags
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-tags.html
 
                   "root"
@@ -1286,10 +1056,10 @@
                   pagename:           no-yfm.html
                   basename:           no-yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       no-yfm.html
                   -->
-                <li><a href="yfm-context.html" class="">yfm-context</a></li>
+<li><a href="yfm-context.html" class="">yfm-context</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1300,7 +1070,7 @@
                   this.pagename:      yfm-context.html
                   this.basename:      yfm-context
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm-context.html
 
                   "page"
@@ -1312,7 +1082,7 @@
                   page.pagename:      collections-tags.html
                   page.basename:      collections-tags
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-tags.html
 
                   "root"
@@ -1324,10 +1094,10 @@
                   pagename:           yfm-context.html
                   basename:           yfm-context
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm-context.html
                   -->
-                <li><a href="yfm.html" class="">yfm</a></li>
+<li><a href="yfm.html" class="">yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1338,7 +1108,7 @@
                   this.pagename:      yfm.html
                   this.basename:      yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm.html
 
                   "page"
@@ -1350,7 +1120,7 @@
                   page.pagename:      collections-tags.html
                   page.basename:      collections-tags
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections-tags.html
 
                   "root"
@@ -1362,10 +1132,9 @@
                   pagename:           yfm.html
                   basename:           yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm.html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1403,6 +1172,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/plugin_preprocess/collections.html
+++ b/test/actual/plugin_preprocess/collections.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="collections-tags.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="complex.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="collections-tags.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="active">
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="complex.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">one</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li class="active">
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li class="active">
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li class="active">
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">one</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li class="active">
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li class="active">
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li class="active">
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -711,101 +476,56 @@
             
 Collections
 <ul class="tags">
-
   <li>alert</li>
-
   <li>bootstrap</li>
-
   <li>collections</li>
-
   <li>complex</li>
-
   <li>example</li>
-
   <li>examples</li>
-
   <li>markdown</li>
-
   <li>md</li>
-
   <li>one</li>
-
   <li>pages</li>
-
   <li>tags</li>
-
   <li>test</li>
-
   <li>tests</li>
-
   <li>three</li>
-
   <li>two</li>
-
 </ul>
 
 <ul class="categories">
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
   <li></li>
-
 </ul>
 
 <ul class="pages">
-
-	<li>debug-helpers</li>
-
-	<li>alert</li>
-
-	<li>collections-pages</li>
-
-	<li>collections-tags</li>
-
-	<li>collections</li>
-
-	<li>complex</li>
-
-	<li>context</li>
-
-	<li>collections-categories</li>
-
 	<li>example</li>
-
+	<li>alert</li>
+	<li>collections-pages</li>
+	<li>collections-tags</li>
+	<li>collections</li>
+	<li>complex</li>
+	<li>context</li>
+	<li>debug-helpers</li>
+	<li>collections-categories</li>
 	<li>gist-helper</li>
-
 	<li>lodash</li>
-
 	<li>md-helper</li>
-
+	<li>no-yfm-data</li>
 	<li>no-yfm</li>
-
 	<li>yfm-context</li>
-
 	<li>yfm</li>
-
 </ul>
 
 
@@ -813,37 +533,22 @@ Collections
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -852,19 +557,19 @@ Collections
               <h1>Page</h1>
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html" class="">debug-helpers</a></li>
+                <li><a href="example.html" class="">example</a></li>
                   <!--
                   "this"
                   ===============================
-                  this.src:           test/fixtures/pages/debug-helpers.hbs
-                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  this.src:           test/fixtures/pages/example.hbs
+                  this.dest:          test/actual/plugin_preprocess/example.html
                   this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      debug-helpers.html
-                  this.pagename:      debug-helpers.html
-                  this.basename:      debug-helpers
+                  this.filename:      example.html
+                  this.pagename:      example.html
+                  this.basename:      example
                   this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  debug-helpers.html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  example.html
 
                   "page"
                   ===============================
@@ -875,22 +580,22 @@ Collections
                   page.pagename:      collections.html
                   page.basename:      collections
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections.html
 
                   "root"
                   ===============================
-                  src:                test/fixtures/pages/debug-helpers.hbs
-                  dest:               test/actual/plugin_preprocess/debug-helpers.html
+                  src:                test/fixtures/pages/example.hbs
+                  dest:               test/actual/plugin_preprocess/example.html
                   dirname:            test/actual/plugin_preprocess
-                  filename:           debug-helpers.html
-                  pagename:           debug-helpers.html
-                  basename:           debug-helpers
+                  filename:           example.html
+                  pagename:           example.html
+                  basename:           example
                   ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       debug-helpers.html
+                  isCurrentPage:           false
+                  relativeLink:       example.html
                   -->
-                <li><a href="alert.html" class="">alert</a></li>
+<li><a href="alert.html" class="">alert</a></li>
                   <!--
                   "this"
                   ===============================
@@ -901,7 +606,7 @@ Collections
                   this.pagename:      alert.html
                   this.basename:      alert
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  alert.html
 
                   "page"
@@ -913,7 +618,7 @@ Collections
                   page.pagename:      collections.html
                   page.basename:      collections
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections.html
 
                   "root"
@@ -925,10 +630,10 @@ Collections
                   pagename:           alert.html
                   basename:           alert
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       alert.html
                   -->
-                <li><a href="collections-pages.html" class="">collections-pages</a></li>
+<li><a href="collections-pages.html" class="">collections-pages</a></li>
                   <!--
                   "this"
                   ===============================
@@ -939,7 +644,7 @@ Collections
                   this.pagename:      collections-pages.html
                   this.basename:      collections-pages
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections-pages.html
 
                   "page"
@@ -951,7 +656,7 @@ Collections
                   page.pagename:      collections.html
                   page.basename:      collections
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections.html
 
                   "root"
@@ -963,10 +668,10 @@ Collections
                   pagename:           collections-pages.html
                   basename:           collections-pages
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections-pages.html
                   -->
-                <li><a href="collections-tags.html" class="">collections-tags</a></li>
+<li><a href="collections-tags.html" class="">collections-tags</a></li>
                   <!--
                   "this"
                   ===============================
@@ -977,7 +682,7 @@ Collections
                   this.pagename:      collections-tags.html
                   this.basename:      collections-tags
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections-tags.html
 
                   "page"
@@ -989,7 +694,7 @@ Collections
                   page.pagename:      collections.html
                   page.basename:      collections
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections.html
 
                   "root"
@@ -1001,10 +706,10 @@ Collections
                   pagename:           collections-tags.html
                   basename:           collections-tags
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections-tags.html
                   -->
-                <li><a href="collections.html" class="active">collections</a></li>
+<li><a href="collections.html" class="active">collections</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1027,7 +732,7 @@ Collections
                   page.pagename:      collections.html
                   page.basename:      collections
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections.html
 
                   "root"
@@ -1042,7 +747,7 @@ Collections
                   isCurrentPage:           true
                   relativeLink:       collections.html
                   -->
-                <li><a href="complex.html" class="">complex</a></li>
+<li><a href="complex.html" class="">complex</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1053,7 +758,7 @@ Collections
                   this.pagename:      complex.html
                   this.basename:      complex
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  complex.html
 
                   "page"
@@ -1065,7 +770,7 @@ Collections
                   page.pagename:      collections.html
                   page.basename:      collections
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections.html
 
                   "root"
@@ -1077,10 +782,10 @@ Collections
                   pagename:           complex.html
                   basename:           complex
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       complex.html
                   -->
-                <li><a href="context.html" class="">context</a></li>
+<li><a href="context.html" class="">context</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1091,7 +796,7 @@ Collections
                   this.pagename:      context.html
                   this.basename:      context
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  context.html
 
                   "page"
@@ -1103,7 +808,7 @@ Collections
                   page.pagename:      collections.html
                   page.basename:      collections
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections.html
 
                   "root"
@@ -1115,10 +820,48 @@ Collections
                   pagename:           context.html
                   basename:           context
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       context.html
                   -->
-                <li><a href="collections-categories.html" class="">collections-categories</a></li>
+<li><a href="debug-helpers.html" class="">debug-helpers</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/debug-helpers.hbs
+                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      debug-helpers.html
+                  this.pagename:      debug-helpers.html
+                  this.basename:      debug-helpers
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  debug-helpers.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/collections.hbs
+                  page.dest:          test/actual/plugin_preprocess/collections.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      collections.html
+                  page.pagename:      collections.html
+                  page.basename:      collections
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  collections.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/debug-helpers.hbs
+                  dest:               test/actual/plugin_preprocess/debug-helpers.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           debug-helpers.html
+                  pagename:           debug-helpers.html
+                  basename:           debug-helpers
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       debug-helpers.html
+                  -->
+<li><a href="collections-categories.html" class="">collections-categories</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1129,7 +872,7 @@ Collections
                   this.pagename:      collections-categories.html
                   this.basename:      collections-categories
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections-categories.html
 
                   "page"
@@ -1141,7 +884,7 @@ Collections
                   page.pagename:      collections.html
                   page.basename:      collections
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections.html
 
                   "root"
@@ -1153,48 +896,10 @@ Collections
                   pagename:           collections-categories.html
                   basename:           collections-categories
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections-categories.html
                   -->
-                <li><a href="example.html" class="">example</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/example.hbs
-                  this.dest:          test/actual/plugin_preprocess/example.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      example.html
-                  this.pagename:      example.html
-                  this.basename:      example
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  example.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/collections.hbs
-                  page.dest:          test/actual/plugin_preprocess/collections.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      collections.html
-                  page.pagename:      collections.html
-                  page.basename:      collections
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  collections.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/example.hbs
-                  dest:               test/actual/plugin_preprocess/example.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           example.html
-                  pagename:           example.html
-                  basename:           example
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       example.html
-                  -->
-                <li><a href="gist-helper.html" class="">gist-helper</a></li>
+<li><a href="gist-helper.html" class="">gist-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1205,7 +910,7 @@ Collections
                   this.pagename:      gist-helper.html
                   this.basename:      gist-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  gist-helper.html
 
                   "page"
@@ -1217,7 +922,7 @@ Collections
                   page.pagename:      collections.html
                   page.basename:      collections
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections.html
 
                   "root"
@@ -1229,10 +934,10 @@ Collections
                   pagename:           gist-helper.html
                   basename:           gist-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       gist-helper.html
                   -->
-                <li><a href="lodash.html" class="">lodash</a></li>
+<li><a href="lodash.html" class="">lodash</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1243,7 +948,7 @@ Collections
                   this.pagename:      lodash.html
                   this.basename:      lodash
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  lodash.html
 
                   "page"
@@ -1255,7 +960,7 @@ Collections
                   page.pagename:      collections.html
                   page.basename:      collections
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections.html
 
                   "root"
@@ -1267,10 +972,10 @@ Collections
                   pagename:           lodash.html
                   basename:           lodash
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       lodash.html
                   -->
-                <li><a href="md-helper.html" class="">md-helper</a></li>
+<li><a href="md-helper.html" class="">md-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1281,7 +986,7 @@ Collections
                   this.pagename:      md-helper.html
                   this.basename:      md-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  md-helper.html
 
                   "page"
@@ -1293,7 +998,7 @@ Collections
                   page.pagename:      collections.html
                   page.basename:      collections
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections.html
 
                   "root"
@@ -1305,10 +1010,48 @@ Collections
                   pagename:           md-helper.html
                   basename:           md-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       md-helper.html
                   -->
-                <li><a href="no-yfm.html" class="">no-yfm</a></li>
+<li><a href="no-yfm-data.html" class="">no-yfm-data</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      no-yfm-data.html
+                  this.pagename:      no-yfm-data.html
+                  this.basename:      no-yfm-data
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  no-yfm-data.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/collections.hbs
+                  page.dest:          test/actual/plugin_preprocess/collections.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      collections.html
+                  page.pagename:      collections.html
+                  page.basename:      collections
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  collections.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/no-yfm-data.hbs
+                  dest:               test/actual/plugin_preprocess/no-yfm-data.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           no-yfm-data.html
+                  pagename:           no-yfm-data.html
+                  basename:           no-yfm-data
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       no-yfm-data.html
+                  -->
+<li><a href="no-yfm.html" class="">no-yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1319,7 +1062,7 @@ Collections
                   this.pagename:      no-yfm.html
                   this.basename:      no-yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  no-yfm.html
 
                   "page"
@@ -1331,7 +1074,7 @@ Collections
                   page.pagename:      collections.html
                   page.basename:      collections
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections.html
 
                   "root"
@@ -1343,10 +1086,10 @@ Collections
                   pagename:           no-yfm.html
                   basename:           no-yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       no-yfm.html
                   -->
-                <li><a href="yfm-context.html" class="">yfm-context</a></li>
+<li><a href="yfm-context.html" class="">yfm-context</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1357,7 +1100,7 @@ Collections
                   this.pagename:      yfm-context.html
                   this.basename:      yfm-context
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm-context.html
 
                   "page"
@@ -1369,7 +1112,7 @@ Collections
                   page.pagename:      collections.html
                   page.basename:      collections
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections.html
 
                   "root"
@@ -1381,10 +1124,10 @@ Collections
                   pagename:           yfm-context.html
                   basename:           yfm-context
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm-context.html
                   -->
-                <li><a href="yfm.html" class="">yfm</a></li>
+<li><a href="yfm.html" class="">yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1395,7 +1138,7 @@ Collections
                   this.pagename:      yfm.html
                   this.basename:      yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm.html
 
                   "page"
@@ -1407,7 +1150,7 @@ Collections
                   page.pagename:      collections.html
                   page.basename:      collections
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  collections.html
 
                   "root"
@@ -1419,10 +1162,9 @@ Collections
                   pagename:           yfm.html
                   basename:           yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm.html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1461,6 +1203,7 @@ Collections
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/plugin_preprocess/complex.html
+++ b/test/actual/plugin_preprocess/complex.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="collections.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="context.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="collections.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li class="active">
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="context.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,486 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">pages</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">pages</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">complex</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">complex</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -719,37 +482,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -758,19 +506,19 @@
               <h1>Page</h1>
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html" class="">debug-helpers</a></li>
+                <li><a href="example.html" class="">example</a></li>
                   <!--
                   "this"
                   ===============================
-                  this.src:           test/fixtures/pages/debug-helpers.hbs
-                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  this.src:           test/fixtures/pages/example.hbs
+                  this.dest:          test/actual/plugin_preprocess/example.html
                   this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      debug-helpers.html
-                  this.pagename:      debug-helpers.html
-                  this.basename:      debug-helpers
+                  this.filename:      example.html
+                  this.pagename:      example.html
+                  this.basename:      example
                   this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  debug-helpers.html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  example.html
 
                   "page"
                   ===============================
@@ -781,22 +529,22 @@
                   page.pagename:      complex.html
                   page.basename:      complex
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  complex.html
 
                   "root"
                   ===============================
-                  src:                test/fixtures/pages/debug-helpers.hbs
-                  dest:               test/actual/plugin_preprocess/debug-helpers.html
+                  src:                test/fixtures/pages/example.hbs
+                  dest:               test/actual/plugin_preprocess/example.html
                   dirname:            test/actual/plugin_preprocess
-                  filename:           debug-helpers.html
-                  pagename:           debug-helpers.html
-                  basename:           debug-helpers
+                  filename:           example.html
+                  pagename:           example.html
+                  basename:           example
                   ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       debug-helpers.html
+                  isCurrentPage:           false
+                  relativeLink:       example.html
                   -->
-                <li><a href="alert.html" class="">alert</a></li>
+<li><a href="alert.html" class="">alert</a></li>
                   <!--
                   "this"
                   ===============================
@@ -807,7 +555,7 @@
                   this.pagename:      alert.html
                   this.basename:      alert
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  alert.html
 
                   "page"
@@ -819,7 +567,7 @@
                   page.pagename:      complex.html
                   page.basename:      complex
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  complex.html
 
                   "root"
@@ -831,10 +579,10 @@
                   pagename:           alert.html
                   basename:           alert
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       alert.html
                   -->
-                <li><a href="collections-pages.html" class="">collections-pages</a></li>
+<li><a href="collections-pages.html" class="">collections-pages</a></li>
                   <!--
                   "this"
                   ===============================
@@ -845,7 +593,7 @@
                   this.pagename:      collections-pages.html
                   this.basename:      collections-pages
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections-pages.html
 
                   "page"
@@ -857,7 +605,7 @@
                   page.pagename:      complex.html
                   page.basename:      complex
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  complex.html
 
                   "root"
@@ -869,10 +617,10 @@
                   pagename:           collections-pages.html
                   basename:           collections-pages
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections-pages.html
                   -->
-                <li><a href="collections-tags.html" class="">collections-tags</a></li>
+<li><a href="collections-tags.html" class="">collections-tags</a></li>
                   <!--
                   "this"
                   ===============================
@@ -883,7 +631,7 @@
                   this.pagename:      collections-tags.html
                   this.basename:      collections-tags
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections-tags.html
 
                   "page"
@@ -895,7 +643,7 @@
                   page.pagename:      complex.html
                   page.basename:      complex
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  complex.html
 
                   "root"
@@ -907,10 +655,10 @@
                   pagename:           collections-tags.html
                   basename:           collections-tags
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections-tags.html
                   -->
-                <li><a href="collections.html" class="">collections</a></li>
+<li><a href="collections.html" class="">collections</a></li>
                   <!--
                   "this"
                   ===============================
@@ -921,7 +669,7 @@
                   this.pagename:      collections.html
                   this.basename:      collections
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections.html
 
                   "page"
@@ -933,7 +681,7 @@
                   page.pagename:      complex.html
                   page.basename:      complex
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  complex.html
 
                   "root"
@@ -945,10 +693,10 @@
                   pagename:           collections.html
                   basename:           collections
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections.html
                   -->
-                <li><a href="complex.html" class="active">complex</a></li>
+<li><a href="complex.html" class="active">complex</a></li>
                   <!--
                   "this"
                   ===============================
@@ -971,7 +719,7 @@
                   page.pagename:      complex.html
                   page.basename:      complex
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  complex.html
 
                   "root"
@@ -986,7 +734,7 @@
                   isCurrentPage:           true
                   relativeLink:       complex.html
                   -->
-                <li><a href="context.html" class="">context</a></li>
+<li><a href="context.html" class="">context</a></li>
                   <!--
                   "this"
                   ===============================
@@ -997,7 +745,7 @@
                   this.pagename:      context.html
                   this.basename:      context
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  context.html
 
                   "page"
@@ -1009,7 +757,7 @@
                   page.pagename:      complex.html
                   page.basename:      complex
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  complex.html
 
                   "root"
@@ -1021,10 +769,48 @@
                   pagename:           context.html
                   basename:           context
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       context.html
                   -->
-                <li><a href="collections-categories.html" class="">collections-categories</a></li>
+<li><a href="debug-helpers.html" class="">debug-helpers</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/debug-helpers.hbs
+                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      debug-helpers.html
+                  this.pagename:      debug-helpers.html
+                  this.basename:      debug-helpers
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  debug-helpers.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/complex.hbs
+                  page.dest:          test/actual/plugin_preprocess/complex.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      complex.html
+                  page.pagename:      complex.html
+                  page.basename:      complex
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  complex.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/debug-helpers.hbs
+                  dest:               test/actual/plugin_preprocess/debug-helpers.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           debug-helpers.html
+                  pagename:           debug-helpers.html
+                  basename:           debug-helpers
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       debug-helpers.html
+                  -->
+<li><a href="collections-categories.html" class="">collections-categories</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1035,7 +821,7 @@
                   this.pagename:      collections-categories.html
                   this.basename:      collections-categories
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections-categories.html
 
                   "page"
@@ -1047,7 +833,7 @@
                   page.pagename:      complex.html
                   page.basename:      complex
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  complex.html
 
                   "root"
@@ -1059,48 +845,10 @@
                   pagename:           collections-categories.html
                   basename:           collections-categories
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections-categories.html
                   -->
-                <li><a href="example.html" class="">example</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/example.hbs
-                  this.dest:          test/actual/plugin_preprocess/example.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      example.html
-                  this.pagename:      example.html
-                  this.basename:      example
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  example.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/complex.hbs
-                  page.dest:          test/actual/plugin_preprocess/complex.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      complex.html
-                  page.pagename:      complex.html
-                  page.basename:      complex
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  complex.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/example.hbs
-                  dest:               test/actual/plugin_preprocess/example.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           example.html
-                  pagename:           example.html
-                  basename:           example
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       example.html
-                  -->
-                <li><a href="gist-helper.html" class="">gist-helper</a></li>
+<li><a href="gist-helper.html" class="">gist-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1111,7 +859,7 @@
                   this.pagename:      gist-helper.html
                   this.basename:      gist-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  gist-helper.html
 
                   "page"
@@ -1123,7 +871,7 @@
                   page.pagename:      complex.html
                   page.basename:      complex
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  complex.html
 
                   "root"
@@ -1135,10 +883,10 @@
                   pagename:           gist-helper.html
                   basename:           gist-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       gist-helper.html
                   -->
-                <li><a href="lodash.html" class="">lodash</a></li>
+<li><a href="lodash.html" class="">lodash</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1149,7 +897,7 @@
                   this.pagename:      lodash.html
                   this.basename:      lodash
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  lodash.html
 
                   "page"
@@ -1161,7 +909,7 @@
                   page.pagename:      complex.html
                   page.basename:      complex
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  complex.html
 
                   "root"
@@ -1173,10 +921,10 @@
                   pagename:           lodash.html
                   basename:           lodash
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       lodash.html
                   -->
-                <li><a href="md-helper.html" class="">md-helper</a></li>
+<li><a href="md-helper.html" class="">md-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1187,7 +935,7 @@
                   this.pagename:      md-helper.html
                   this.basename:      md-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  md-helper.html
 
                   "page"
@@ -1199,7 +947,7 @@
                   page.pagename:      complex.html
                   page.basename:      complex
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  complex.html
 
                   "root"
@@ -1211,10 +959,48 @@
                   pagename:           md-helper.html
                   basename:           md-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       md-helper.html
                   -->
-                <li><a href="no-yfm.html" class="">no-yfm</a></li>
+<li><a href="no-yfm-data.html" class="">no-yfm-data</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      no-yfm-data.html
+                  this.pagename:      no-yfm-data.html
+                  this.basename:      no-yfm-data
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  no-yfm-data.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/complex.hbs
+                  page.dest:          test/actual/plugin_preprocess/complex.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      complex.html
+                  page.pagename:      complex.html
+                  page.basename:      complex
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  complex.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/no-yfm-data.hbs
+                  dest:               test/actual/plugin_preprocess/no-yfm-data.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           no-yfm-data.html
+                  pagename:           no-yfm-data.html
+                  basename:           no-yfm-data
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       no-yfm-data.html
+                  -->
+<li><a href="no-yfm.html" class="">no-yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1225,7 +1011,7 @@
                   this.pagename:      no-yfm.html
                   this.basename:      no-yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  no-yfm.html
 
                   "page"
@@ -1237,7 +1023,7 @@
                   page.pagename:      complex.html
                   page.basename:      complex
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  complex.html
 
                   "root"
@@ -1249,10 +1035,10 @@
                   pagename:           no-yfm.html
                   basename:           no-yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       no-yfm.html
                   -->
-                <li><a href="yfm-context.html" class="">yfm-context</a></li>
+<li><a href="yfm-context.html" class="">yfm-context</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1263,7 +1049,7 @@
                   this.pagename:      yfm-context.html
                   this.basename:      yfm-context
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm-context.html
 
                   "page"
@@ -1275,7 +1061,7 @@
                   page.pagename:      complex.html
                   page.basename:      complex
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  complex.html
 
                   "root"
@@ -1287,10 +1073,10 @@
                   pagename:           yfm-context.html
                   basename:           yfm-context
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm-context.html
                   -->
-                <li><a href="yfm.html" class="">yfm</a></li>
+<li><a href="yfm.html" class="">yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1301,7 +1087,7 @@
                   this.pagename:      yfm.html
                   this.basename:      yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm.html
 
                   "page"
@@ -1313,7 +1099,7 @@
                   page.pagename:      complex.html
                   page.basename:      complex
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  complex.html
 
                   "root"
@@ -1325,10 +1111,9 @@
                   pagename:           yfm.html
                   basename:           yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm.html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1375,6 +1160,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/plugin_preprocess/context.html
+++ b/test/actual/plugin_preprocess/context.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="complex.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="collections-categories.html">Next &rarr;</a>
+      <a href="debug-helpers.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="complex.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li class="active">
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="collections-categories.html">Next &rarr;</a>
+      <a href="debug-helpers.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">fixtures</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -753,193 +518,171 @@
 <hr>
 
 <ul class="context-test">
-
-  <li><a href="#" data-context="basename">debug-helpers</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">debug-helpers</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">alert</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">alert</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections-pages</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections-pages</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections-tags</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections-tags</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">complex</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">complex</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">context</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">context</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
-  <li><a href="#" data-context="basename">collections-categories</a></li>
-  <li><a href="#" data-context="../basename">context</a></li>
-  <li><a href="#" data-context="this.basename">collections-categories</a></li>
-  <li><a href="#" data-context="page.basename"></a></li>
-  <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">example</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">example</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
+  <li><a href="#" data-context="basename">alert</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">alert</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections-pages</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections-pages</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections-tags</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections-tags</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">complex</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">complex</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">context</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">context</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">debug-helpers</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">debug-helpers</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
+  <li><a href="#" data-context="basename">collections-categories</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">collections-categories</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
   <li><a href="#" data-context="basename">gist-helper</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">gist-helper</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">lodash</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">lodash</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">md-helper</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">md-helper</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
+  <li><a href="#" data-context="basename">no-yfm-data</a></li>
+  <li><a href="#" data-context="../basename">context</a></li>
+  <li><a href="#" data-context="this.basename">no-yfm-data</a></li>
+  <li><a href="#" data-context="page.basename"></a></li>
+  <li><a href="#" data-context="data.basename"></a></li>
   <li><a href="#" data-context="basename">no-yfm</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">no-yfm</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">yfm-context</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">yfm-context</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
   <li><a href="#" data-context="basename">yfm</a></li>
   <li><a href="#" data-context="../basename">context</a></li>
   <li><a href="#" data-context="this.basename">yfm</a></li>
   <li><a href="#" data-context="page.basename"></a></li>
   <li><a href="#" data-context="data.basename"></a></li>
-
 </ul>
 
 <hr>
 
 <ul class="context-test">
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Debug Helper</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Title for &quot;alert.hbs&quot;</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Pages Collection</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Tags Test</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Collections</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Complex YFM</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Context</a></li>
-
-  <li><a href="#" data-context="title"></a></li>
-  <li><a href="#" data-context="../title">Context</a></li>
-  <li><a href="#" data-context="this.title"></a></li>
-  <li><a href="#" data-context="page.title"></a></li>
-  <li><a href="#" data-context="data.title">Collections Categories</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">Title from YFM of &quot;example.hbs&quot;</a></li>
-
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Title for &quot;alert.hbs&quot;</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Pages Collection</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Tags Test</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Collections</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Complex YFM</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Context</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Debug Helper</a></li>
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title">Collections Categories</a></li>
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">Gist Helper</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">&lt;%= site.title %&gt;</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">md helper</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title"></a></li>
-
+  <li><a href="#" data-context="title"></a></li>
+  <li><a href="#" data-context="../title">Context</a></li>
+  <li><a href="#" data-context="this.title"></a></li>
+  <li><a href="#" data-context="page.title"></a></li>
+  <li><a href="#" data-context="data.title"></a></li>
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">This title is from the YFM of the current page</a></li>
-
   <li><a href="#" data-context="title"></a></li>
   <li><a href="#" data-context="../title">Context</a></li>
   <li><a href="#" data-context="this.title"></a></li>
   <li><a href="#" data-context="page.title"></a></li>
   <li><a href="#" data-context="data.title">YFM</a></li>
-
 </ul>
 
 
@@ -947,37 +690,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -986,19 +714,19 @@
               <h1>Page</h1>
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html" class="">debug-helpers</a></li>
+                <li><a href="example.html" class="">example</a></li>
                   <!--
                   "this"
                   ===============================
-                  this.src:           test/fixtures/pages/debug-helpers.hbs
-                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  this.src:           test/fixtures/pages/example.hbs
+                  this.dest:          test/actual/plugin_preprocess/example.html
                   this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      debug-helpers.html
-                  this.pagename:      debug-helpers.html
-                  this.basename:      debug-helpers
+                  this.filename:      example.html
+                  this.pagename:      example.html
+                  this.basename:      example
                   this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  debug-helpers.html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  example.html
 
                   "page"
                   ===============================
@@ -1009,22 +737,22 @@
                   page.pagename:      context.html
                   page.basename:      context
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  context.html
 
                   "root"
                   ===============================
-                  src:                test/fixtures/pages/debug-helpers.hbs
-                  dest:               test/actual/plugin_preprocess/debug-helpers.html
+                  src:                test/fixtures/pages/example.hbs
+                  dest:               test/actual/plugin_preprocess/example.html
                   dirname:            test/actual/plugin_preprocess
-                  filename:           debug-helpers.html
-                  pagename:           debug-helpers.html
-                  basename:           debug-helpers
+                  filename:           example.html
+                  pagename:           example.html
+                  basename:           example
                   ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       debug-helpers.html
+                  isCurrentPage:           false
+                  relativeLink:       example.html
                   -->
-                <li><a href="alert.html" class="">alert</a></li>
+<li><a href="alert.html" class="">alert</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1035,7 +763,7 @@
                   this.pagename:      alert.html
                   this.basename:      alert
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  alert.html
 
                   "page"
@@ -1047,7 +775,7 @@
                   page.pagename:      context.html
                   page.basename:      context
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  context.html
 
                   "root"
@@ -1059,10 +787,10 @@
                   pagename:           alert.html
                   basename:           alert
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       alert.html
                   -->
-                <li><a href="collections-pages.html" class="">collections-pages</a></li>
+<li><a href="collections-pages.html" class="">collections-pages</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1073,7 +801,7 @@
                   this.pagename:      collections-pages.html
                   this.basename:      collections-pages
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections-pages.html
 
                   "page"
@@ -1085,7 +813,7 @@
                   page.pagename:      context.html
                   page.basename:      context
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  context.html
 
                   "root"
@@ -1097,10 +825,10 @@
                   pagename:           collections-pages.html
                   basename:           collections-pages
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections-pages.html
                   -->
-                <li><a href="collections-tags.html" class="">collections-tags</a></li>
+<li><a href="collections-tags.html" class="">collections-tags</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1111,7 +839,7 @@
                   this.pagename:      collections-tags.html
                   this.basename:      collections-tags
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections-tags.html
 
                   "page"
@@ -1123,7 +851,7 @@
                   page.pagename:      context.html
                   page.basename:      context
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  context.html
 
                   "root"
@@ -1135,10 +863,10 @@
                   pagename:           collections-tags.html
                   basename:           collections-tags
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections-tags.html
                   -->
-                <li><a href="collections.html" class="">collections</a></li>
+<li><a href="collections.html" class="">collections</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1149,7 +877,7 @@
                   this.pagename:      collections.html
                   this.basename:      collections
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections.html
 
                   "page"
@@ -1161,7 +889,7 @@
                   page.pagename:      context.html
                   page.basename:      context
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  context.html
 
                   "root"
@@ -1173,10 +901,10 @@
                   pagename:           collections.html
                   basename:           collections
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections.html
                   -->
-                <li><a href="complex.html" class="">complex</a></li>
+<li><a href="complex.html" class="">complex</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1187,7 +915,7 @@
                   this.pagename:      complex.html
                   this.basename:      complex
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  complex.html
 
                   "page"
@@ -1199,7 +927,7 @@
                   page.pagename:      context.html
                   page.basename:      context
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  context.html
 
                   "root"
@@ -1211,10 +939,10 @@
                   pagename:           complex.html
                   basename:           complex
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       complex.html
                   -->
-                <li><a href="context.html" class="active">context</a></li>
+<li><a href="context.html" class="active">context</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1237,7 +965,7 @@
                   page.pagename:      context.html
                   page.basename:      context
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  context.html
 
                   "root"
@@ -1252,7 +980,45 @@
                   isCurrentPage:           true
                   relativeLink:       context.html
                   -->
-                <li><a href="collections-categories.html" class="">collections-categories</a></li>
+<li><a href="debug-helpers.html" class="">debug-helpers</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/debug-helpers.hbs
+                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      debug-helpers.html
+                  this.pagename:      debug-helpers.html
+                  this.basename:      debug-helpers
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  debug-helpers.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/context.hbs
+                  page.dest:          test/actual/plugin_preprocess/context.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      context.html
+                  page.pagename:      context.html
+                  page.basename:      context
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  context.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/debug-helpers.hbs
+                  dest:               test/actual/plugin_preprocess/debug-helpers.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           debug-helpers.html
+                  pagename:           debug-helpers.html
+                  basename:           debug-helpers
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       debug-helpers.html
+                  -->
+<li><a href="collections-categories.html" class="">collections-categories</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1263,7 +1029,7 @@
                   this.pagename:      collections-categories.html
                   this.basename:      collections-categories
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections-categories.html
 
                   "page"
@@ -1275,7 +1041,7 @@
                   page.pagename:      context.html
                   page.basename:      context
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  context.html
 
                   "root"
@@ -1287,48 +1053,10 @@
                   pagename:           collections-categories.html
                   basename:           collections-categories
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections-categories.html
                   -->
-                <li><a href="example.html" class="">example</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/example.hbs
-                  this.dest:          test/actual/plugin_preprocess/example.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      example.html
-                  this.pagename:      example.html
-                  this.basename:      example
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  example.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/context.hbs
-                  page.dest:          test/actual/plugin_preprocess/context.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      context.html
-                  page.pagename:      context.html
-                  page.basename:      context
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  context.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/example.hbs
-                  dest:               test/actual/plugin_preprocess/example.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           example.html
-                  pagename:           example.html
-                  basename:           example
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       example.html
-                  -->
-                <li><a href="gist-helper.html" class="">gist-helper</a></li>
+<li><a href="gist-helper.html" class="">gist-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1339,7 +1067,7 @@
                   this.pagename:      gist-helper.html
                   this.basename:      gist-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  gist-helper.html
 
                   "page"
@@ -1351,7 +1079,7 @@
                   page.pagename:      context.html
                   page.basename:      context
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  context.html
 
                   "root"
@@ -1363,10 +1091,10 @@
                   pagename:           gist-helper.html
                   basename:           gist-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       gist-helper.html
                   -->
-                <li><a href="lodash.html" class="">lodash</a></li>
+<li><a href="lodash.html" class="">lodash</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1377,7 +1105,7 @@
                   this.pagename:      lodash.html
                   this.basename:      lodash
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  lodash.html
 
                   "page"
@@ -1389,7 +1117,7 @@
                   page.pagename:      context.html
                   page.basename:      context
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  context.html
 
                   "root"
@@ -1401,10 +1129,10 @@
                   pagename:           lodash.html
                   basename:           lodash
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       lodash.html
                   -->
-                <li><a href="md-helper.html" class="">md-helper</a></li>
+<li><a href="md-helper.html" class="">md-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1415,7 +1143,7 @@
                   this.pagename:      md-helper.html
                   this.basename:      md-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  md-helper.html
 
                   "page"
@@ -1427,7 +1155,7 @@
                   page.pagename:      context.html
                   page.basename:      context
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  context.html
 
                   "root"
@@ -1439,10 +1167,48 @@
                   pagename:           md-helper.html
                   basename:           md-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       md-helper.html
                   -->
-                <li><a href="no-yfm.html" class="">no-yfm</a></li>
+<li><a href="no-yfm-data.html" class="">no-yfm-data</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      no-yfm-data.html
+                  this.pagename:      no-yfm-data.html
+                  this.basename:      no-yfm-data
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  no-yfm-data.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/context.hbs
+                  page.dest:          test/actual/plugin_preprocess/context.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      context.html
+                  page.pagename:      context.html
+                  page.basename:      context
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  context.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/no-yfm-data.hbs
+                  dest:               test/actual/plugin_preprocess/no-yfm-data.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           no-yfm-data.html
+                  pagename:           no-yfm-data.html
+                  basename:           no-yfm-data
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       no-yfm-data.html
+                  -->
+<li><a href="no-yfm.html" class="">no-yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1453,7 +1219,7 @@
                   this.pagename:      no-yfm.html
                   this.basename:      no-yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  no-yfm.html
 
                   "page"
@@ -1465,7 +1231,7 @@
                   page.pagename:      context.html
                   page.basename:      context
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  context.html
 
                   "root"
@@ -1477,10 +1243,10 @@
                   pagename:           no-yfm.html
                   basename:           no-yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       no-yfm.html
                   -->
-                <li><a href="yfm-context.html" class="">yfm-context</a></li>
+<li><a href="yfm-context.html" class="">yfm-context</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1491,7 +1257,7 @@
                   this.pagename:      yfm-context.html
                   this.basename:      yfm-context
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm-context.html
 
                   "page"
@@ -1503,7 +1269,7 @@
                   page.pagename:      context.html
                   page.basename:      context
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  context.html
 
                   "root"
@@ -1515,10 +1281,10 @@
                   pagename:           yfm-context.html
                   basename:           yfm-context
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm-context.html
                   -->
-                <li><a href="yfm.html" class="">yfm</a></li>
+<li><a href="yfm.html" class="">yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1529,7 +1295,7 @@
                   this.pagename:      yfm.html
                   this.basename:      yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm.html
 
                   "page"
@@ -1541,7 +1307,7 @@
                   page.pagename:      context.html
                   page.basename:      context
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  context.html
 
                   "root"
@@ -1553,10 +1319,9 @@
                   pagename:           yfm.html
                   basename:           yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm.html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1602,6 +1367,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/plugin_preprocess/debug-helpers.html
+++ b/test/actual/plugin_preprocess/debug-helpers.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
-    <li class="previous disabled">
-      <a unselectable="on" class="unselectable">First</a>
-    </li>
-    <li class="previous disabled">
-      <a unselectable="on" class="unselectable">&larr; Previous</a>
-    </li>
-  
 
-  
-
-  
-    <li class="active pager-middle">
-      <a href="debug-helpers.html">1</a>
+    <li class="previous">
+      <a href="example.html">First</a>
     </li>
-  
+    <li class="previous">
+      <a href="context.html">&larr; Previous</a>
+    </li>
+
+    <li class="pager-middle">
+      <a href="example.html">1</a>
+    </li>
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
-    <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+    <li class="active pager-middle">
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="alert.html">Next &rarr;</a>
+      <a href="collections-categories.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
-    <li class="prev disabled">
-      <a unselectable="on" class="unselectable">First</a>
-    </li>
-    <li class="prev disabled">
-      <a unselectable="on" class="unselectable">&larr; Previous</a>
-    </li>
-  
 
-  
-
-  
-    <li class="active">
-      <a href="debug-helpers.html">1</a>
+    <li class="prev">
+      <a href="example.html">First</a>
     </li>
-  
+    <li class="prev">
+      <a href="context.html">&larr; Previous</a>
+    </li>
+
+    <li>
+      <a href="example.html">1</a>
+    </li>
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
-    <li>
-      <a href="collections-categories.html">8</a>
+    <li class="active">
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="alert.html">Next &rarr;</a>
+      <a href="collections-categories.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -707,42 +476,26 @@
 <p>Uncomment the <code>debug</code> helper below, run <code>grunt assemble</code>, and watch the output in the command line to see how it works.</p>
 
 
-
             <div class="docs-header" id="content">
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -751,7 +504,273 @@
               <h1>Page</h1>
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html" class="active">debug-helpers</a></li>
+                <li><a href="example.html" class="">example</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/example.hbs
+                  this.dest:          test/actual/plugin_preprocess/example.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      example.html
+                  this.pagename:      example.html
+                  this.basename:      example
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  example.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/debug-helpers.hbs
+                  page.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      debug-helpers.html
+                  page.pagename:      debug-helpers.html
+                  page.basename:      debug-helpers
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  debug-helpers.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/example.hbs
+                  dest:               test/actual/plugin_preprocess/example.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           example.html
+                  pagename:           example.html
+                  basename:           example
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       example.html
+                  -->
+<li><a href="alert.html" class="">alert</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/alert.hbs
+                  this.dest:          test/actual/plugin_preprocess/alert.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      alert.html
+                  this.pagename:      alert.html
+                  this.basename:      alert
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  alert.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/debug-helpers.hbs
+                  page.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      debug-helpers.html
+                  page.pagename:      debug-helpers.html
+                  page.basename:      debug-helpers
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  debug-helpers.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/alert.hbs
+                  dest:               test/actual/plugin_preprocess/alert.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           alert.html
+                  pagename:           alert.html
+                  basename:           alert
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       alert.html
+                  -->
+<li><a href="collections-pages.html" class="">collections-pages</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-pages.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-pages.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-pages.html
+                  this.pagename:      collections-pages.html
+                  this.basename:      collections-pages
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-pages.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/debug-helpers.hbs
+                  page.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      debug-helpers.html
+                  page.pagename:      debug-helpers.html
+                  page.basename:      debug-helpers
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  debug-helpers.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-pages.hbs
+                  dest:               test/actual/plugin_preprocess/collections-pages.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-pages.html
+                  pagename:           collections-pages.html
+                  basename:           collections-pages
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-pages.html
+                  -->
+<li><a href="collections-tags.html" class="">collections-tags</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-tags.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-tags.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-tags.html
+                  this.pagename:      collections-tags.html
+                  this.basename:      collections-tags
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-tags.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/debug-helpers.hbs
+                  page.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      debug-helpers.html
+                  page.pagename:      debug-helpers.html
+                  page.basename:      debug-helpers
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  debug-helpers.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-tags.hbs
+                  dest:               test/actual/plugin_preprocess/collections-tags.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-tags.html
+                  pagename:           collections-tags.html
+                  basename:           collections-tags
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-tags.html
+                  -->
+<li><a href="collections.html" class="">collections</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections.html
+                  this.pagename:      collections.html
+                  this.basename:      collections
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/debug-helpers.hbs
+                  page.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      debug-helpers.html
+                  page.pagename:      debug-helpers.html
+                  page.basename:      debug-helpers
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  debug-helpers.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections.hbs
+                  dest:               test/actual/plugin_preprocess/collections.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections.html
+                  pagename:           collections.html
+                  basename:           collections
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections.html
+                  -->
+<li><a href="complex.html" class="">complex</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/complex.hbs
+                  this.dest:          test/actual/plugin_preprocess/complex.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      complex.html
+                  this.pagename:      complex.html
+                  this.basename:      complex
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  complex.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/debug-helpers.hbs
+                  page.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      debug-helpers.html
+                  page.pagename:      debug-helpers.html
+                  page.basename:      debug-helpers
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  debug-helpers.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/complex.hbs
+                  dest:               test/actual/plugin_preprocess/complex.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           complex.html
+                  pagename:           complex.html
+                  basename:           complex
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       complex.html
+                  -->
+<li><a href="context.html" class="">context</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/context.hbs
+                  this.dest:          test/actual/plugin_preprocess/context.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      context.html
+                  this.pagename:      context.html
+                  this.basename:      context
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  context.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/debug-helpers.hbs
+                  page.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      debug-helpers.html
+                  page.pagename:      debug-helpers.html
+                  page.basename:      debug-helpers
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  debug-helpers.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/context.hbs
+                  dest:               test/actual/plugin_preprocess/context.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           context.html
+                  pagename:           context.html
+                  basename:           context
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       context.html
+                  -->
+<li><a href="debug-helpers.html" class="active">debug-helpers</a></li>
                   <!--
                   "this"
                   ===============================
@@ -774,8 +793,8 @@
                   page.pagename:      debug-helpers.html
                   page.basename:      debug-helpers
                   page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  
+                  page.isCurrentPage:      false
+                  page.relativeLink:  debug-helpers.html
 
                   "root"
                   ===============================
@@ -789,235 +808,7 @@
                   isCurrentPage:           true
                   relativeLink:       debug-helpers.html
                   -->
-                <li><a href="alert.html" class="">alert</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/alert.hbs
-                  this.dest:          test/actual/plugin_preprocess/alert.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      alert.html
-                  this.pagename:      alert.html
-                  this.basename:      alert
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  alert.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/debug-helpers.hbs
-                  page.dest:          test/actual/plugin_preprocess/debug-helpers.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      debug-helpers.html
-                  page.pagename:      debug-helpers.html
-                  page.basename:      debug-helpers
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/alert.hbs
-                  dest:               test/actual/plugin_preprocess/alert.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           alert.html
-                  pagename:           alert.html
-                  basename:           alert
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       alert.html
-                  -->
-                <li><a href="collections-pages.html" class="">collections-pages</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-pages.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-pages.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-pages.html
-                  this.pagename:      collections-pages.html
-                  this.basename:      collections-pages
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-pages.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/debug-helpers.hbs
-                  page.dest:          test/actual/plugin_preprocess/debug-helpers.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      debug-helpers.html
-                  page.pagename:      debug-helpers.html
-                  page.basename:      debug-helpers
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-pages.hbs
-                  dest:               test/actual/plugin_preprocess/collections-pages.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-pages.html
-                  pagename:           collections-pages.html
-                  basename:           collections-pages
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-pages.html
-                  -->
-                <li><a href="collections-tags.html" class="">collections-tags</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-tags.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-tags.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-tags.html
-                  this.pagename:      collections-tags.html
-                  this.basename:      collections-tags
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-tags.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/debug-helpers.hbs
-                  page.dest:          test/actual/plugin_preprocess/debug-helpers.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      debug-helpers.html
-                  page.pagename:      debug-helpers.html
-                  page.basename:      debug-helpers
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-tags.hbs
-                  dest:               test/actual/plugin_preprocess/collections-tags.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-tags.html
-                  pagename:           collections-tags.html
-                  basename:           collections-tags
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-tags.html
-                  -->
-                <li><a href="collections.html" class="">collections</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections.html
-                  this.pagename:      collections.html
-                  this.basename:      collections
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/debug-helpers.hbs
-                  page.dest:          test/actual/plugin_preprocess/debug-helpers.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      debug-helpers.html
-                  page.pagename:      debug-helpers.html
-                  page.basename:      debug-helpers
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections.hbs
-                  dest:               test/actual/plugin_preprocess/collections.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections.html
-                  pagename:           collections.html
-                  basename:           collections
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections.html
-                  -->
-                <li><a href="complex.html" class="">complex</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/complex.hbs
-                  this.dest:          test/actual/plugin_preprocess/complex.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      complex.html
-                  this.pagename:      complex.html
-                  this.basename:      complex
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  complex.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/debug-helpers.hbs
-                  page.dest:          test/actual/plugin_preprocess/debug-helpers.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      debug-helpers.html
-                  page.pagename:      debug-helpers.html
-                  page.basename:      debug-helpers
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/complex.hbs
-                  dest:               test/actual/plugin_preprocess/complex.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           complex.html
-                  pagename:           complex.html
-                  basename:           complex
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       complex.html
-                  -->
-                <li><a href="context.html" class="">context</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/context.hbs
-                  this.dest:          test/actual/plugin_preprocess/context.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      context.html
-                  this.pagename:      context.html
-                  this.basename:      context
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  context.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/debug-helpers.hbs
-                  page.dest:          test/actual/plugin_preprocess/debug-helpers.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      debug-helpers.html
-                  page.pagename:      debug-helpers.html
-                  page.basename:      debug-helpers
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/context.hbs
-                  dest:               test/actual/plugin_preprocess/context.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           context.html
-                  pagename:           context.html
-                  basename:           context
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       context.html
-                  -->
-                <li><a href="collections-categories.html" class="">collections-categories</a></li>
+<li><a href="collections-categories.html" class="">collections-categories</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1028,7 +819,7 @@
                   this.pagename:      collections-categories.html
                   this.basename:      collections-categories
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  collections-categories.html
 
                   "page"
@@ -1040,8 +831,8 @@
                   page.pagename:      debug-helpers.html
                   page.basename:      debug-helpers
                   page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  
+                  page.isCurrentPage:      false
+                  page.relativeLink:  debug-helpers.html
 
                   "root"
                   ===============================
@@ -1052,48 +843,10 @@
                   pagename:           collections-categories.html
                   basename:           collections-categories
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       collections-categories.html
                   -->
-                <li><a href="example.html" class="">example</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/example.hbs
-                  this.dest:          test/actual/plugin_preprocess/example.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      example.html
-                  this.pagename:      example.html
-                  this.basename:      example
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  example.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/debug-helpers.hbs
-                  page.dest:          test/actual/plugin_preprocess/debug-helpers.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      debug-helpers.html
-                  page.pagename:      debug-helpers.html
-                  page.basename:      debug-helpers
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/example.hbs
-                  dest:               test/actual/plugin_preprocess/example.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           example.html
-                  pagename:           example.html
-                  basename:           example
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       example.html
-                  -->
-                <li><a href="gist-helper.html" class="">gist-helper</a></li>
+<li><a href="gist-helper.html" class="">gist-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1104,7 +857,7 @@
                   this.pagename:      gist-helper.html
                   this.basename:      gist-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  gist-helper.html
 
                   "page"
@@ -1116,8 +869,8 @@
                   page.pagename:      debug-helpers.html
                   page.basename:      debug-helpers
                   page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  
+                  page.isCurrentPage:      false
+                  page.relativeLink:  debug-helpers.html
 
                   "root"
                   ===============================
@@ -1128,10 +881,10 @@
                   pagename:           gist-helper.html
                   basename:           gist-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       gist-helper.html
                   -->
-                <li><a href="lodash.html" class="">lodash</a></li>
+<li><a href="lodash.html" class="">lodash</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1142,7 +895,7 @@
                   this.pagename:      lodash.html
                   this.basename:      lodash
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  lodash.html
 
                   "page"
@@ -1154,8 +907,8 @@
                   page.pagename:      debug-helpers.html
                   page.basename:      debug-helpers
                   page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  
+                  page.isCurrentPage:      false
+                  page.relativeLink:  debug-helpers.html
 
                   "root"
                   ===============================
@@ -1166,10 +919,10 @@
                   pagename:           lodash.html
                   basename:           lodash
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       lodash.html
                   -->
-                <li><a href="md-helper.html" class="">md-helper</a></li>
+<li><a href="md-helper.html" class="">md-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1180,7 +933,7 @@
                   this.pagename:      md-helper.html
                   this.basename:      md-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  md-helper.html
 
                   "page"
@@ -1192,8 +945,8 @@
                   page.pagename:      debug-helpers.html
                   page.basename:      debug-helpers
                   page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  
+                  page.isCurrentPage:      false
+                  page.relativeLink:  debug-helpers.html
 
                   "root"
                   ===============================
@@ -1204,10 +957,48 @@
                   pagename:           md-helper.html
                   basename:           md-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       md-helper.html
                   -->
-                <li><a href="no-yfm.html" class="">no-yfm</a></li>
+<li><a href="no-yfm-data.html" class="">no-yfm-data</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      no-yfm-data.html
+                  this.pagename:      no-yfm-data.html
+                  this.basename:      no-yfm-data
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  no-yfm-data.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/debug-helpers.hbs
+                  page.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      debug-helpers.html
+                  page.pagename:      debug-helpers.html
+                  page.basename:      debug-helpers
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  debug-helpers.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/no-yfm-data.hbs
+                  dest:               test/actual/plugin_preprocess/no-yfm-data.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           no-yfm-data.html
+                  pagename:           no-yfm-data.html
+                  basename:           no-yfm-data
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       no-yfm-data.html
+                  -->
+<li><a href="no-yfm.html" class="">no-yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1218,7 +1009,7 @@
                   this.pagename:      no-yfm.html
                   this.basename:      no-yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  no-yfm.html
 
                   "page"
@@ -1230,8 +1021,8 @@
                   page.pagename:      debug-helpers.html
                   page.basename:      debug-helpers
                   page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  
+                  page.isCurrentPage:      false
+                  page.relativeLink:  debug-helpers.html
 
                   "root"
                   ===============================
@@ -1242,10 +1033,10 @@
                   pagename:           no-yfm.html
                   basename:           no-yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       no-yfm.html
                   -->
-                <li><a href="yfm-context.html" class="">yfm-context</a></li>
+<li><a href="yfm-context.html" class="">yfm-context</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1256,7 +1047,7 @@
                   this.pagename:      yfm-context.html
                   this.basename:      yfm-context
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm-context.html
 
                   "page"
@@ -1268,8 +1059,8 @@
                   page.pagename:      debug-helpers.html
                   page.basename:      debug-helpers
                   page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  
+                  page.isCurrentPage:      false
+                  page.relativeLink:  debug-helpers.html
 
                   "root"
                   ===============================
@@ -1280,10 +1071,10 @@
                   pagename:           yfm-context.html
                   basename:           yfm-context
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm-context.html
                   -->
-                <li><a href="yfm.html" class="">yfm</a></li>
+<li><a href="yfm.html" class="">yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1294,7 +1085,7 @@
                   this.pagename:      yfm.html
                   this.basename:      yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm.html
 
                   "page"
@@ -1306,8 +1097,8 @@
                   page.pagename:      debug-helpers.html
                   page.basename:      debug-helpers
                   page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  
+                  page.isCurrentPage:      false
+                  page.relativeLink:  debug-helpers.html
 
                   "root"
                   ===============================
@@ -1318,10 +1109,9 @@
                   pagename:           yfm.html
                   basename:           yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm.html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1351,6 +1141,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1364,15 +1155,18 @@
     }
   },
   "filename": "debug-helpers.html",
-  "first": true,
-  "index": 0,
+  "first": false,
+  "index": 7,
+  "isCurrentPage": false,
   "last": false,
-  "middle": false,
-  "next": 1,
-  "number": 1,
+  "middle": true,
+  "next": 8,
+  "number": 8,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n{{#markdown}}\n\n### \\{{debug}} helper\nUncomment the `debug` helper below, run `grunt assemble`, and watch the output in the command line to see how it works.\n{{!debug text}}\n\n{{/markdown}}\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relative ../page.dest dest}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\" class=\"{{#isCurrentPage}}active{{/isCurrentPage}}\">{{basename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:           {{this.src}}\n                  this.dest:          {{this.dest}}\n                  this.dirname:       {{this.dirname}}\n                  this.filename:      {{this.filename}}\n                  this.pagename:      {{this.pagename}}\n                  this.basename:      {{this.basename}}\n                  this.ext:           {{this.ext}}\n                  this.isCurrentPage:      {{this.isCurrentPage}}\n                  this.relativeLink:  {{this.relativeLink}}\n\n                  \"page\"\n                  ===============================\n                  page.src:           {{../page.src}}\n                  page.dest:          {{../page.dest}}\n                  page.dirname:       {{../page.dirname}}\n                  page.filename:      {{../page.filename}}\n                  page.pagename:      {{../page.pagename}}\n                  page.basename:      {{../page.basename}}\n                  page.ext:           {{../page.ext}}\n                  page.isCurrentPage:      {{../page.isCurrentPage}}\n                  page.relativeLink:  {{../page.relativeLink}}\n\n                  \"root\"\n                  ===============================\n                  src:                {{src}}\n                  dest:               {{dest}}\n                  dirname:            {{dirname}}\n                  filename:           {{filename}}\n                  pagename:           {{pagename}}\n                  basename:           {{basename}}\n                  ext:                {{ext}}\n                  isCurrentPage:           {{isCurrentPage}}\n                  relativeLink:       {{relativeLink}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "debug-helpers.html",
   "pagename": "debug-helpers.html",
+  "prev": 6,
+  "relativeLink": "debug-helpers.html",
   "src": "test/fixtures/pages/debug-helpers.hbs",
   "title": "Debug Helper"
 }

--- a/test/actual/plugin_preprocess/example.html
+++ b/test/actual/plugin_preprocess/example.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
+    <li class="previous disabled">
+      <a unselectable="on" class="unselectable">First</a>
+    </li>
+    <li class="previous disabled">
+      <a unselectable="on" class="unselectable">&larr; Previous</a>
+    </li>
 
-  
-    <li class="previous">
-      <a href="debug-helpers.html">First</a>
-    </li>
-    <li class="previous">
-      <a href="collections-categories.html">&larr; Previous</a>
-    </li>
-  
 
-  
-    <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+    <li class="active pager-middle">
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
-    <li class="active pager-middle">
-      <a href="example.html">9</a>
+    <li class="pager-middle">
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="gist-helper.html">Next &rarr;</a>
+      <a href="alert.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
+    <li class="prev disabled">
+      <a unselectable="on" class="unselectable">First</a>
+    </li>
+    <li class="prev disabled">
+      <a unselectable="on" class="unselectable">&larr; Previous</a>
+    </li>
 
-  
-    <li class="prev">
-      <a href="debug-helpers.html">First</a>
-    </li>
-    <li class="prev">
-      <a href="collections-categories.html">&larr; Previous</a>
-    </li>
-  
 
-  
-    <li>
-      <a href="debug-helpers.html">1</a>
+    <li class="active">
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
-    <li class="active">
-      <a href="example.html">9</a>
+    <li>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="gist-helper.html">Next &rarr;</a>
+      <a href="alert.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,286 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">2</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">2</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">example</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">example</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -726,37 +490,22 @@ This example shows that the properties from "example.json" and "example.hbs" are
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -765,310 +514,6 @@ This example shows that the properties from "example.json" and "example.hbs" are
               <h1>Page</h1>
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html" class="">debug-helpers</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/debug-helpers.hbs
-                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      debug-helpers.html
-                  this.pagename:      debug-helpers.html
-                  this.basename:      debug-helpers
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  debug-helpers.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/example.hbs
-                  page.dest:          test/actual/plugin_preprocess/example.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      example.html
-                  page.pagename:      example.html
-                  page.basename:      example
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  example.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/debug-helpers.hbs
-                  dest:               test/actual/plugin_preprocess/debug-helpers.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           debug-helpers.html
-                  pagename:           debug-helpers.html
-                  basename:           debug-helpers
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       debug-helpers.html
-                  -->
-                <li><a href="alert.html" class="">alert</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/alert.hbs
-                  this.dest:          test/actual/plugin_preprocess/alert.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      alert.html
-                  this.pagename:      alert.html
-                  this.basename:      alert
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  alert.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/example.hbs
-                  page.dest:          test/actual/plugin_preprocess/example.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      example.html
-                  page.pagename:      example.html
-                  page.basename:      example
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  example.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/alert.hbs
-                  dest:               test/actual/plugin_preprocess/alert.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           alert.html
-                  pagename:           alert.html
-                  basename:           alert
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       alert.html
-                  -->
-                <li><a href="collections-pages.html" class="">collections-pages</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-pages.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-pages.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-pages.html
-                  this.pagename:      collections-pages.html
-                  this.basename:      collections-pages
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-pages.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/example.hbs
-                  page.dest:          test/actual/plugin_preprocess/example.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      example.html
-                  page.pagename:      example.html
-                  page.basename:      example
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  example.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-pages.hbs
-                  dest:               test/actual/plugin_preprocess/collections-pages.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-pages.html
-                  pagename:           collections-pages.html
-                  basename:           collections-pages
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-pages.html
-                  -->
-                <li><a href="collections-tags.html" class="">collections-tags</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-tags.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-tags.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-tags.html
-                  this.pagename:      collections-tags.html
-                  this.basename:      collections-tags
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-tags.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/example.hbs
-                  page.dest:          test/actual/plugin_preprocess/example.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      example.html
-                  page.pagename:      example.html
-                  page.basename:      example
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  example.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-tags.hbs
-                  dest:               test/actual/plugin_preprocess/collections-tags.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-tags.html
-                  pagename:           collections-tags.html
-                  basename:           collections-tags
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-tags.html
-                  -->
-                <li><a href="collections.html" class="">collections</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections.html
-                  this.pagename:      collections.html
-                  this.basename:      collections
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/example.hbs
-                  page.dest:          test/actual/plugin_preprocess/example.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      example.html
-                  page.pagename:      example.html
-                  page.basename:      example
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  example.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections.hbs
-                  dest:               test/actual/plugin_preprocess/collections.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections.html
-                  pagename:           collections.html
-                  basename:           collections
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections.html
-                  -->
-                <li><a href="complex.html" class="">complex</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/complex.hbs
-                  this.dest:          test/actual/plugin_preprocess/complex.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      complex.html
-                  this.pagename:      complex.html
-                  this.basename:      complex
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  complex.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/example.hbs
-                  page.dest:          test/actual/plugin_preprocess/example.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      example.html
-                  page.pagename:      example.html
-                  page.basename:      example
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  example.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/complex.hbs
-                  dest:               test/actual/plugin_preprocess/complex.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           complex.html
-                  pagename:           complex.html
-                  basename:           complex
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       complex.html
-                  -->
-                <li><a href="context.html" class="">context</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/context.hbs
-                  this.dest:          test/actual/plugin_preprocess/context.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      context.html
-                  this.pagename:      context.html
-                  this.basename:      context
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  context.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/example.hbs
-                  page.dest:          test/actual/plugin_preprocess/example.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      example.html
-                  page.pagename:      example.html
-                  page.basename:      example
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  example.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/context.hbs
-                  dest:               test/actual/plugin_preprocess/context.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           context.html
-                  pagename:           context.html
-                  basename:           context
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       context.html
-                  -->
-                <li><a href="collections-categories.html" class="">collections-categories</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-categories.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-categories.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-categories.html
-                  this.pagename:      collections-categories.html
-                  this.basename:      collections-categories
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-categories.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/example.hbs
-                  page.dest:          test/actual/plugin_preprocess/example.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      example.html
-                  page.pagename:      example.html
-                  page.basename:      example
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  example.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-categories.hbs
-                  dest:               test/actual/plugin_preprocess/collections-categories.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-categories.html
-                  pagename:           collections-categories.html
-                  basename:           collections-categories
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-categories.html
-                  -->
                 <li><a href="example.html" class="active">example</a></li>
                   <!--
                   "this"
@@ -1093,7 +538,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   page.basename:      example
                   page.ext:           .html
                   page.isCurrentPage:      
-                  page.relativeLink:  example.html
+                  page.relativeLink:  
 
                   "root"
                   ===============================
@@ -1107,7 +552,311 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   isCurrentPage:           true
                   relativeLink:       example.html
                   -->
-                <li><a href="gist-helper.html" class="">gist-helper</a></li>
+<li><a href="alert.html" class="">alert</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/alert.hbs
+                  this.dest:          test/actual/plugin_preprocess/alert.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      alert.html
+                  this.pagename:      alert.html
+                  this.basename:      alert
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  alert.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/example.hbs
+                  page.dest:          test/actual/plugin_preprocess/example.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      example.html
+                  page.pagename:      example.html
+                  page.basename:      example
+                  page.ext:           .html
+                  page.isCurrentPage:      
+                  page.relativeLink:  
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/alert.hbs
+                  dest:               test/actual/plugin_preprocess/alert.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           alert.html
+                  pagename:           alert.html
+                  basename:           alert
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       alert.html
+                  -->
+<li><a href="collections-pages.html" class="">collections-pages</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-pages.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-pages.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-pages.html
+                  this.pagename:      collections-pages.html
+                  this.basename:      collections-pages
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-pages.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/example.hbs
+                  page.dest:          test/actual/plugin_preprocess/example.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      example.html
+                  page.pagename:      example.html
+                  page.basename:      example
+                  page.ext:           .html
+                  page.isCurrentPage:      
+                  page.relativeLink:  
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-pages.hbs
+                  dest:               test/actual/plugin_preprocess/collections-pages.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-pages.html
+                  pagename:           collections-pages.html
+                  basename:           collections-pages
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-pages.html
+                  -->
+<li><a href="collections-tags.html" class="">collections-tags</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-tags.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-tags.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-tags.html
+                  this.pagename:      collections-tags.html
+                  this.basename:      collections-tags
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-tags.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/example.hbs
+                  page.dest:          test/actual/plugin_preprocess/example.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      example.html
+                  page.pagename:      example.html
+                  page.basename:      example
+                  page.ext:           .html
+                  page.isCurrentPage:      
+                  page.relativeLink:  
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-tags.hbs
+                  dest:               test/actual/plugin_preprocess/collections-tags.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-tags.html
+                  pagename:           collections-tags.html
+                  basename:           collections-tags
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-tags.html
+                  -->
+<li><a href="collections.html" class="">collections</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections.html
+                  this.pagename:      collections.html
+                  this.basename:      collections
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/example.hbs
+                  page.dest:          test/actual/plugin_preprocess/example.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      example.html
+                  page.pagename:      example.html
+                  page.basename:      example
+                  page.ext:           .html
+                  page.isCurrentPage:      
+                  page.relativeLink:  
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections.hbs
+                  dest:               test/actual/plugin_preprocess/collections.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections.html
+                  pagename:           collections.html
+                  basename:           collections
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections.html
+                  -->
+<li><a href="complex.html" class="">complex</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/complex.hbs
+                  this.dest:          test/actual/plugin_preprocess/complex.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      complex.html
+                  this.pagename:      complex.html
+                  this.basename:      complex
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  complex.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/example.hbs
+                  page.dest:          test/actual/plugin_preprocess/example.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      example.html
+                  page.pagename:      example.html
+                  page.basename:      example
+                  page.ext:           .html
+                  page.isCurrentPage:      
+                  page.relativeLink:  
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/complex.hbs
+                  dest:               test/actual/plugin_preprocess/complex.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           complex.html
+                  pagename:           complex.html
+                  basename:           complex
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       complex.html
+                  -->
+<li><a href="context.html" class="">context</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/context.hbs
+                  this.dest:          test/actual/plugin_preprocess/context.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      context.html
+                  this.pagename:      context.html
+                  this.basename:      context
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  context.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/example.hbs
+                  page.dest:          test/actual/plugin_preprocess/example.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      example.html
+                  page.pagename:      example.html
+                  page.basename:      example
+                  page.ext:           .html
+                  page.isCurrentPage:      
+                  page.relativeLink:  
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/context.hbs
+                  dest:               test/actual/plugin_preprocess/context.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           context.html
+                  pagename:           context.html
+                  basename:           context
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       context.html
+                  -->
+<li><a href="debug-helpers.html" class="">debug-helpers</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/debug-helpers.hbs
+                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      debug-helpers.html
+                  this.pagename:      debug-helpers.html
+                  this.basename:      debug-helpers
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  debug-helpers.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/example.hbs
+                  page.dest:          test/actual/plugin_preprocess/example.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      example.html
+                  page.pagename:      example.html
+                  page.basename:      example
+                  page.ext:           .html
+                  page.isCurrentPage:      
+                  page.relativeLink:  
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/debug-helpers.hbs
+                  dest:               test/actual/plugin_preprocess/debug-helpers.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           debug-helpers.html
+                  pagename:           debug-helpers.html
+                  basename:           debug-helpers
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       debug-helpers.html
+                  -->
+<li><a href="collections-categories.html" class="">collections-categories</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-categories.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-categories.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-categories.html
+                  this.pagename:      collections-categories.html
+                  this.basename:      collections-categories
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-categories.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/example.hbs
+                  page.dest:          test/actual/plugin_preprocess/example.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      example.html
+                  page.pagename:      example.html
+                  page.basename:      example
+                  page.ext:           .html
+                  page.isCurrentPage:      
+                  page.relativeLink:  
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-categories.hbs
+                  dest:               test/actual/plugin_preprocess/collections-categories.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-categories.html
+                  pagename:           collections-categories.html
+                  basename:           collections-categories
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-categories.html
+                  -->
+<li><a href="gist-helper.html" class="">gist-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1118,7 +867,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   this.pagename:      gist-helper.html
                   this.basename:      gist-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  gist-helper.html
 
                   "page"
@@ -1131,7 +880,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   page.basename:      example
                   page.ext:           .html
                   page.isCurrentPage:      
-                  page.relativeLink:  example.html
+                  page.relativeLink:  
 
                   "root"
                   ===============================
@@ -1142,10 +891,10 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   pagename:           gist-helper.html
                   basename:           gist-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       gist-helper.html
                   -->
-                <li><a href="lodash.html" class="">lodash</a></li>
+<li><a href="lodash.html" class="">lodash</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1156,7 +905,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   this.pagename:      lodash.html
                   this.basename:      lodash
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  lodash.html
 
                   "page"
@@ -1169,7 +918,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   page.basename:      example
                   page.ext:           .html
                   page.isCurrentPage:      
-                  page.relativeLink:  example.html
+                  page.relativeLink:  
 
                   "root"
                   ===============================
@@ -1180,10 +929,10 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   pagename:           lodash.html
                   basename:           lodash
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       lodash.html
                   -->
-                <li><a href="md-helper.html" class="">md-helper</a></li>
+<li><a href="md-helper.html" class="">md-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1194,7 +943,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   this.pagename:      md-helper.html
                   this.basename:      md-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  md-helper.html
 
                   "page"
@@ -1207,7 +956,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   page.basename:      example
                   page.ext:           .html
                   page.isCurrentPage:      
-                  page.relativeLink:  example.html
+                  page.relativeLink:  
 
                   "root"
                   ===============================
@@ -1218,10 +967,48 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   pagename:           md-helper.html
                   basename:           md-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       md-helper.html
                   -->
-                <li><a href="no-yfm.html" class="">no-yfm</a></li>
+<li><a href="no-yfm-data.html" class="">no-yfm-data</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      no-yfm-data.html
+                  this.pagename:      no-yfm-data.html
+                  this.basename:      no-yfm-data
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  no-yfm-data.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/example.hbs
+                  page.dest:          test/actual/plugin_preprocess/example.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      example.html
+                  page.pagename:      example.html
+                  page.basename:      example
+                  page.ext:           .html
+                  page.isCurrentPage:      
+                  page.relativeLink:  
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/no-yfm-data.hbs
+                  dest:               test/actual/plugin_preprocess/no-yfm-data.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           no-yfm-data.html
+                  pagename:           no-yfm-data.html
+                  basename:           no-yfm-data
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       no-yfm-data.html
+                  -->
+<li><a href="no-yfm.html" class="">no-yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1232,7 +1019,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   this.pagename:      no-yfm.html
                   this.basename:      no-yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  no-yfm.html
 
                   "page"
@@ -1245,7 +1032,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   page.basename:      example
                   page.ext:           .html
                   page.isCurrentPage:      
-                  page.relativeLink:  example.html
+                  page.relativeLink:  
 
                   "root"
                   ===============================
@@ -1256,10 +1043,10 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   pagename:           no-yfm.html
                   basename:           no-yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       no-yfm.html
                   -->
-                <li><a href="yfm-context.html" class="">yfm-context</a></li>
+<li><a href="yfm-context.html" class="">yfm-context</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1270,7 +1057,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   this.pagename:      yfm-context.html
                   this.basename:      yfm-context
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm-context.html
 
                   "page"
@@ -1283,7 +1070,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   page.basename:      example
                   page.ext:           .html
                   page.isCurrentPage:      
-                  page.relativeLink:  example.html
+                  page.relativeLink:  
 
                   "root"
                   ===============================
@@ -1294,10 +1081,10 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   pagename:           yfm-context.html
                   basename:           yfm-context
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm-context.html
                   -->
-                <li><a href="yfm.html" class="">yfm</a></li>
+<li><a href="yfm.html" class="">yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1308,7 +1095,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   this.pagename:      yfm.html
                   this.basename:      yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm.html
 
                   "page"
@@ -1321,7 +1108,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   page.basename:      example
                   page.ext:           .html
                   page.isCurrentPage:      
-                  page.relativeLink:  example.html
+                  page.relativeLink:  
 
                   "root"
                   ===============================
@@ -1332,10 +1119,9 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   pagename:           yfm.html
                   basename:           yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm.html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1380,6 +1166,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1393,23 +1180,20 @@ This example shows that the properties from "example.json" and "example.hbs" are
     }
   },
   "filename": "example.html",
-  "first": false,
-  "index": 8,
+  "first": true,
+  "index": 0,
   "info": "Congratulations! This is data from example.yml.",
-  "isCurrentPage": false,
   "items": [
     "omega",
     "gamma"
   ],
   "last": false,
-  "middle": true,
-  "next": 9,
-  "number": 9,
+  "middle": false,
+  "next": 1,
+  "number": 1,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n\nThis example shows that the properties from \"example.json\" and \"example.hbs\" are on the page object.\n\n<hr>\n\n<div>{{page.title}}</div>\n<div>{{page.text}}</div>\n\n<hr>\n\n<div>{{title}}</div>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relative ../page.dest dest}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\" class=\"{{#isCurrentPage}}active{{/isCurrentPage}}\">{{basename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:           {{this.src}}\n                  this.dest:          {{this.dest}}\n                  this.dirname:       {{this.dirname}}\n                  this.filename:      {{this.filename}}\n                  this.pagename:      {{this.pagename}}\n                  this.basename:      {{this.basename}}\n                  this.ext:           {{this.ext}}\n                  this.isCurrentPage:      {{this.isCurrentPage}}\n                  this.relativeLink:  {{this.relativeLink}}\n\n                  \"page\"\n                  ===============================\n                  page.src:           {{../page.src}}\n                  page.dest:          {{../page.dest}}\n                  page.dirname:       {{../page.dirname}}\n                  page.filename:      {{../page.filename}}\n                  page.pagename:      {{../page.pagename}}\n                  page.basename:      {{../page.basename}}\n                  page.ext:           {{../page.ext}}\n                  page.isCurrentPage:      {{../page.isCurrentPage}}\n                  page.relativeLink:  {{../page.relativeLink}}\n\n                  \"root\"\n                  ===============================\n                  src:                {{src}}\n                  dest:               {{dest}}\n                  dirname:            {{dirname}}\n                  filename:           {{filename}}\n                  pagename:           {{pagename}}\n                  basename:           {{basename}}\n                  ext:                {{ext}}\n                  isCurrentPage:           {{isCurrentPage}}\n                  relativeLink:       {{relativeLink}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "example.html",
   "pagename": "example.html",
-  "prev": 7,
-  "relativeLink": "example.html",
   "src": "test/fixtures/pages/example.hbs",
   "tags": [
     "example"

--- a/test/actual/plugin_preprocess/gist-helper.html
+++ b/test/actual/plugin_preprocess/gist-helper.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
-      <a href="example.html">&larr; Previous</a>
+      <a href="collections-categories.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="lodash.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
-      <a href="example.html">&larr; Previous</a>
+      <a href="collections-categories.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="active">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="lodash.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -704,45 +473,28 @@
 
             
 <h1 id="-gist-helper">{{gist}} helper</h1>
-<script src="https://gist.github.com/5193239.js"></script>
-
-
+<p>&lt;script src=&quot;<a href="https://gist.github.com/5193239.js&quot;&gt;&lt;/script&amp;gt">https://gist.github.com/5193239.js&quot;&gt;&lt;/script&amp;gt</a>;</p>
 
             <div class="docs-header" id="content">
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -751,310 +503,6 @@
               <h1>Page</h1>
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html" class="">debug-helpers</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/debug-helpers.hbs
-                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      debug-helpers.html
-                  this.pagename:      debug-helpers.html
-                  this.basename:      debug-helpers
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  debug-helpers.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/gist-helper.hbs
-                  page.dest:          test/actual/plugin_preprocess/gist-helper.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      gist-helper.html
-                  page.pagename:      gist-helper.html
-                  page.basename:      gist-helper
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  gist-helper.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/debug-helpers.hbs
-                  dest:               test/actual/plugin_preprocess/debug-helpers.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           debug-helpers.html
-                  pagename:           debug-helpers.html
-                  basename:           debug-helpers
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       debug-helpers.html
-                  -->
-                <li><a href="alert.html" class="">alert</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/alert.hbs
-                  this.dest:          test/actual/plugin_preprocess/alert.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      alert.html
-                  this.pagename:      alert.html
-                  this.basename:      alert
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  alert.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/gist-helper.hbs
-                  page.dest:          test/actual/plugin_preprocess/gist-helper.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      gist-helper.html
-                  page.pagename:      gist-helper.html
-                  page.basename:      gist-helper
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  gist-helper.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/alert.hbs
-                  dest:               test/actual/plugin_preprocess/alert.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           alert.html
-                  pagename:           alert.html
-                  basename:           alert
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       alert.html
-                  -->
-                <li><a href="collections-pages.html" class="">collections-pages</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-pages.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-pages.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-pages.html
-                  this.pagename:      collections-pages.html
-                  this.basename:      collections-pages
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-pages.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/gist-helper.hbs
-                  page.dest:          test/actual/plugin_preprocess/gist-helper.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      gist-helper.html
-                  page.pagename:      gist-helper.html
-                  page.basename:      gist-helper
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  gist-helper.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-pages.hbs
-                  dest:               test/actual/plugin_preprocess/collections-pages.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-pages.html
-                  pagename:           collections-pages.html
-                  basename:           collections-pages
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-pages.html
-                  -->
-                <li><a href="collections-tags.html" class="">collections-tags</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-tags.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-tags.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-tags.html
-                  this.pagename:      collections-tags.html
-                  this.basename:      collections-tags
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-tags.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/gist-helper.hbs
-                  page.dest:          test/actual/plugin_preprocess/gist-helper.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      gist-helper.html
-                  page.pagename:      gist-helper.html
-                  page.basename:      gist-helper
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  gist-helper.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-tags.hbs
-                  dest:               test/actual/plugin_preprocess/collections-tags.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-tags.html
-                  pagename:           collections-tags.html
-                  basename:           collections-tags
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-tags.html
-                  -->
-                <li><a href="collections.html" class="">collections</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections.html
-                  this.pagename:      collections.html
-                  this.basename:      collections
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/gist-helper.hbs
-                  page.dest:          test/actual/plugin_preprocess/gist-helper.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      gist-helper.html
-                  page.pagename:      gist-helper.html
-                  page.basename:      gist-helper
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  gist-helper.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections.hbs
-                  dest:               test/actual/plugin_preprocess/collections.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections.html
-                  pagename:           collections.html
-                  basename:           collections
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections.html
-                  -->
-                <li><a href="complex.html" class="">complex</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/complex.hbs
-                  this.dest:          test/actual/plugin_preprocess/complex.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      complex.html
-                  this.pagename:      complex.html
-                  this.basename:      complex
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  complex.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/gist-helper.hbs
-                  page.dest:          test/actual/plugin_preprocess/gist-helper.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      gist-helper.html
-                  page.pagename:      gist-helper.html
-                  page.basename:      gist-helper
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  gist-helper.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/complex.hbs
-                  dest:               test/actual/plugin_preprocess/complex.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           complex.html
-                  pagename:           complex.html
-                  basename:           complex
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       complex.html
-                  -->
-                <li><a href="context.html" class="">context</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/context.hbs
-                  this.dest:          test/actual/plugin_preprocess/context.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      context.html
-                  this.pagename:      context.html
-                  this.basename:      context
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  context.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/gist-helper.hbs
-                  page.dest:          test/actual/plugin_preprocess/gist-helper.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      gist-helper.html
-                  page.pagename:      gist-helper.html
-                  page.basename:      gist-helper
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  gist-helper.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/context.hbs
-                  dest:               test/actual/plugin_preprocess/context.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           context.html
-                  pagename:           context.html
-                  basename:           context
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       context.html
-                  -->
-                <li><a href="collections-categories.html" class="">collections-categories</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-categories.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-categories.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-categories.html
-                  this.pagename:      collections-categories.html
-                  this.basename:      collections-categories
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-categories.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/gist-helper.hbs
-                  page.dest:          test/actual/plugin_preprocess/gist-helper.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      gist-helper.html
-                  page.pagename:      gist-helper.html
-                  page.basename:      gist-helper
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  gist-helper.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-categories.hbs
-                  dest:               test/actual/plugin_preprocess/collections-categories.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-categories.html
-                  pagename:           collections-categories.html
-                  basename:           collections-categories
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-categories.html
-                  -->
                 <li><a href="example.html" class="">example</a></li>
                   <!--
                   "this"
@@ -1066,7 +514,7 @@
                   this.pagename:      example.html
                   this.basename:      example
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  example.html
 
                   "page"
@@ -1078,7 +526,7 @@
                   page.pagename:      gist-helper.html
                   page.basename:      gist-helper
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  gist-helper.html
 
                   "root"
@@ -1090,10 +538,314 @@
                   pagename:           example.html
                   basename:           example
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       example.html
                   -->
-                <li><a href="gist-helper.html" class="active">gist-helper</a></li>
+<li><a href="alert.html" class="">alert</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/alert.hbs
+                  this.dest:          test/actual/plugin_preprocess/alert.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      alert.html
+                  this.pagename:      alert.html
+                  this.basename:      alert
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  alert.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/gist-helper.hbs
+                  page.dest:          test/actual/plugin_preprocess/gist-helper.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      gist-helper.html
+                  page.pagename:      gist-helper.html
+                  page.basename:      gist-helper
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  gist-helper.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/alert.hbs
+                  dest:               test/actual/plugin_preprocess/alert.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           alert.html
+                  pagename:           alert.html
+                  basename:           alert
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       alert.html
+                  -->
+<li><a href="collections-pages.html" class="">collections-pages</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-pages.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-pages.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-pages.html
+                  this.pagename:      collections-pages.html
+                  this.basename:      collections-pages
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-pages.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/gist-helper.hbs
+                  page.dest:          test/actual/plugin_preprocess/gist-helper.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      gist-helper.html
+                  page.pagename:      gist-helper.html
+                  page.basename:      gist-helper
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  gist-helper.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-pages.hbs
+                  dest:               test/actual/plugin_preprocess/collections-pages.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-pages.html
+                  pagename:           collections-pages.html
+                  basename:           collections-pages
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-pages.html
+                  -->
+<li><a href="collections-tags.html" class="">collections-tags</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-tags.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-tags.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-tags.html
+                  this.pagename:      collections-tags.html
+                  this.basename:      collections-tags
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-tags.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/gist-helper.hbs
+                  page.dest:          test/actual/plugin_preprocess/gist-helper.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      gist-helper.html
+                  page.pagename:      gist-helper.html
+                  page.basename:      gist-helper
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  gist-helper.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-tags.hbs
+                  dest:               test/actual/plugin_preprocess/collections-tags.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-tags.html
+                  pagename:           collections-tags.html
+                  basename:           collections-tags
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-tags.html
+                  -->
+<li><a href="collections.html" class="">collections</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections.html
+                  this.pagename:      collections.html
+                  this.basename:      collections
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/gist-helper.hbs
+                  page.dest:          test/actual/plugin_preprocess/gist-helper.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      gist-helper.html
+                  page.pagename:      gist-helper.html
+                  page.basename:      gist-helper
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  gist-helper.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections.hbs
+                  dest:               test/actual/plugin_preprocess/collections.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections.html
+                  pagename:           collections.html
+                  basename:           collections
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections.html
+                  -->
+<li><a href="complex.html" class="">complex</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/complex.hbs
+                  this.dest:          test/actual/plugin_preprocess/complex.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      complex.html
+                  this.pagename:      complex.html
+                  this.basename:      complex
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  complex.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/gist-helper.hbs
+                  page.dest:          test/actual/plugin_preprocess/gist-helper.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      gist-helper.html
+                  page.pagename:      gist-helper.html
+                  page.basename:      gist-helper
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  gist-helper.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/complex.hbs
+                  dest:               test/actual/plugin_preprocess/complex.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           complex.html
+                  pagename:           complex.html
+                  basename:           complex
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       complex.html
+                  -->
+<li><a href="context.html" class="">context</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/context.hbs
+                  this.dest:          test/actual/plugin_preprocess/context.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      context.html
+                  this.pagename:      context.html
+                  this.basename:      context
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  context.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/gist-helper.hbs
+                  page.dest:          test/actual/plugin_preprocess/gist-helper.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      gist-helper.html
+                  page.pagename:      gist-helper.html
+                  page.basename:      gist-helper
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  gist-helper.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/context.hbs
+                  dest:               test/actual/plugin_preprocess/context.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           context.html
+                  pagename:           context.html
+                  basename:           context
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       context.html
+                  -->
+<li><a href="debug-helpers.html" class="">debug-helpers</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/debug-helpers.hbs
+                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      debug-helpers.html
+                  this.pagename:      debug-helpers.html
+                  this.basename:      debug-helpers
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  debug-helpers.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/gist-helper.hbs
+                  page.dest:          test/actual/plugin_preprocess/gist-helper.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      gist-helper.html
+                  page.pagename:      gist-helper.html
+                  page.basename:      gist-helper
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  gist-helper.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/debug-helpers.hbs
+                  dest:               test/actual/plugin_preprocess/debug-helpers.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           debug-helpers.html
+                  pagename:           debug-helpers.html
+                  basename:           debug-helpers
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       debug-helpers.html
+                  -->
+<li><a href="collections-categories.html" class="">collections-categories</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-categories.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-categories.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-categories.html
+                  this.pagename:      collections-categories.html
+                  this.basename:      collections-categories
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-categories.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/gist-helper.hbs
+                  page.dest:          test/actual/plugin_preprocess/gist-helper.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      gist-helper.html
+                  page.pagename:      gist-helper.html
+                  page.basename:      gist-helper
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  gist-helper.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-categories.hbs
+                  dest:               test/actual/plugin_preprocess/collections-categories.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-categories.html
+                  pagename:           collections-categories.html
+                  basename:           collections-categories
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-categories.html
+                  -->
+<li><a href="gist-helper.html" class="active">gist-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1116,7 +868,7 @@
                   page.pagename:      gist-helper.html
                   page.basename:      gist-helper
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  gist-helper.html
 
                   "root"
@@ -1131,7 +883,7 @@
                   isCurrentPage:           true
                   relativeLink:       gist-helper.html
                   -->
-                <li><a href="lodash.html" class="">lodash</a></li>
+<li><a href="lodash.html" class="">lodash</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1142,7 +894,7 @@
                   this.pagename:      lodash.html
                   this.basename:      lodash
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  lodash.html
 
                   "page"
@@ -1154,7 +906,7 @@
                   page.pagename:      gist-helper.html
                   page.basename:      gist-helper
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  gist-helper.html
 
                   "root"
@@ -1166,10 +918,10 @@
                   pagename:           lodash.html
                   basename:           lodash
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       lodash.html
                   -->
-                <li><a href="md-helper.html" class="">md-helper</a></li>
+<li><a href="md-helper.html" class="">md-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1180,7 +932,7 @@
                   this.pagename:      md-helper.html
                   this.basename:      md-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  md-helper.html
 
                   "page"
@@ -1192,7 +944,7 @@
                   page.pagename:      gist-helper.html
                   page.basename:      gist-helper
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  gist-helper.html
 
                   "root"
@@ -1204,10 +956,48 @@
                   pagename:           md-helper.html
                   basename:           md-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       md-helper.html
                   -->
-                <li><a href="no-yfm.html" class="">no-yfm</a></li>
+<li><a href="no-yfm-data.html" class="">no-yfm-data</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      no-yfm-data.html
+                  this.pagename:      no-yfm-data.html
+                  this.basename:      no-yfm-data
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  no-yfm-data.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/gist-helper.hbs
+                  page.dest:          test/actual/plugin_preprocess/gist-helper.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      gist-helper.html
+                  page.pagename:      gist-helper.html
+                  page.basename:      gist-helper
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  gist-helper.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/no-yfm-data.hbs
+                  dest:               test/actual/plugin_preprocess/no-yfm-data.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           no-yfm-data.html
+                  pagename:           no-yfm-data.html
+                  basename:           no-yfm-data
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       no-yfm-data.html
+                  -->
+<li><a href="no-yfm.html" class="">no-yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1218,7 +1008,7 @@
                   this.pagename:      no-yfm.html
                   this.basename:      no-yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  no-yfm.html
 
                   "page"
@@ -1230,7 +1020,7 @@
                   page.pagename:      gist-helper.html
                   page.basename:      gist-helper
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  gist-helper.html
 
                   "root"
@@ -1242,10 +1032,10 @@
                   pagename:           no-yfm.html
                   basename:           no-yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       no-yfm.html
                   -->
-                <li><a href="yfm-context.html" class="">yfm-context</a></li>
+<li><a href="yfm-context.html" class="">yfm-context</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1256,7 +1046,7 @@
                   this.pagename:      yfm-context.html
                   this.basename:      yfm-context
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm-context.html
 
                   "page"
@@ -1268,7 +1058,7 @@
                   page.pagename:      gist-helper.html
                   page.basename:      gist-helper
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  gist-helper.html
 
                   "root"
@@ -1280,10 +1070,10 @@
                   pagename:           yfm-context.html
                   basename:           yfm-context
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm-context.html
                   -->
-                <li><a href="yfm.html" class="">yfm</a></li>
+<li><a href="yfm.html" class="">yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1294,7 +1084,7 @@
                   this.pagename:      yfm.html
                   this.basename:      yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm.html
 
                   "page"
@@ -1306,7 +1096,7 @@
                   page.pagename:      gist-helper.html
                   page.basename:      gist-helper
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  gist-helper.html
 
                   "root"
@@ -1318,10 +1108,9 @@
                   pagename:           yfm.html
                   basename:           yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm.html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1351,6 +1140,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/plugin_preprocess/lodash.html
+++ b/test/actual/plugin_preprocess/lodash.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="gist-helper.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="md-helper.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="gist-helper.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="active">
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="md-helper.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -711,37 +480,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -750,310 +504,6 @@
               <h1>Page</h1>
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html" class="">debug-helpers</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/debug-helpers.hbs
-                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      debug-helpers.html
-                  this.pagename:      debug-helpers.html
-                  this.basename:      debug-helpers
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  debug-helpers.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/lodash.hbs
-                  page.dest:          test/actual/plugin_preprocess/lodash.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      lodash.html
-                  page.pagename:      lodash.html
-                  page.basename:      lodash
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  lodash.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/debug-helpers.hbs
-                  dest:               test/actual/plugin_preprocess/debug-helpers.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           debug-helpers.html
-                  pagename:           debug-helpers.html
-                  basename:           debug-helpers
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       debug-helpers.html
-                  -->
-                <li><a href="alert.html" class="">alert</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/alert.hbs
-                  this.dest:          test/actual/plugin_preprocess/alert.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      alert.html
-                  this.pagename:      alert.html
-                  this.basename:      alert
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  alert.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/lodash.hbs
-                  page.dest:          test/actual/plugin_preprocess/lodash.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      lodash.html
-                  page.pagename:      lodash.html
-                  page.basename:      lodash
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  lodash.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/alert.hbs
-                  dest:               test/actual/plugin_preprocess/alert.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           alert.html
-                  pagename:           alert.html
-                  basename:           alert
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       alert.html
-                  -->
-                <li><a href="collections-pages.html" class="">collections-pages</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-pages.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-pages.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-pages.html
-                  this.pagename:      collections-pages.html
-                  this.basename:      collections-pages
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-pages.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/lodash.hbs
-                  page.dest:          test/actual/plugin_preprocess/lodash.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      lodash.html
-                  page.pagename:      lodash.html
-                  page.basename:      lodash
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  lodash.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-pages.hbs
-                  dest:               test/actual/plugin_preprocess/collections-pages.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-pages.html
-                  pagename:           collections-pages.html
-                  basename:           collections-pages
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-pages.html
-                  -->
-                <li><a href="collections-tags.html" class="">collections-tags</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-tags.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-tags.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-tags.html
-                  this.pagename:      collections-tags.html
-                  this.basename:      collections-tags
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-tags.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/lodash.hbs
-                  page.dest:          test/actual/plugin_preprocess/lodash.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      lodash.html
-                  page.pagename:      lodash.html
-                  page.basename:      lodash
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  lodash.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-tags.hbs
-                  dest:               test/actual/plugin_preprocess/collections-tags.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-tags.html
-                  pagename:           collections-tags.html
-                  basename:           collections-tags
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-tags.html
-                  -->
-                <li><a href="collections.html" class="">collections</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections.html
-                  this.pagename:      collections.html
-                  this.basename:      collections
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/lodash.hbs
-                  page.dest:          test/actual/plugin_preprocess/lodash.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      lodash.html
-                  page.pagename:      lodash.html
-                  page.basename:      lodash
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  lodash.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections.hbs
-                  dest:               test/actual/plugin_preprocess/collections.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections.html
-                  pagename:           collections.html
-                  basename:           collections
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections.html
-                  -->
-                <li><a href="complex.html" class="">complex</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/complex.hbs
-                  this.dest:          test/actual/plugin_preprocess/complex.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      complex.html
-                  this.pagename:      complex.html
-                  this.basename:      complex
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  complex.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/lodash.hbs
-                  page.dest:          test/actual/plugin_preprocess/lodash.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      lodash.html
-                  page.pagename:      lodash.html
-                  page.basename:      lodash
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  lodash.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/complex.hbs
-                  dest:               test/actual/plugin_preprocess/complex.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           complex.html
-                  pagename:           complex.html
-                  basename:           complex
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       complex.html
-                  -->
-                <li><a href="context.html" class="">context</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/context.hbs
-                  this.dest:          test/actual/plugin_preprocess/context.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      context.html
-                  this.pagename:      context.html
-                  this.basename:      context
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  context.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/lodash.hbs
-                  page.dest:          test/actual/plugin_preprocess/lodash.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      lodash.html
-                  page.pagename:      lodash.html
-                  page.basename:      lodash
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  lodash.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/context.hbs
-                  dest:               test/actual/plugin_preprocess/context.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           context.html
-                  pagename:           context.html
-                  basename:           context
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       context.html
-                  -->
-                <li><a href="collections-categories.html" class="">collections-categories</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-categories.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-categories.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-categories.html
-                  this.pagename:      collections-categories.html
-                  this.basename:      collections-categories
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-categories.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/lodash.hbs
-                  page.dest:          test/actual/plugin_preprocess/lodash.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      lodash.html
-                  page.pagename:      lodash.html
-                  page.basename:      lodash
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  lodash.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-categories.hbs
-                  dest:               test/actual/plugin_preprocess/collections-categories.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-categories.html
-                  pagename:           collections-categories.html
-                  basename:           collections-categories
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-categories.html
-                  -->
                 <li><a href="example.html" class="">example</a></li>
                   <!--
                   "this"
@@ -1065,7 +515,7 @@
                   this.pagename:      example.html
                   this.basename:      example
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  example.html
 
                   "page"
@@ -1077,7 +527,7 @@
                   page.pagename:      lodash.html
                   page.basename:      lodash
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  lodash.html
 
                   "root"
@@ -1089,10 +539,314 @@
                   pagename:           example.html
                   basename:           example
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       example.html
                   -->
-                <li><a href="gist-helper.html" class="">gist-helper</a></li>
+<li><a href="alert.html" class="">alert</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/alert.hbs
+                  this.dest:          test/actual/plugin_preprocess/alert.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      alert.html
+                  this.pagename:      alert.html
+                  this.basename:      alert
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  alert.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/lodash.hbs
+                  page.dest:          test/actual/plugin_preprocess/lodash.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      lodash.html
+                  page.pagename:      lodash.html
+                  page.basename:      lodash
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  lodash.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/alert.hbs
+                  dest:               test/actual/plugin_preprocess/alert.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           alert.html
+                  pagename:           alert.html
+                  basename:           alert
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       alert.html
+                  -->
+<li><a href="collections-pages.html" class="">collections-pages</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-pages.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-pages.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-pages.html
+                  this.pagename:      collections-pages.html
+                  this.basename:      collections-pages
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-pages.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/lodash.hbs
+                  page.dest:          test/actual/plugin_preprocess/lodash.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      lodash.html
+                  page.pagename:      lodash.html
+                  page.basename:      lodash
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  lodash.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-pages.hbs
+                  dest:               test/actual/plugin_preprocess/collections-pages.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-pages.html
+                  pagename:           collections-pages.html
+                  basename:           collections-pages
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-pages.html
+                  -->
+<li><a href="collections-tags.html" class="">collections-tags</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-tags.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-tags.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-tags.html
+                  this.pagename:      collections-tags.html
+                  this.basename:      collections-tags
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-tags.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/lodash.hbs
+                  page.dest:          test/actual/plugin_preprocess/lodash.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      lodash.html
+                  page.pagename:      lodash.html
+                  page.basename:      lodash
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  lodash.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-tags.hbs
+                  dest:               test/actual/plugin_preprocess/collections-tags.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-tags.html
+                  pagename:           collections-tags.html
+                  basename:           collections-tags
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-tags.html
+                  -->
+<li><a href="collections.html" class="">collections</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections.html
+                  this.pagename:      collections.html
+                  this.basename:      collections
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/lodash.hbs
+                  page.dest:          test/actual/plugin_preprocess/lodash.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      lodash.html
+                  page.pagename:      lodash.html
+                  page.basename:      lodash
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  lodash.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections.hbs
+                  dest:               test/actual/plugin_preprocess/collections.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections.html
+                  pagename:           collections.html
+                  basename:           collections
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections.html
+                  -->
+<li><a href="complex.html" class="">complex</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/complex.hbs
+                  this.dest:          test/actual/plugin_preprocess/complex.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      complex.html
+                  this.pagename:      complex.html
+                  this.basename:      complex
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  complex.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/lodash.hbs
+                  page.dest:          test/actual/plugin_preprocess/lodash.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      lodash.html
+                  page.pagename:      lodash.html
+                  page.basename:      lodash
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  lodash.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/complex.hbs
+                  dest:               test/actual/plugin_preprocess/complex.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           complex.html
+                  pagename:           complex.html
+                  basename:           complex
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       complex.html
+                  -->
+<li><a href="context.html" class="">context</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/context.hbs
+                  this.dest:          test/actual/plugin_preprocess/context.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      context.html
+                  this.pagename:      context.html
+                  this.basename:      context
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  context.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/lodash.hbs
+                  page.dest:          test/actual/plugin_preprocess/lodash.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      lodash.html
+                  page.pagename:      lodash.html
+                  page.basename:      lodash
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  lodash.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/context.hbs
+                  dest:               test/actual/plugin_preprocess/context.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           context.html
+                  pagename:           context.html
+                  basename:           context
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       context.html
+                  -->
+<li><a href="debug-helpers.html" class="">debug-helpers</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/debug-helpers.hbs
+                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      debug-helpers.html
+                  this.pagename:      debug-helpers.html
+                  this.basename:      debug-helpers
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  debug-helpers.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/lodash.hbs
+                  page.dest:          test/actual/plugin_preprocess/lodash.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      lodash.html
+                  page.pagename:      lodash.html
+                  page.basename:      lodash
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  lodash.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/debug-helpers.hbs
+                  dest:               test/actual/plugin_preprocess/debug-helpers.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           debug-helpers.html
+                  pagename:           debug-helpers.html
+                  basename:           debug-helpers
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       debug-helpers.html
+                  -->
+<li><a href="collections-categories.html" class="">collections-categories</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-categories.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-categories.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-categories.html
+                  this.pagename:      collections-categories.html
+                  this.basename:      collections-categories
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-categories.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/lodash.hbs
+                  page.dest:          test/actual/plugin_preprocess/lodash.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      lodash.html
+                  page.pagename:      lodash.html
+                  page.basename:      lodash
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  lodash.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-categories.hbs
+                  dest:               test/actual/plugin_preprocess/collections-categories.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-categories.html
+                  pagename:           collections-categories.html
+                  basename:           collections-categories
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-categories.html
+                  -->
+<li><a href="gist-helper.html" class="">gist-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1103,7 +857,7 @@
                   this.pagename:      gist-helper.html
                   this.basename:      gist-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  gist-helper.html
 
                   "page"
@@ -1115,7 +869,7 @@
                   page.pagename:      lodash.html
                   page.basename:      lodash
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  lodash.html
 
                   "root"
@@ -1127,10 +881,10 @@
                   pagename:           gist-helper.html
                   basename:           gist-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       gist-helper.html
                   -->
-                <li><a href="lodash.html" class="active">lodash</a></li>
+<li><a href="lodash.html" class="active">lodash</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1153,7 +907,7 @@
                   page.pagename:      lodash.html
                   page.basename:      lodash
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  lodash.html
 
                   "root"
@@ -1168,7 +922,7 @@
                   isCurrentPage:           true
                   relativeLink:       lodash.html
                   -->
-                <li><a href="md-helper.html" class="">md-helper</a></li>
+<li><a href="md-helper.html" class="">md-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1179,7 +933,7 @@
                   this.pagename:      md-helper.html
                   this.basename:      md-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  md-helper.html
 
                   "page"
@@ -1191,7 +945,7 @@
                   page.pagename:      lodash.html
                   page.basename:      lodash
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  lodash.html
 
                   "root"
@@ -1203,10 +957,48 @@
                   pagename:           md-helper.html
                   basename:           md-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       md-helper.html
                   -->
-                <li><a href="no-yfm.html" class="">no-yfm</a></li>
+<li><a href="no-yfm-data.html" class="">no-yfm-data</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      no-yfm-data.html
+                  this.pagename:      no-yfm-data.html
+                  this.basename:      no-yfm-data
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  no-yfm-data.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/lodash.hbs
+                  page.dest:          test/actual/plugin_preprocess/lodash.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      lodash.html
+                  page.pagename:      lodash.html
+                  page.basename:      lodash
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  lodash.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/no-yfm-data.hbs
+                  dest:               test/actual/plugin_preprocess/no-yfm-data.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           no-yfm-data.html
+                  pagename:           no-yfm-data.html
+                  basename:           no-yfm-data
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       no-yfm-data.html
+                  -->
+<li><a href="no-yfm.html" class="">no-yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1217,7 +1009,7 @@
                   this.pagename:      no-yfm.html
                   this.basename:      no-yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  no-yfm.html
 
                   "page"
@@ -1229,7 +1021,7 @@
                   page.pagename:      lodash.html
                   page.basename:      lodash
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  lodash.html
 
                   "root"
@@ -1241,10 +1033,10 @@
                   pagename:           no-yfm.html
                   basename:           no-yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       no-yfm.html
                   -->
-                <li><a href="yfm-context.html" class="">yfm-context</a></li>
+<li><a href="yfm-context.html" class="">yfm-context</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1255,7 +1047,7 @@
                   this.pagename:      yfm-context.html
                   this.basename:      yfm-context
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm-context.html
 
                   "page"
@@ -1267,7 +1059,7 @@
                   page.pagename:      lodash.html
                   page.basename:      lodash
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  lodash.html
 
                   "root"
@@ -1279,10 +1071,10 @@
                   pagename:           yfm-context.html
                   basename:           yfm-context
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm-context.html
                   -->
-                <li><a href="yfm.html" class="">yfm</a></li>
+<li><a href="yfm.html" class="">yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1293,7 +1085,7 @@
                   this.pagename:      yfm.html
                   this.basename:      yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm.html
 
                   "page"
@@ -1305,7 +1097,7 @@
                   page.pagename:      lodash.html
                   page.basename:      lodash
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  lodash.html
 
                   "root"
@@ -1317,10 +1109,9 @@
                   pagename:           yfm.html
                   basename:           yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm.html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1352,6 +1143,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/plugin_preprocess/md-helper.html
+++ b/test/actual/plugin_preprocess/md-helper.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="lodash.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
-      <a href="no-yfm.html">Next &rarr;</a>
+      <a href="no-yfm-data.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="lodash.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="active">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
 
-  
     <li class="next">
-      <a href="no-yfm.html">Next &rarr;</a>
+      <a href="no-yfm-data.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,488 +187,288 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">2</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">helper</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">2</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">helper</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">markdown</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">markdown</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -738,37 +500,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -777,310 +524,6 @@
               <h1>Page</h1>
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html" class="">debug-helpers</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/debug-helpers.hbs
-                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      debug-helpers.html
-                  this.pagename:      debug-helpers.html
-                  this.basename:      debug-helpers
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  debug-helpers.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/md-helper.hbs
-                  page.dest:          test/actual/plugin_preprocess/md-helper.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      md-helper.html
-                  page.pagename:      md-helper.html
-                  page.basename:      md-helper
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  md-helper.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/debug-helpers.hbs
-                  dest:               test/actual/plugin_preprocess/debug-helpers.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           debug-helpers.html
-                  pagename:           debug-helpers.html
-                  basename:           debug-helpers
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       debug-helpers.html
-                  -->
-                <li><a href="alert.html" class="">alert</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/alert.hbs
-                  this.dest:          test/actual/plugin_preprocess/alert.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      alert.html
-                  this.pagename:      alert.html
-                  this.basename:      alert
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  alert.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/md-helper.hbs
-                  page.dest:          test/actual/plugin_preprocess/md-helper.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      md-helper.html
-                  page.pagename:      md-helper.html
-                  page.basename:      md-helper
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  md-helper.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/alert.hbs
-                  dest:               test/actual/plugin_preprocess/alert.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           alert.html
-                  pagename:           alert.html
-                  basename:           alert
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       alert.html
-                  -->
-                <li><a href="collections-pages.html" class="">collections-pages</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-pages.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-pages.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-pages.html
-                  this.pagename:      collections-pages.html
-                  this.basename:      collections-pages
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-pages.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/md-helper.hbs
-                  page.dest:          test/actual/plugin_preprocess/md-helper.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      md-helper.html
-                  page.pagename:      md-helper.html
-                  page.basename:      md-helper
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  md-helper.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-pages.hbs
-                  dest:               test/actual/plugin_preprocess/collections-pages.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-pages.html
-                  pagename:           collections-pages.html
-                  basename:           collections-pages
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-pages.html
-                  -->
-                <li><a href="collections-tags.html" class="">collections-tags</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-tags.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-tags.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-tags.html
-                  this.pagename:      collections-tags.html
-                  this.basename:      collections-tags
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-tags.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/md-helper.hbs
-                  page.dest:          test/actual/plugin_preprocess/md-helper.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      md-helper.html
-                  page.pagename:      md-helper.html
-                  page.basename:      md-helper
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  md-helper.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-tags.hbs
-                  dest:               test/actual/plugin_preprocess/collections-tags.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-tags.html
-                  pagename:           collections-tags.html
-                  basename:           collections-tags
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-tags.html
-                  -->
-                <li><a href="collections.html" class="">collections</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections.html
-                  this.pagename:      collections.html
-                  this.basename:      collections
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/md-helper.hbs
-                  page.dest:          test/actual/plugin_preprocess/md-helper.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      md-helper.html
-                  page.pagename:      md-helper.html
-                  page.basename:      md-helper
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  md-helper.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections.hbs
-                  dest:               test/actual/plugin_preprocess/collections.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections.html
-                  pagename:           collections.html
-                  basename:           collections
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections.html
-                  -->
-                <li><a href="complex.html" class="">complex</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/complex.hbs
-                  this.dest:          test/actual/plugin_preprocess/complex.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      complex.html
-                  this.pagename:      complex.html
-                  this.basename:      complex
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  complex.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/md-helper.hbs
-                  page.dest:          test/actual/plugin_preprocess/md-helper.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      md-helper.html
-                  page.pagename:      md-helper.html
-                  page.basename:      md-helper
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  md-helper.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/complex.hbs
-                  dest:               test/actual/plugin_preprocess/complex.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           complex.html
-                  pagename:           complex.html
-                  basename:           complex
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       complex.html
-                  -->
-                <li><a href="context.html" class="">context</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/context.hbs
-                  this.dest:          test/actual/plugin_preprocess/context.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      context.html
-                  this.pagename:      context.html
-                  this.basename:      context
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  context.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/md-helper.hbs
-                  page.dest:          test/actual/plugin_preprocess/md-helper.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      md-helper.html
-                  page.pagename:      md-helper.html
-                  page.basename:      md-helper
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  md-helper.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/context.hbs
-                  dest:               test/actual/plugin_preprocess/context.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           context.html
-                  pagename:           context.html
-                  basename:           context
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       context.html
-                  -->
-                <li><a href="collections-categories.html" class="">collections-categories</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-categories.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-categories.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-categories.html
-                  this.pagename:      collections-categories.html
-                  this.basename:      collections-categories
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-categories.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/md-helper.hbs
-                  page.dest:          test/actual/plugin_preprocess/md-helper.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      md-helper.html
-                  page.pagename:      md-helper.html
-                  page.basename:      md-helper
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  md-helper.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-categories.hbs
-                  dest:               test/actual/plugin_preprocess/collections-categories.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-categories.html
-                  pagename:           collections-categories.html
-                  basename:           collections-categories
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-categories.html
-                  -->
                 <li><a href="example.html" class="">example</a></li>
                   <!--
                   "this"
@@ -1092,7 +535,7 @@
                   this.pagename:      example.html
                   this.basename:      example
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  example.html
 
                   "page"
@@ -1104,7 +547,7 @@
                   page.pagename:      md-helper.html
                   page.basename:      md-helper
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  md-helper.html
 
                   "root"
@@ -1116,10 +559,314 @@
                   pagename:           example.html
                   basename:           example
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       example.html
                   -->
-                <li><a href="gist-helper.html" class="">gist-helper</a></li>
+<li><a href="alert.html" class="">alert</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/alert.hbs
+                  this.dest:          test/actual/plugin_preprocess/alert.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      alert.html
+                  this.pagename:      alert.html
+                  this.basename:      alert
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  alert.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/md-helper.hbs
+                  page.dest:          test/actual/plugin_preprocess/md-helper.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      md-helper.html
+                  page.pagename:      md-helper.html
+                  page.basename:      md-helper
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  md-helper.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/alert.hbs
+                  dest:               test/actual/plugin_preprocess/alert.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           alert.html
+                  pagename:           alert.html
+                  basename:           alert
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       alert.html
+                  -->
+<li><a href="collections-pages.html" class="">collections-pages</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-pages.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-pages.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-pages.html
+                  this.pagename:      collections-pages.html
+                  this.basename:      collections-pages
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-pages.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/md-helper.hbs
+                  page.dest:          test/actual/plugin_preprocess/md-helper.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      md-helper.html
+                  page.pagename:      md-helper.html
+                  page.basename:      md-helper
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  md-helper.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-pages.hbs
+                  dest:               test/actual/plugin_preprocess/collections-pages.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-pages.html
+                  pagename:           collections-pages.html
+                  basename:           collections-pages
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-pages.html
+                  -->
+<li><a href="collections-tags.html" class="">collections-tags</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-tags.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-tags.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-tags.html
+                  this.pagename:      collections-tags.html
+                  this.basename:      collections-tags
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-tags.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/md-helper.hbs
+                  page.dest:          test/actual/plugin_preprocess/md-helper.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      md-helper.html
+                  page.pagename:      md-helper.html
+                  page.basename:      md-helper
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  md-helper.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-tags.hbs
+                  dest:               test/actual/plugin_preprocess/collections-tags.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-tags.html
+                  pagename:           collections-tags.html
+                  basename:           collections-tags
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-tags.html
+                  -->
+<li><a href="collections.html" class="">collections</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections.html
+                  this.pagename:      collections.html
+                  this.basename:      collections
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/md-helper.hbs
+                  page.dest:          test/actual/plugin_preprocess/md-helper.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      md-helper.html
+                  page.pagename:      md-helper.html
+                  page.basename:      md-helper
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  md-helper.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections.hbs
+                  dest:               test/actual/plugin_preprocess/collections.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections.html
+                  pagename:           collections.html
+                  basename:           collections
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections.html
+                  -->
+<li><a href="complex.html" class="">complex</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/complex.hbs
+                  this.dest:          test/actual/plugin_preprocess/complex.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      complex.html
+                  this.pagename:      complex.html
+                  this.basename:      complex
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  complex.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/md-helper.hbs
+                  page.dest:          test/actual/plugin_preprocess/md-helper.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      md-helper.html
+                  page.pagename:      md-helper.html
+                  page.basename:      md-helper
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  md-helper.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/complex.hbs
+                  dest:               test/actual/plugin_preprocess/complex.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           complex.html
+                  pagename:           complex.html
+                  basename:           complex
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       complex.html
+                  -->
+<li><a href="context.html" class="">context</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/context.hbs
+                  this.dest:          test/actual/plugin_preprocess/context.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      context.html
+                  this.pagename:      context.html
+                  this.basename:      context
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  context.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/md-helper.hbs
+                  page.dest:          test/actual/plugin_preprocess/md-helper.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      md-helper.html
+                  page.pagename:      md-helper.html
+                  page.basename:      md-helper
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  md-helper.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/context.hbs
+                  dest:               test/actual/plugin_preprocess/context.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           context.html
+                  pagename:           context.html
+                  basename:           context
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       context.html
+                  -->
+<li><a href="debug-helpers.html" class="">debug-helpers</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/debug-helpers.hbs
+                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      debug-helpers.html
+                  this.pagename:      debug-helpers.html
+                  this.basename:      debug-helpers
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  debug-helpers.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/md-helper.hbs
+                  page.dest:          test/actual/plugin_preprocess/md-helper.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      md-helper.html
+                  page.pagename:      md-helper.html
+                  page.basename:      md-helper
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  md-helper.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/debug-helpers.hbs
+                  dest:               test/actual/plugin_preprocess/debug-helpers.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           debug-helpers.html
+                  pagename:           debug-helpers.html
+                  basename:           debug-helpers
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       debug-helpers.html
+                  -->
+<li><a href="collections-categories.html" class="">collections-categories</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-categories.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-categories.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-categories.html
+                  this.pagename:      collections-categories.html
+                  this.basename:      collections-categories
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-categories.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/md-helper.hbs
+                  page.dest:          test/actual/plugin_preprocess/md-helper.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      md-helper.html
+                  page.pagename:      md-helper.html
+                  page.basename:      md-helper
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  md-helper.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-categories.hbs
+                  dest:               test/actual/plugin_preprocess/collections-categories.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-categories.html
+                  pagename:           collections-categories.html
+                  basename:           collections-categories
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-categories.html
+                  -->
+<li><a href="gist-helper.html" class="">gist-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1130,7 +877,7 @@
                   this.pagename:      gist-helper.html
                   this.basename:      gist-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  gist-helper.html
 
                   "page"
@@ -1142,7 +889,7 @@
                   page.pagename:      md-helper.html
                   page.basename:      md-helper
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  md-helper.html
 
                   "root"
@@ -1154,10 +901,10 @@
                   pagename:           gist-helper.html
                   basename:           gist-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       gist-helper.html
                   -->
-                <li><a href="lodash.html" class="">lodash</a></li>
+<li><a href="lodash.html" class="">lodash</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1168,7 +915,7 @@
                   this.pagename:      lodash.html
                   this.basename:      lodash
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  lodash.html
 
                   "page"
@@ -1180,7 +927,7 @@
                   page.pagename:      md-helper.html
                   page.basename:      md-helper
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  md-helper.html
 
                   "root"
@@ -1192,10 +939,10 @@
                   pagename:           lodash.html
                   basename:           lodash
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       lodash.html
                   -->
-                <li><a href="md-helper.html" class="active">md-helper</a></li>
+<li><a href="md-helper.html" class="active">md-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1218,7 +965,7 @@
                   page.pagename:      md-helper.html
                   page.basename:      md-helper
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  md-helper.html
 
                   "root"
@@ -1233,7 +980,45 @@
                   isCurrentPage:           true
                   relativeLink:       md-helper.html
                   -->
-                <li><a href="no-yfm.html" class="">no-yfm</a></li>
+<li><a href="no-yfm-data.html" class="">no-yfm-data</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      no-yfm-data.html
+                  this.pagename:      no-yfm-data.html
+                  this.basename:      no-yfm-data
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  no-yfm-data.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/md-helper.hbs
+                  page.dest:          test/actual/plugin_preprocess/md-helper.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      md-helper.html
+                  page.pagename:      md-helper.html
+                  page.basename:      md-helper
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  md-helper.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/no-yfm-data.hbs
+                  dest:               test/actual/plugin_preprocess/no-yfm-data.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           no-yfm-data.html
+                  pagename:           no-yfm-data.html
+                  basename:           no-yfm-data
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       no-yfm-data.html
+                  -->
+<li><a href="no-yfm.html" class="">no-yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1244,7 +1029,7 @@
                   this.pagename:      no-yfm.html
                   this.basename:      no-yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  no-yfm.html
 
                   "page"
@@ -1256,7 +1041,7 @@
                   page.pagename:      md-helper.html
                   page.basename:      md-helper
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  md-helper.html
 
                   "root"
@@ -1268,10 +1053,10 @@
                   pagename:           no-yfm.html
                   basename:           no-yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       no-yfm.html
                   -->
-                <li><a href="yfm-context.html" class="">yfm-context</a></li>
+<li><a href="yfm-context.html" class="">yfm-context</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1282,7 +1067,7 @@
                   this.pagename:      yfm-context.html
                   this.basename:      yfm-context
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm-context.html
 
                   "page"
@@ -1294,7 +1079,7 @@
                   page.pagename:      md-helper.html
                   page.basename:      md-helper
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  md-helper.html
 
                   "root"
@@ -1306,10 +1091,10 @@
                   pagename:           yfm-context.html
                   basename:           yfm-context
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm-context.html
                   -->
-                <li><a href="yfm.html" class="">yfm</a></li>
+<li><a href="yfm.html" class="">yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1320,7 +1105,7 @@
                   this.pagename:      yfm.html
                   this.basename:      yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm.html
 
                   "page"
@@ -1332,7 +1117,7 @@
                   page.pagename:      md-helper.html
                   page.basename:      md-helper
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  md-helper.html
 
                   "root"
@@ -1344,10 +1129,9 @@
                   pagename:           yfm.html
                   basename:           yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm.html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1396,6 +1180,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"

--- a/test/actual/plugin_preprocess/no-yfm-data.html
+++ b/test/actual/plugin_preprocess/no-yfm-data.html
@@ -1,0 +1,1183 @@
+<!DOCTYPE html>
+  <html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Layout filename: ''</title>
+    <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../assets/validation.css">
+  </head>
+  <body style="padding-top: 60px;">
+    <div class="container">
+
+      <!-- validate assets path -->
+      <section id="validate"></section>
+      <div class="docs-section">
+        <div class="docs-header" id="content">
+          <h4><strong class="text-muted">test/fixtures/pages/no-yfm-data.hbs</strong> &#x2192; <strong class="text-success">test/actual/plugin_preprocess/no-yfm-data.html</strong></h4>
+        </div>
+        <hr>
+      </div>
+
+      <ul class="pager">
+
+
+    <li class="previous">
+      <a href="example.html">First</a>
+    </li>
+    <li class="previous">
+      <a href="md-helper.html">&larr; Previous</a>
+    </li>
+
+    <li class="pager-middle">
+      <a href="example.html">1</a>
+    </li>
+    <li class="pager-middle">
+      <a href="alert.html">2</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections-pages.html">3</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections-tags.html">4</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections.html">5</a>
+    </li>
+    <li class="pager-middle">
+      <a href="complex.html">6</a>
+    </li>
+    <li class="pager-middle">
+      <a href="context.html">7</a>
+    </li>
+    <li class="pager-middle">
+      <a href="debug-helpers.html">8</a>
+    </li>
+    <li class="pager-middle">
+      <a href="collections-categories.html">9</a>
+    </li>
+    <li class="pager-middle">
+      <a href="gist-helper.html">10</a>
+    </li>
+    <li class="pager-middle">
+      <a href="lodash.html">11</a>
+    </li>
+    <li class="pager-middle">
+      <a href="md-helper.html">12</a>
+    </li>
+    <li class="active pager-middle">
+      <a href="no-yfm-data.html">13</a>
+    </li>
+    <li class="pager-middle">
+      <a href="no-yfm.html">14</a>
+    </li>
+    <li class="pager-middle">
+      <a href="yfm-context.html">15</a>
+    </li>
+    <li class="pager-middle">
+      <a href="yfm.html">16</a>
+    </li>
+
+    <li class="next">
+      <a href="yfm.html">Last</a>
+    </li>
+    <li class="next">
+      <a href="no-yfm.html">Next &rarr;</a>
+    </li>
+
+
+</ul><style>
+.unselectable {
+  -webkit-touch-callout: none;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+}
+</style>
+      <hr>
+
+      <div class="row">
+        <!-- Column: sidebar -->
+        <div class="col-md-3">
+          <div class="bs-sidebar hidden-print" role="complementary">
+            <!-- pagination -->
+            <ul class="nav nav-pills nav-stacked">
+
+
+    <li class="prev">
+      <a href="example.html">First</a>
+    </li>
+    <li class="prev">
+      <a href="md-helper.html">&larr; Previous</a>
+    </li>
+
+    <li>
+      <a href="example.html">1</a>
+    </li>
+    <li>
+      <a href="alert.html">2</a>
+    </li>
+    <li>
+      <a href="collections-pages.html">3</a>
+    </li>
+    <li>
+      <a href="collections-tags.html">4</a>
+    </li>
+    <li>
+      <a href="collections.html">5</a>
+    </li>
+    <li>
+      <a href="complex.html">6</a>
+    </li>
+    <li>
+      <a href="context.html">7</a>
+    </li>
+    <li>
+      <a href="debug-helpers.html">8</a>
+    </li>
+    <li>
+      <a href="collections-categories.html">9</a>
+    </li>
+    <li>
+      <a href="gist-helper.html">10</a>
+    </li>
+    <li>
+      <a href="lodash.html">11</a>
+    </li>
+    <li>
+      <a href="md-helper.html">12</a>
+    </li>
+    <li class="active">
+      <a href="no-yfm-data.html">13</a>
+    </li>
+    <li>
+      <a href="no-yfm.html">14</a>
+    </li>
+    <li>
+      <a href="yfm-context.html">15</a>
+    </li>
+    <li>
+      <a href="yfm.html">16</a>
+    </li>
+
+    <li class="next">
+      <a href="no-yfm.html">Next &rarr;</a>
+    </li>
+    <li class="next">
+      <a href="yfm.html">Last</a>
+    </li>
+
+
+</ul>
+          </div>
+        </div>
+        <!-- Column: content -->
+        <div class="col-md-9" role="main">
+          <div class="docs-section">
+            <div class="docs-header" id="content">
+              <h4><strong>Page layout:</strong> preprocess.hbs</h4>
+              <h4><strong>Page src:</strong> test/fixtures/pages/no-yfm-data.hbs</h4>
+              <h4><strong>Page dest:</strong> test/actual/plugin_preprocess/no-yfm-data.html</h4>
+              <h4><strong>Dest filename:</strong> no-yfm-data.html</h4>
+              <h4><strong>Dest basename:</strong> no-yfm-data</h4>
+              <h4><strong>Page title:</strong> (no title defined)</h4>
+            </div>
+
+            <hr>
+            <div class="row">
+              <div class="col-md-6">
+                <!-- Categories Collection -->
+                  
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
+              </div>
+              <div class="col-md-6">
+                  
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
+              </div>
+            </div>
+
+            <hr>
+
+            There is no YAML front matter in this page.
+
+<ul>
+  <li>first</li>
+  <li>second</li>
+  <li>third</li>
+  <li>globalData1</li>
+</ul>
+
+
+            <div class="docs-header" id="content">
+              <h1>Content</h1>
+            </div>
+            <ul>
+              <li><a href="example.html">example.html</a></li>
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
+              <li><a href="gist-helper.html">gist-helper.html</a></li>
+              <li><a href="lodash.html">lodash.html</a></li>
+              <li><a href="md-helper.html">md-helper.html</a></li>
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
+              <li><a href="no-yfm.html">no-yfm.html</a></li>
+              <li><a href="yfm-context.html">yfm-context.html</a></li>
+              <li><a href="yfm.html">yfm.html</a></li>
+            </ul>
+
+            <hr>
+            <div style="display: none">
+
+              <h1>Page</h1>
+              <h1>Each pages</h1>
+              <ul>
+                <li><a href="example.html" class="">example</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/example.hbs
+                  this.dest:          test/actual/plugin_preprocess/example.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      example.html
+                  this.pagename:      example.html
+                  this.basename:      example
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  example.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm-data.html
+                  page.pagename:      no-yfm-data.html
+                  page.basename:      no-yfm-data
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm-data.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/example.hbs
+                  dest:               test/actual/plugin_preprocess/example.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           example.html
+                  pagename:           example.html
+                  basename:           example
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       example.html
+                  -->
+<li><a href="alert.html" class="">alert</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/alert.hbs
+                  this.dest:          test/actual/plugin_preprocess/alert.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      alert.html
+                  this.pagename:      alert.html
+                  this.basename:      alert
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  alert.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm-data.html
+                  page.pagename:      no-yfm-data.html
+                  page.basename:      no-yfm-data
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm-data.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/alert.hbs
+                  dest:               test/actual/plugin_preprocess/alert.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           alert.html
+                  pagename:           alert.html
+                  basename:           alert
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       alert.html
+                  -->
+<li><a href="collections-pages.html" class="">collections-pages</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-pages.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-pages.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-pages.html
+                  this.pagename:      collections-pages.html
+                  this.basename:      collections-pages
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-pages.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm-data.html
+                  page.pagename:      no-yfm-data.html
+                  page.basename:      no-yfm-data
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm-data.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-pages.hbs
+                  dest:               test/actual/plugin_preprocess/collections-pages.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-pages.html
+                  pagename:           collections-pages.html
+                  basename:           collections-pages
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-pages.html
+                  -->
+<li><a href="collections-tags.html" class="">collections-tags</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-tags.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-tags.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-tags.html
+                  this.pagename:      collections-tags.html
+                  this.basename:      collections-tags
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-tags.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm-data.html
+                  page.pagename:      no-yfm-data.html
+                  page.basename:      no-yfm-data
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm-data.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-tags.hbs
+                  dest:               test/actual/plugin_preprocess/collections-tags.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-tags.html
+                  pagename:           collections-tags.html
+                  basename:           collections-tags
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-tags.html
+                  -->
+<li><a href="collections.html" class="">collections</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections.html
+                  this.pagename:      collections.html
+                  this.basename:      collections
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm-data.html
+                  page.pagename:      no-yfm-data.html
+                  page.basename:      no-yfm-data
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm-data.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections.hbs
+                  dest:               test/actual/plugin_preprocess/collections.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections.html
+                  pagename:           collections.html
+                  basename:           collections
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections.html
+                  -->
+<li><a href="complex.html" class="">complex</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/complex.hbs
+                  this.dest:          test/actual/plugin_preprocess/complex.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      complex.html
+                  this.pagename:      complex.html
+                  this.basename:      complex
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  complex.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm-data.html
+                  page.pagename:      no-yfm-data.html
+                  page.basename:      no-yfm-data
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm-data.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/complex.hbs
+                  dest:               test/actual/plugin_preprocess/complex.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           complex.html
+                  pagename:           complex.html
+                  basename:           complex
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       complex.html
+                  -->
+<li><a href="context.html" class="">context</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/context.hbs
+                  this.dest:          test/actual/plugin_preprocess/context.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      context.html
+                  this.pagename:      context.html
+                  this.basename:      context
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  context.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm-data.html
+                  page.pagename:      no-yfm-data.html
+                  page.basename:      no-yfm-data
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm-data.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/context.hbs
+                  dest:               test/actual/plugin_preprocess/context.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           context.html
+                  pagename:           context.html
+                  basename:           context
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       context.html
+                  -->
+<li><a href="debug-helpers.html" class="">debug-helpers</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/debug-helpers.hbs
+                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      debug-helpers.html
+                  this.pagename:      debug-helpers.html
+                  this.basename:      debug-helpers
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  debug-helpers.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm-data.html
+                  page.pagename:      no-yfm-data.html
+                  page.basename:      no-yfm-data
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm-data.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/debug-helpers.hbs
+                  dest:               test/actual/plugin_preprocess/debug-helpers.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           debug-helpers.html
+                  pagename:           debug-helpers.html
+                  basename:           debug-helpers
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       debug-helpers.html
+                  -->
+<li><a href="collections-categories.html" class="">collections-categories</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-categories.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-categories.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-categories.html
+                  this.pagename:      collections-categories.html
+                  this.basename:      collections-categories
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-categories.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm-data.html
+                  page.pagename:      no-yfm-data.html
+                  page.basename:      no-yfm-data
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm-data.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-categories.hbs
+                  dest:               test/actual/plugin_preprocess/collections-categories.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-categories.html
+                  pagename:           collections-categories.html
+                  basename:           collections-categories
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-categories.html
+                  -->
+<li><a href="gist-helper.html" class="">gist-helper</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/gist-helper.hbs
+                  this.dest:          test/actual/plugin_preprocess/gist-helper.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      gist-helper.html
+                  this.pagename:      gist-helper.html
+                  this.basename:      gist-helper
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  gist-helper.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm-data.html
+                  page.pagename:      no-yfm-data.html
+                  page.basename:      no-yfm-data
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm-data.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/gist-helper.hbs
+                  dest:               test/actual/plugin_preprocess/gist-helper.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           gist-helper.html
+                  pagename:           gist-helper.html
+                  basename:           gist-helper
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       gist-helper.html
+                  -->
+<li><a href="lodash.html" class="">lodash</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/lodash.hbs
+                  this.dest:          test/actual/plugin_preprocess/lodash.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      lodash.html
+                  this.pagename:      lodash.html
+                  this.basename:      lodash
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  lodash.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm-data.html
+                  page.pagename:      no-yfm-data.html
+                  page.basename:      no-yfm-data
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm-data.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/lodash.hbs
+                  dest:               test/actual/plugin_preprocess/lodash.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           lodash.html
+                  pagename:           lodash.html
+                  basename:           lodash
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       lodash.html
+                  -->
+<li><a href="md-helper.html" class="">md-helper</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/md-helper.hbs
+                  this.dest:          test/actual/plugin_preprocess/md-helper.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      md-helper.html
+                  this.pagename:      md-helper.html
+                  this.basename:      md-helper
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  md-helper.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm-data.html
+                  page.pagename:      no-yfm-data.html
+                  page.basename:      no-yfm-data
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm-data.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/md-helper.hbs
+                  dest:               test/actual/plugin_preprocess/md-helper.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           md-helper.html
+                  pagename:           md-helper.html
+                  basename:           md-helper
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       md-helper.html
+                  -->
+<li><a href="no-yfm-data.html" class="active">no-yfm-data</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      no-yfm-data.html
+                  this.pagename:      no-yfm-data.html
+                  this.basename:      no-yfm-data
+                  this.ext:           .html
+                  this.isCurrentPage:      true
+                  this.relativeLink:  no-yfm-data.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm-data.html
+                  page.pagename:      no-yfm-data.html
+                  page.basename:      no-yfm-data
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm-data.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/no-yfm-data.hbs
+                  dest:               test/actual/plugin_preprocess/no-yfm-data.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           no-yfm-data.html
+                  pagename:           no-yfm-data.html
+                  basename:           no-yfm-data
+                  ext:                .html
+                  isCurrentPage:           true
+                  relativeLink:       no-yfm-data.html
+                  -->
+<li><a href="no-yfm.html" class="">no-yfm</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/no-yfm.hbs
+                  this.dest:          test/actual/plugin_preprocess/no-yfm.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      no-yfm.html
+                  this.pagename:      no-yfm.html
+                  this.basename:      no-yfm
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  no-yfm.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm-data.html
+                  page.pagename:      no-yfm-data.html
+                  page.basename:      no-yfm-data
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm-data.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/no-yfm.hbs
+                  dest:               test/actual/plugin_preprocess/no-yfm.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           no-yfm.html
+                  pagename:           no-yfm.html
+                  basename:           no-yfm
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       no-yfm.html
+                  -->
+<li><a href="yfm-context.html" class="">yfm-context</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/yfm-context.hbs
+                  this.dest:          test/actual/plugin_preprocess/yfm-context.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      yfm-context.html
+                  this.pagename:      yfm-context.html
+                  this.basename:      yfm-context
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  yfm-context.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm-data.html
+                  page.pagename:      no-yfm-data.html
+                  page.basename:      no-yfm-data
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm-data.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/yfm-context.hbs
+                  dest:               test/actual/plugin_preprocess/yfm-context.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           yfm-context.html
+                  pagename:           yfm-context.html
+                  basename:           yfm-context
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       yfm-context.html
+                  -->
+<li><a href="yfm.html" class="">yfm</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/yfm.hbs
+                  this.dest:          test/actual/plugin_preprocess/yfm.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      yfm.html
+                  this.pagename:      yfm.html
+                  this.basename:      yfm
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  yfm.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm-data.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm-data.html
+                  page.pagename:      no-yfm-data.html
+                  page.basename:      no-yfm-data
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm-data.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/yfm.hbs
+                  dest:               test/actual/plugin_preprocess/yfm.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           yfm.html
+                  pagename:           yfm.html
+                  basename:           yfm
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       yfm.html
+                  -->
+              </ul>
+
+              <h1>Debug Info</h1>
+              <pre><code class="json">
+{
+  "_page": "all",
+  "assets": "../../assets",
+  "basename": "no-yfm-data",
+  "data": {},
+  "dest": "test/actual/plugin_preprocess/no-yfm-data.html",
+  "dirname": "test/actual/plugin_preprocess",
+  "ext": ".html",
+  "extname": ".html",
+  "filePair": {
+    "src": [
+      "test/fixtures/pages/alert.hbs",
+      "test/fixtures/pages/collections-categories.hbs",
+      "test/fixtures/pages/collections-pages.hbs",
+      "test/fixtures/pages/collections-tags.hbs",
+      "test/fixtures/pages/collections.hbs",
+      "test/fixtures/pages/complex.hbs",
+      "test/fixtures/pages/context.hbs",
+      "test/fixtures/pages/debug-helpers.hbs",
+      "test/fixtures/pages/example.hbs",
+      "test/fixtures/pages/gist-helper.hbs",
+      "test/fixtures/pages/lodash.hbs",
+      "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
+      "test/fixtures/pages/no-yfm.hbs",
+      "test/fixtures/pages/yfm-context.hbs",
+      "test/fixtures/pages/yfm.hbs"
+    ],
+    "dest": "test/actual/plugin_preprocess/",
+    "orig": {
+      "src": [
+        "test/fixtures/pages/*.hbs"
+      ],
+      "dest": "test/actual/plugin_preprocess/"
+    }
+  },
+  "filename": "no-yfm-data.html",
+  "first": false,
+  "index": 12,
+  "isCurrentPage": false,
+  "last": false,
+  "middle": true,
+  "next": 13,
+  "number": 13,
+  "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            There is no YAML front matter in this page.\n\n<ul>\n  <li>{{one}}</li>\n  <li>{{two}}</li>\n  <li>{{three}}</li>\n  <li>{{global1}}</li>\n</ul>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relative ../page.dest dest}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\" class=\"{{#isCurrentPage}}active{{/isCurrentPage}}\">{{basename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:           {{this.src}}\n                  this.dest:          {{this.dest}}\n                  this.dirname:       {{this.dirname}}\n                  this.filename:      {{this.filename}}\n                  this.pagename:      {{this.pagename}}\n                  this.basename:      {{this.basename}}\n                  this.ext:           {{this.ext}}\n                  this.isCurrentPage:      {{this.isCurrentPage}}\n                  this.relativeLink:  {{this.relativeLink}}\n\n                  \"page\"\n                  ===============================\n                  page.src:           {{../page.src}}\n                  page.dest:          {{../page.dest}}\n                  page.dirname:       {{../page.dirname}}\n                  page.filename:      {{../page.filename}}\n                  page.pagename:      {{../page.pagename}}\n                  page.basename:      {{../page.basename}}\n                  page.ext:           {{../page.ext}}\n                  page.isCurrentPage:      {{../page.isCurrentPage}}\n                  page.relativeLink:  {{../page.relativeLink}}\n\n                  \"root\"\n                  ===============================\n                  src:                {{src}}\n                  dest:               {{dest}}\n                  dirname:            {{dirname}}\n                  filename:           {{filename}}\n                  pagename:           {{pagename}}\n                  basename:           {{basename}}\n                  ext:                {{ext}}\n                  isCurrentPage:           {{isCurrentPage}}\n                  relativeLink:       {{relativeLink}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
+  "pageName": "no-yfm-data.html",
+  "pagename": "no-yfm-data.html",
+  "prev": 11,
+  "relativeLink": "no-yfm-data.html",
+  "src": "test/fixtures/pages/no-yfm-data.hbs"
+}
+</code></pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script src="../../assets/validation.js"></script>
+  </body>
+</html>

--- a/test/actual/plugin_preprocess/no-yfm.html
+++ b/test/actual/plugin_preprocess/no-yfm.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
-      <a href="md-helper.html">&larr; Previous</a>
+      <a href="no-yfm-data.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="no-yfm-data.html">13</a>
+    </li>
     <li class="active pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="yfm-context.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
-      <a href="md-helper.html">&larr; Previous</a>
+      <a href="no-yfm-data.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
+    <li>
+      <a href="no-yfm-data.html">13</a>
+    </li>
     <li class="active">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="yfm-context.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -714,37 +483,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -753,310 +507,6 @@
               <h1>Page</h1>
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html" class="">debug-helpers</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/debug-helpers.hbs
-                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      debug-helpers.html
-                  this.pagename:      debug-helpers.html
-                  this.basename:      debug-helpers
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  debug-helpers.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/no-yfm.hbs
-                  page.dest:          test/actual/plugin_preprocess/no-yfm.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      no-yfm.html
-                  page.pagename:      no-yfm.html
-                  page.basename:      no-yfm
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  no-yfm.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/debug-helpers.hbs
-                  dest:               test/actual/plugin_preprocess/debug-helpers.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           debug-helpers.html
-                  pagename:           debug-helpers.html
-                  basename:           debug-helpers
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       debug-helpers.html
-                  -->
-                <li><a href="alert.html" class="">alert</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/alert.hbs
-                  this.dest:          test/actual/plugin_preprocess/alert.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      alert.html
-                  this.pagename:      alert.html
-                  this.basename:      alert
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  alert.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/no-yfm.hbs
-                  page.dest:          test/actual/plugin_preprocess/no-yfm.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      no-yfm.html
-                  page.pagename:      no-yfm.html
-                  page.basename:      no-yfm
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  no-yfm.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/alert.hbs
-                  dest:               test/actual/plugin_preprocess/alert.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           alert.html
-                  pagename:           alert.html
-                  basename:           alert
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       alert.html
-                  -->
-                <li><a href="collections-pages.html" class="">collections-pages</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-pages.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-pages.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-pages.html
-                  this.pagename:      collections-pages.html
-                  this.basename:      collections-pages
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-pages.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/no-yfm.hbs
-                  page.dest:          test/actual/plugin_preprocess/no-yfm.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      no-yfm.html
-                  page.pagename:      no-yfm.html
-                  page.basename:      no-yfm
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  no-yfm.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-pages.hbs
-                  dest:               test/actual/plugin_preprocess/collections-pages.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-pages.html
-                  pagename:           collections-pages.html
-                  basename:           collections-pages
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-pages.html
-                  -->
-                <li><a href="collections-tags.html" class="">collections-tags</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-tags.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-tags.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-tags.html
-                  this.pagename:      collections-tags.html
-                  this.basename:      collections-tags
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-tags.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/no-yfm.hbs
-                  page.dest:          test/actual/plugin_preprocess/no-yfm.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      no-yfm.html
-                  page.pagename:      no-yfm.html
-                  page.basename:      no-yfm
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  no-yfm.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-tags.hbs
-                  dest:               test/actual/plugin_preprocess/collections-tags.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-tags.html
-                  pagename:           collections-tags.html
-                  basename:           collections-tags
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-tags.html
-                  -->
-                <li><a href="collections.html" class="">collections</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections.html
-                  this.pagename:      collections.html
-                  this.basename:      collections
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/no-yfm.hbs
-                  page.dest:          test/actual/plugin_preprocess/no-yfm.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      no-yfm.html
-                  page.pagename:      no-yfm.html
-                  page.basename:      no-yfm
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  no-yfm.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections.hbs
-                  dest:               test/actual/plugin_preprocess/collections.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections.html
-                  pagename:           collections.html
-                  basename:           collections
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections.html
-                  -->
-                <li><a href="complex.html" class="">complex</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/complex.hbs
-                  this.dest:          test/actual/plugin_preprocess/complex.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      complex.html
-                  this.pagename:      complex.html
-                  this.basename:      complex
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  complex.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/no-yfm.hbs
-                  page.dest:          test/actual/plugin_preprocess/no-yfm.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      no-yfm.html
-                  page.pagename:      no-yfm.html
-                  page.basename:      no-yfm
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  no-yfm.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/complex.hbs
-                  dest:               test/actual/plugin_preprocess/complex.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           complex.html
-                  pagename:           complex.html
-                  basename:           complex
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       complex.html
-                  -->
-                <li><a href="context.html" class="">context</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/context.hbs
-                  this.dest:          test/actual/plugin_preprocess/context.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      context.html
-                  this.pagename:      context.html
-                  this.basename:      context
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  context.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/no-yfm.hbs
-                  page.dest:          test/actual/plugin_preprocess/no-yfm.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      no-yfm.html
-                  page.pagename:      no-yfm.html
-                  page.basename:      no-yfm
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  no-yfm.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/context.hbs
-                  dest:               test/actual/plugin_preprocess/context.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           context.html
-                  pagename:           context.html
-                  basename:           context
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       context.html
-                  -->
-                <li><a href="collections-categories.html" class="">collections-categories</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-categories.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-categories.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-categories.html
-                  this.pagename:      collections-categories.html
-                  this.basename:      collections-categories
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-categories.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/no-yfm.hbs
-                  page.dest:          test/actual/plugin_preprocess/no-yfm.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      no-yfm.html
-                  page.pagename:      no-yfm.html
-                  page.basename:      no-yfm
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  no-yfm.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-categories.hbs
-                  dest:               test/actual/plugin_preprocess/collections-categories.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-categories.html
-                  pagename:           collections-categories.html
-                  basename:           collections-categories
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-categories.html
-                  -->
                 <li><a href="example.html" class="">example</a></li>
                   <!--
                   "this"
@@ -1068,7 +518,7 @@
                   this.pagename:      example.html
                   this.basename:      example
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  example.html
 
                   "page"
@@ -1080,7 +530,7 @@
                   page.pagename:      no-yfm.html
                   page.basename:      no-yfm
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  no-yfm.html
 
                   "root"
@@ -1092,10 +542,314 @@
                   pagename:           example.html
                   basename:           example
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       example.html
                   -->
-                <li><a href="gist-helper.html" class="">gist-helper</a></li>
+<li><a href="alert.html" class="">alert</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/alert.hbs
+                  this.dest:          test/actual/plugin_preprocess/alert.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      alert.html
+                  this.pagename:      alert.html
+                  this.basename:      alert
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  alert.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm.html
+                  page.pagename:      no-yfm.html
+                  page.basename:      no-yfm
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/alert.hbs
+                  dest:               test/actual/plugin_preprocess/alert.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           alert.html
+                  pagename:           alert.html
+                  basename:           alert
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       alert.html
+                  -->
+<li><a href="collections-pages.html" class="">collections-pages</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-pages.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-pages.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-pages.html
+                  this.pagename:      collections-pages.html
+                  this.basename:      collections-pages
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-pages.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm.html
+                  page.pagename:      no-yfm.html
+                  page.basename:      no-yfm
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-pages.hbs
+                  dest:               test/actual/plugin_preprocess/collections-pages.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-pages.html
+                  pagename:           collections-pages.html
+                  basename:           collections-pages
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-pages.html
+                  -->
+<li><a href="collections-tags.html" class="">collections-tags</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-tags.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-tags.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-tags.html
+                  this.pagename:      collections-tags.html
+                  this.basename:      collections-tags
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-tags.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm.html
+                  page.pagename:      no-yfm.html
+                  page.basename:      no-yfm
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-tags.hbs
+                  dest:               test/actual/plugin_preprocess/collections-tags.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-tags.html
+                  pagename:           collections-tags.html
+                  basename:           collections-tags
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-tags.html
+                  -->
+<li><a href="collections.html" class="">collections</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections.html
+                  this.pagename:      collections.html
+                  this.basename:      collections
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm.html
+                  page.pagename:      no-yfm.html
+                  page.basename:      no-yfm
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections.hbs
+                  dest:               test/actual/plugin_preprocess/collections.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections.html
+                  pagename:           collections.html
+                  basename:           collections
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections.html
+                  -->
+<li><a href="complex.html" class="">complex</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/complex.hbs
+                  this.dest:          test/actual/plugin_preprocess/complex.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      complex.html
+                  this.pagename:      complex.html
+                  this.basename:      complex
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  complex.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm.html
+                  page.pagename:      no-yfm.html
+                  page.basename:      no-yfm
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/complex.hbs
+                  dest:               test/actual/plugin_preprocess/complex.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           complex.html
+                  pagename:           complex.html
+                  basename:           complex
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       complex.html
+                  -->
+<li><a href="context.html" class="">context</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/context.hbs
+                  this.dest:          test/actual/plugin_preprocess/context.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      context.html
+                  this.pagename:      context.html
+                  this.basename:      context
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  context.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm.html
+                  page.pagename:      no-yfm.html
+                  page.basename:      no-yfm
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/context.hbs
+                  dest:               test/actual/plugin_preprocess/context.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           context.html
+                  pagename:           context.html
+                  basename:           context
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       context.html
+                  -->
+<li><a href="debug-helpers.html" class="">debug-helpers</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/debug-helpers.hbs
+                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      debug-helpers.html
+                  this.pagename:      debug-helpers.html
+                  this.basename:      debug-helpers
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  debug-helpers.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm.html
+                  page.pagename:      no-yfm.html
+                  page.basename:      no-yfm
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/debug-helpers.hbs
+                  dest:               test/actual/plugin_preprocess/debug-helpers.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           debug-helpers.html
+                  pagename:           debug-helpers.html
+                  basename:           debug-helpers
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       debug-helpers.html
+                  -->
+<li><a href="collections-categories.html" class="">collections-categories</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-categories.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-categories.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-categories.html
+                  this.pagename:      collections-categories.html
+                  this.basename:      collections-categories
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-categories.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm.html
+                  page.pagename:      no-yfm.html
+                  page.basename:      no-yfm
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-categories.hbs
+                  dest:               test/actual/plugin_preprocess/collections-categories.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-categories.html
+                  pagename:           collections-categories.html
+                  basename:           collections-categories
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-categories.html
+                  -->
+<li><a href="gist-helper.html" class="">gist-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1106,7 +860,7 @@
                   this.pagename:      gist-helper.html
                   this.basename:      gist-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  gist-helper.html
 
                   "page"
@@ -1118,7 +872,7 @@
                   page.pagename:      no-yfm.html
                   page.basename:      no-yfm
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  no-yfm.html
 
                   "root"
@@ -1130,10 +884,10 @@
                   pagename:           gist-helper.html
                   basename:           gist-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       gist-helper.html
                   -->
-                <li><a href="lodash.html" class="">lodash</a></li>
+<li><a href="lodash.html" class="">lodash</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1144,7 +898,7 @@
                   this.pagename:      lodash.html
                   this.basename:      lodash
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  lodash.html
 
                   "page"
@@ -1156,7 +910,7 @@
                   page.pagename:      no-yfm.html
                   page.basename:      no-yfm
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  no-yfm.html
 
                   "root"
@@ -1168,10 +922,10 @@
                   pagename:           lodash.html
                   basename:           lodash
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       lodash.html
                   -->
-                <li><a href="md-helper.html" class="">md-helper</a></li>
+<li><a href="md-helper.html" class="">md-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1182,7 +936,7 @@
                   this.pagename:      md-helper.html
                   this.basename:      md-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  md-helper.html
 
                   "page"
@@ -1194,7 +948,7 @@
                   page.pagename:      no-yfm.html
                   page.basename:      no-yfm
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  no-yfm.html
 
                   "root"
@@ -1206,10 +960,48 @@
                   pagename:           md-helper.html
                   basename:           md-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       md-helper.html
                   -->
-                <li><a href="no-yfm.html" class="active">no-yfm</a></li>
+<li><a href="no-yfm-data.html" class="">no-yfm-data</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      no-yfm-data.html
+                  this.pagename:      no-yfm-data.html
+                  this.basename:      no-yfm-data
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  no-yfm-data.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/no-yfm.hbs
+                  page.dest:          test/actual/plugin_preprocess/no-yfm.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      no-yfm.html
+                  page.pagename:      no-yfm.html
+                  page.basename:      no-yfm
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  no-yfm.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/no-yfm-data.hbs
+                  dest:               test/actual/plugin_preprocess/no-yfm-data.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           no-yfm-data.html
+                  pagename:           no-yfm-data.html
+                  basename:           no-yfm-data
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       no-yfm-data.html
+                  -->
+<li><a href="no-yfm.html" class="active">no-yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1232,7 +1024,7 @@
                   page.pagename:      no-yfm.html
                   page.basename:      no-yfm
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  no-yfm.html
 
                   "root"
@@ -1247,7 +1039,7 @@
                   isCurrentPage:           true
                   relativeLink:       no-yfm.html
                   -->
-                <li><a href="yfm-context.html" class="">yfm-context</a></li>
+<li><a href="yfm-context.html" class="">yfm-context</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1258,7 +1050,7 @@
                   this.pagename:      yfm-context.html
                   this.basename:      yfm-context
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm-context.html
 
                   "page"
@@ -1270,7 +1062,7 @@
                   page.pagename:      no-yfm.html
                   page.basename:      no-yfm
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  no-yfm.html
 
                   "root"
@@ -1282,10 +1074,10 @@
                   pagename:           yfm-context.html
                   basename:           yfm-context
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm-context.html
                   -->
-                <li><a href="yfm.html" class="">yfm</a></li>
+<li><a href="yfm.html" class="">yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1296,7 +1088,7 @@
                   this.pagename:      yfm.html
                   this.basename:      yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm.html
 
                   "page"
@@ -1308,7 +1100,7 @@
                   page.pagename:      no-yfm.html
                   page.basename:      no-yfm
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  no-yfm.html
 
                   "root"
@@ -1320,10 +1112,9 @@
                   pagename:           yfm.html
                   basename:           yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm.html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1351,6 +1142,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1365,16 +1157,16 @@
   },
   "filename": "no-yfm.html",
   "first": false,
-  "index": 12,
+  "index": 13,
   "isCurrentPage": false,
   "last": false,
   "middle": true,
-  "next": 13,
-  "number": 13,
+  "next": 14,
+  "number": 14,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            There is no YAML front matter in this page.\n\n<div>{{noyfm.one}}</div>\n<div>{{noyfm.two}}</div>\n\n\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relative ../page.dest dest}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\" class=\"{{#isCurrentPage}}active{{/isCurrentPage}}\">{{basename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:           {{this.src}}\n                  this.dest:          {{this.dest}}\n                  this.dirname:       {{this.dirname}}\n                  this.filename:      {{this.filename}}\n                  this.pagename:      {{this.pagename}}\n                  this.basename:      {{this.basename}}\n                  this.ext:           {{this.ext}}\n                  this.isCurrentPage:      {{this.isCurrentPage}}\n                  this.relativeLink:  {{this.relativeLink}}\n\n                  \"page\"\n                  ===============================\n                  page.src:           {{../page.src}}\n                  page.dest:          {{../page.dest}}\n                  page.dirname:       {{../page.dirname}}\n                  page.filename:      {{../page.filename}}\n                  page.pagename:      {{../page.pagename}}\n                  page.basename:      {{../page.basename}}\n                  page.ext:           {{../page.ext}}\n                  page.isCurrentPage:      {{../page.isCurrentPage}}\n                  page.relativeLink:  {{../page.relativeLink}}\n\n                  \"root\"\n                  ===============================\n                  src:                {{src}}\n                  dest:               {{dest}}\n                  dirname:            {{dirname}}\n                  filename:           {{filename}}\n                  pagename:           {{pagename}}\n                  basename:           {{basename}}\n                  ext:                {{ext}}\n                  isCurrentPage:           {{isCurrentPage}}\n                  relativeLink:       {{relativeLink}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "no-yfm.html",
   "pagename": "no-yfm.html",
-  "prev": 11,
+  "prev": 12,
   "relativeLink": "no-yfm.html",
   "src": "test/fixtures/pages/no-yfm.hbs"
 }

--- a/test/actual/plugin_preprocess/yfm-context.html
+++ b/test/actual/plugin_preprocess/yfm-context.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="no-yfm.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="no-yfm.html">14</a>
+    </li>
     <li class="active pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
     <li class="next">
       <a href="yfm.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="no-yfm.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
+    <li>
+      <a href="no-yfm.html">14</a>
+    </li>
     <li class="active">
-      <a href="yfm-context.html">14</a>
+      <a href="yfm-context.html">15</a>
     </li>
-  
     <li>
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="yfm.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="yfm.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -225,484 +187,287 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">3</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yfm</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">context</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li class="active">
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">3</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yfm</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">context</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li class="active">
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -736,37 +501,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -775,310 +525,6 @@
               <h1>Page</h1>
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html" class="">debug-helpers</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/debug-helpers.hbs
-                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      debug-helpers.html
-                  this.pagename:      debug-helpers.html
-                  this.basename:      debug-helpers
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  debug-helpers.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/yfm-context.hbs
-                  page.dest:          test/actual/plugin_preprocess/yfm-context.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      yfm-context.html
-                  page.pagename:      yfm-context.html
-                  page.basename:      yfm-context
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  yfm-context.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/debug-helpers.hbs
-                  dest:               test/actual/plugin_preprocess/debug-helpers.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           debug-helpers.html
-                  pagename:           debug-helpers.html
-                  basename:           debug-helpers
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       debug-helpers.html
-                  -->
-                <li><a href="alert.html" class="">alert</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/alert.hbs
-                  this.dest:          test/actual/plugin_preprocess/alert.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      alert.html
-                  this.pagename:      alert.html
-                  this.basename:      alert
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  alert.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/yfm-context.hbs
-                  page.dest:          test/actual/plugin_preprocess/yfm-context.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      yfm-context.html
-                  page.pagename:      yfm-context.html
-                  page.basename:      yfm-context
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  yfm-context.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/alert.hbs
-                  dest:               test/actual/plugin_preprocess/alert.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           alert.html
-                  pagename:           alert.html
-                  basename:           alert
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       alert.html
-                  -->
-                <li><a href="collections-pages.html" class="">collections-pages</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-pages.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-pages.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-pages.html
-                  this.pagename:      collections-pages.html
-                  this.basename:      collections-pages
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-pages.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/yfm-context.hbs
-                  page.dest:          test/actual/plugin_preprocess/yfm-context.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      yfm-context.html
-                  page.pagename:      yfm-context.html
-                  page.basename:      yfm-context
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  yfm-context.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-pages.hbs
-                  dest:               test/actual/plugin_preprocess/collections-pages.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-pages.html
-                  pagename:           collections-pages.html
-                  basename:           collections-pages
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-pages.html
-                  -->
-                <li><a href="collections-tags.html" class="">collections-tags</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-tags.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-tags.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-tags.html
-                  this.pagename:      collections-tags.html
-                  this.basename:      collections-tags
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-tags.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/yfm-context.hbs
-                  page.dest:          test/actual/plugin_preprocess/yfm-context.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      yfm-context.html
-                  page.pagename:      yfm-context.html
-                  page.basename:      yfm-context
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  yfm-context.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-tags.hbs
-                  dest:               test/actual/plugin_preprocess/collections-tags.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-tags.html
-                  pagename:           collections-tags.html
-                  basename:           collections-tags
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-tags.html
-                  -->
-                <li><a href="collections.html" class="">collections</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections.html
-                  this.pagename:      collections.html
-                  this.basename:      collections
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/yfm-context.hbs
-                  page.dest:          test/actual/plugin_preprocess/yfm-context.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      yfm-context.html
-                  page.pagename:      yfm-context.html
-                  page.basename:      yfm-context
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  yfm-context.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections.hbs
-                  dest:               test/actual/plugin_preprocess/collections.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections.html
-                  pagename:           collections.html
-                  basename:           collections
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections.html
-                  -->
-                <li><a href="complex.html" class="">complex</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/complex.hbs
-                  this.dest:          test/actual/plugin_preprocess/complex.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      complex.html
-                  this.pagename:      complex.html
-                  this.basename:      complex
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  complex.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/yfm-context.hbs
-                  page.dest:          test/actual/plugin_preprocess/yfm-context.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      yfm-context.html
-                  page.pagename:      yfm-context.html
-                  page.basename:      yfm-context
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  yfm-context.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/complex.hbs
-                  dest:               test/actual/plugin_preprocess/complex.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           complex.html
-                  pagename:           complex.html
-                  basename:           complex
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       complex.html
-                  -->
-                <li><a href="context.html" class="">context</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/context.hbs
-                  this.dest:          test/actual/plugin_preprocess/context.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      context.html
-                  this.pagename:      context.html
-                  this.basename:      context
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  context.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/yfm-context.hbs
-                  page.dest:          test/actual/plugin_preprocess/yfm-context.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      yfm-context.html
-                  page.pagename:      yfm-context.html
-                  page.basename:      yfm-context
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  yfm-context.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/context.hbs
-                  dest:               test/actual/plugin_preprocess/context.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           context.html
-                  pagename:           context.html
-                  basename:           context
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       context.html
-                  -->
-                <li><a href="collections-categories.html" class="">collections-categories</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-categories.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-categories.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-categories.html
-                  this.pagename:      collections-categories.html
-                  this.basename:      collections-categories
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-categories.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/yfm-context.hbs
-                  page.dest:          test/actual/plugin_preprocess/yfm-context.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      yfm-context.html
-                  page.pagename:      yfm-context.html
-                  page.basename:      yfm-context
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  yfm-context.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-categories.hbs
-                  dest:               test/actual/plugin_preprocess/collections-categories.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-categories.html
-                  pagename:           collections-categories.html
-                  basename:           collections-categories
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-categories.html
-                  -->
                 <li><a href="example.html" class="">example</a></li>
                   <!--
                   "this"
@@ -1090,7 +536,7 @@
                   this.pagename:      example.html
                   this.basename:      example
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  example.html
 
                   "page"
@@ -1102,7 +548,7 @@
                   page.pagename:      yfm-context.html
                   page.basename:      yfm-context
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  yfm-context.html
 
                   "root"
@@ -1114,10 +560,314 @@
                   pagename:           example.html
                   basename:           example
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       example.html
                   -->
-                <li><a href="gist-helper.html" class="">gist-helper</a></li>
+<li><a href="alert.html" class="">alert</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/alert.hbs
+                  this.dest:          test/actual/plugin_preprocess/alert.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      alert.html
+                  this.pagename:      alert.html
+                  this.basename:      alert
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  alert.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/yfm-context.hbs
+                  page.dest:          test/actual/plugin_preprocess/yfm-context.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      yfm-context.html
+                  page.pagename:      yfm-context.html
+                  page.basename:      yfm-context
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  yfm-context.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/alert.hbs
+                  dest:               test/actual/plugin_preprocess/alert.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           alert.html
+                  pagename:           alert.html
+                  basename:           alert
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       alert.html
+                  -->
+<li><a href="collections-pages.html" class="">collections-pages</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-pages.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-pages.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-pages.html
+                  this.pagename:      collections-pages.html
+                  this.basename:      collections-pages
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-pages.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/yfm-context.hbs
+                  page.dest:          test/actual/plugin_preprocess/yfm-context.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      yfm-context.html
+                  page.pagename:      yfm-context.html
+                  page.basename:      yfm-context
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  yfm-context.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-pages.hbs
+                  dest:               test/actual/plugin_preprocess/collections-pages.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-pages.html
+                  pagename:           collections-pages.html
+                  basename:           collections-pages
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-pages.html
+                  -->
+<li><a href="collections-tags.html" class="">collections-tags</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-tags.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-tags.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-tags.html
+                  this.pagename:      collections-tags.html
+                  this.basename:      collections-tags
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-tags.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/yfm-context.hbs
+                  page.dest:          test/actual/plugin_preprocess/yfm-context.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      yfm-context.html
+                  page.pagename:      yfm-context.html
+                  page.basename:      yfm-context
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  yfm-context.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-tags.hbs
+                  dest:               test/actual/plugin_preprocess/collections-tags.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-tags.html
+                  pagename:           collections-tags.html
+                  basename:           collections-tags
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-tags.html
+                  -->
+<li><a href="collections.html" class="">collections</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections.html
+                  this.pagename:      collections.html
+                  this.basename:      collections
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/yfm-context.hbs
+                  page.dest:          test/actual/plugin_preprocess/yfm-context.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      yfm-context.html
+                  page.pagename:      yfm-context.html
+                  page.basename:      yfm-context
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  yfm-context.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections.hbs
+                  dest:               test/actual/plugin_preprocess/collections.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections.html
+                  pagename:           collections.html
+                  basename:           collections
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections.html
+                  -->
+<li><a href="complex.html" class="">complex</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/complex.hbs
+                  this.dest:          test/actual/plugin_preprocess/complex.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      complex.html
+                  this.pagename:      complex.html
+                  this.basename:      complex
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  complex.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/yfm-context.hbs
+                  page.dest:          test/actual/plugin_preprocess/yfm-context.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      yfm-context.html
+                  page.pagename:      yfm-context.html
+                  page.basename:      yfm-context
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  yfm-context.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/complex.hbs
+                  dest:               test/actual/plugin_preprocess/complex.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           complex.html
+                  pagename:           complex.html
+                  basename:           complex
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       complex.html
+                  -->
+<li><a href="context.html" class="">context</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/context.hbs
+                  this.dest:          test/actual/plugin_preprocess/context.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      context.html
+                  this.pagename:      context.html
+                  this.basename:      context
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  context.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/yfm-context.hbs
+                  page.dest:          test/actual/plugin_preprocess/yfm-context.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      yfm-context.html
+                  page.pagename:      yfm-context.html
+                  page.basename:      yfm-context
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  yfm-context.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/context.hbs
+                  dest:               test/actual/plugin_preprocess/context.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           context.html
+                  pagename:           context.html
+                  basename:           context
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       context.html
+                  -->
+<li><a href="debug-helpers.html" class="">debug-helpers</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/debug-helpers.hbs
+                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      debug-helpers.html
+                  this.pagename:      debug-helpers.html
+                  this.basename:      debug-helpers
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  debug-helpers.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/yfm-context.hbs
+                  page.dest:          test/actual/plugin_preprocess/yfm-context.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      yfm-context.html
+                  page.pagename:      yfm-context.html
+                  page.basename:      yfm-context
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  yfm-context.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/debug-helpers.hbs
+                  dest:               test/actual/plugin_preprocess/debug-helpers.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           debug-helpers.html
+                  pagename:           debug-helpers.html
+                  basename:           debug-helpers
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       debug-helpers.html
+                  -->
+<li><a href="collections-categories.html" class="">collections-categories</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-categories.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-categories.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-categories.html
+                  this.pagename:      collections-categories.html
+                  this.basename:      collections-categories
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-categories.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/yfm-context.hbs
+                  page.dest:          test/actual/plugin_preprocess/yfm-context.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      yfm-context.html
+                  page.pagename:      yfm-context.html
+                  page.basename:      yfm-context
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  yfm-context.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-categories.hbs
+                  dest:               test/actual/plugin_preprocess/collections-categories.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-categories.html
+                  pagename:           collections-categories.html
+                  basename:           collections-categories
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-categories.html
+                  -->
+<li><a href="gist-helper.html" class="">gist-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1128,7 +878,7 @@
                   this.pagename:      gist-helper.html
                   this.basename:      gist-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  gist-helper.html
 
                   "page"
@@ -1140,7 +890,7 @@
                   page.pagename:      yfm-context.html
                   page.basename:      yfm-context
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  yfm-context.html
 
                   "root"
@@ -1152,10 +902,10 @@
                   pagename:           gist-helper.html
                   basename:           gist-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       gist-helper.html
                   -->
-                <li><a href="lodash.html" class="">lodash</a></li>
+<li><a href="lodash.html" class="">lodash</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1166,7 +916,7 @@
                   this.pagename:      lodash.html
                   this.basename:      lodash
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  lodash.html
 
                   "page"
@@ -1178,7 +928,7 @@
                   page.pagename:      yfm-context.html
                   page.basename:      yfm-context
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  yfm-context.html
 
                   "root"
@@ -1190,10 +940,10 @@
                   pagename:           lodash.html
                   basename:           lodash
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       lodash.html
                   -->
-                <li><a href="md-helper.html" class="">md-helper</a></li>
+<li><a href="md-helper.html" class="">md-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1204,7 +954,7 @@
                   this.pagename:      md-helper.html
                   this.basename:      md-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  md-helper.html
 
                   "page"
@@ -1216,7 +966,7 @@
                   page.pagename:      yfm-context.html
                   page.basename:      yfm-context
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  yfm-context.html
 
                   "root"
@@ -1228,10 +978,48 @@
                   pagename:           md-helper.html
                   basename:           md-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       md-helper.html
                   -->
-                <li><a href="no-yfm.html" class="">no-yfm</a></li>
+<li><a href="no-yfm-data.html" class="">no-yfm-data</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      no-yfm-data.html
+                  this.pagename:      no-yfm-data.html
+                  this.basename:      no-yfm-data
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  no-yfm-data.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/yfm-context.hbs
+                  page.dest:          test/actual/plugin_preprocess/yfm-context.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      yfm-context.html
+                  page.pagename:      yfm-context.html
+                  page.basename:      yfm-context
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  yfm-context.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/no-yfm-data.hbs
+                  dest:               test/actual/plugin_preprocess/no-yfm-data.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           no-yfm-data.html
+                  pagename:           no-yfm-data.html
+                  basename:           no-yfm-data
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       no-yfm-data.html
+                  -->
+<li><a href="no-yfm.html" class="">no-yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1242,7 +1030,7 @@
                   this.pagename:      no-yfm.html
                   this.basename:      no-yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  no-yfm.html
 
                   "page"
@@ -1254,7 +1042,7 @@
                   page.pagename:      yfm-context.html
                   page.basename:      yfm-context
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  yfm-context.html
 
                   "root"
@@ -1266,10 +1054,10 @@
                   pagename:           no-yfm.html
                   basename:           no-yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       no-yfm.html
                   -->
-                <li><a href="yfm-context.html" class="active">yfm-context</a></li>
+<li><a href="yfm-context.html" class="active">yfm-context</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1292,7 +1080,7 @@
                   page.pagename:      yfm-context.html
                   page.basename:      yfm-context
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  yfm-context.html
 
                   "root"
@@ -1307,7 +1095,7 @@
                   isCurrentPage:           true
                   relativeLink:       yfm-context.html
                   -->
-                <li><a href="yfm.html" class="">yfm</a></li>
+<li><a href="yfm.html" class="">yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1318,7 +1106,7 @@
                   this.pagename:      yfm.html
                   this.basename:      yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm.html
 
                   "page"
@@ -1330,7 +1118,7 @@
                   page.pagename:      yfm-context.html
                   page.basename:      yfm-context
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  yfm-context.html
 
                   "root"
@@ -1342,10 +1130,9 @@
                   pagename:           yfm.html
                   basename:           yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm.html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1387,6 +1174,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1401,16 +1189,16 @@
   },
   "filename": "yfm-context.html",
   "first": false,
-  "index": 13,
+  "index": 14,
   "isCurrentPage": false,
   "last": false,
   "middle": true,
-  "next": 14,
-  "number": 14,
+  "next": 15,
+  "number": 15,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n\n<div class=\"page-header\">\n  <h1>{{{default home.title \"Title from home.json didn't render.\"}}}</h1>\n  <p class=\"lead\">{{{default home.description \"Description from home.json didn't render.\"}}}</p>\n</div>\n\n<hr>\n\n<div class=\"page-header\">\n  <h1>{{{default page.title \"page.title didn't render.\"}}}</h1>\n  <p class=\"lead\">{{{default page.description \"page.description didn't render.\"}}}</p>\n</div>\n\n<hr>\n\n<div class=\"page-header\">\n  <h1>{{{default title \"title didn't render.\"}}}</h1>\n  <p class=\"lead\">{{{default description \"description didn't render.\"}}}</p>\n</div>\n\n\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relative ../page.dest dest}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\" class=\"{{#isCurrentPage}}active{{/isCurrentPage}}\">{{basename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:           {{this.src}}\n                  this.dest:          {{this.dest}}\n                  this.dirname:       {{this.dirname}}\n                  this.filename:      {{this.filename}}\n                  this.pagename:      {{this.pagename}}\n                  this.basename:      {{this.basename}}\n                  this.ext:           {{this.ext}}\n                  this.isCurrentPage:      {{this.isCurrentPage}}\n                  this.relativeLink:  {{this.relativeLink}}\n\n                  \"page\"\n                  ===============================\n                  page.src:           {{../page.src}}\n                  page.dest:          {{../page.dest}}\n                  page.dirname:       {{../page.dirname}}\n                  page.filename:      {{../page.filename}}\n                  page.pagename:      {{../page.pagename}}\n                  page.basename:      {{../page.basename}}\n                  page.ext:           {{../page.ext}}\n                  page.isCurrentPage:      {{../page.isCurrentPage}}\n                  page.relativeLink:  {{../page.relativeLink}}\n\n                  \"root\"\n                  ===============================\n                  src:                {{src}}\n                  dest:               {{dest}}\n                  dirname:            {{dirname}}\n                  filename:           {{filename}}\n                  pagename:           {{pagename}}\n                  basename:           {{basename}}\n                  ext:                {{ext}}\n                  isCurrentPage:           {{isCurrentPage}}\n                  relativeLink:       {{relativeLink}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "yfm-context.html",
   "pagename": "yfm-context.html",
-  "prev": 12,
+  "prev": 13,
   "relativeLink": "yfm-context.html",
   "src": "test/fixtures/pages/yfm-context.hbs",
   "title": "This title is from the YFM of the current page"

--- a/test/actual/plugin_preprocess/yfm.html
+++ b/test/actual/plugin_preprocess/yfm.html
@@ -20,89 +20,70 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="previous">
       <a href="yfm-context.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="alert.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="collections.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="complex.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="context.html">7</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lodash.html">11</a>
     </li>
-  
     <li class="pager-middle">
       <a href="md-helper.html">12</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li class="pager-middle">
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
+    <li class="pager-middle">
+      <a href="yfm-context.html">15</a>
+    </li>
     <li class="active pager-middle">
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
-  
 
 </ul><style>
 .unselectable {
@@ -122,89 +103,70 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
-      <a href="debug-helpers.html">First</a>
+      <a href="example.html">First</a>
     </li>
     <li class="prev">
       <a href="yfm-context.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
-      <a href="debug-helpers.html">1</a>
+      <a href="example.html">1</a>
     </li>
-  
     <li>
       <a href="alert.html">2</a>
     </li>
-  
     <li>
       <a href="collections-pages.html">3</a>
     </li>
-  
     <li>
       <a href="collections-tags.html">4</a>
     </li>
-  
     <li>
       <a href="collections.html">5</a>
     </li>
-  
     <li>
       <a href="complex.html">6</a>
     </li>
-  
     <li>
       <a href="context.html">7</a>
     </li>
-  
     <li>
-      <a href="collections-categories.html">8</a>
+      <a href="debug-helpers.html">8</a>
     </li>
-  
     <li>
-      <a href="example.html">9</a>
+      <a href="collections-categories.html">9</a>
     </li>
-  
     <li>
       <a href="gist-helper.html">10</a>
     </li>
-  
     <li>
       <a href="lodash.html">11</a>
     </li>
-  
     <li>
       <a href="md-helper.html">12</a>
     </li>
-  
     <li>
-      <a href="no-yfm.html">13</a>
+      <a href="no-yfm-data.html">13</a>
     </li>
-  
     <li>
-      <a href="yfm-context.html">14</a>
+      <a href="no-yfm.html">14</a>
     </li>
-  
+    <li>
+      <a href="yfm-context.html">15</a>
+    </li>
     <li class="active">
-      <a href="yfm.html">15</a>
+      <a href="yfm.html">16</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
-  
 
 </ul>
           </div>
@@ -225,478 +187,285 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No categories defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">13</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">categories</span>
-    
-      <span class="label label-info">collections</span>
-    
-      <span class="label label-info">components</span>
-    
-      <span class="label label-info">context</span>
-    
-      <span class="label label-info">fixtures</span>
-    
-      <span class="label label-info">helper</span>
-    
-      <span class="label label-info">markdown</span>
-    
-      <span class="label label-info">one</span>
-    
-      <span class="label label-info">pages</span>
-    
-      <span class="label label-info">three</span>
-    
-      <span class="label label-info">two</span>
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">categories</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">collections</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">components</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="alert.html">alert.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">context</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">fixtures</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">helper</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">markdown</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="md-helper.html">md-helper.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">one</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">pages</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="complex.html">complex.html</a>
-          </li>
-        
-          <li>
-            <a href="context.html">context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">three</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">two</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="collections-categories.html">collections-categories.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li>
-            <a href="example.html">example.html</a>
-          </li>
-        
-          <li>
-            <a href="yfm-context.html">yfm-context.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No categories defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">13</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">categories</span>
+                        <span class="label label-info">collections</span>
+                        <span class="label label-info">components</span>
+                        <span class="label label-info">context</span>
+                        <span class="label label-info">fixtures</span>
+                        <span class="label label-info">helper</span>
+                        <span class="label label-info">markdown</span>
+                        <span class="label label-info">one</span>
+                        <span class="label label-info">pages</span>
+                        <span class="label label-info">three</span>
+                        <span class="label label-info">two</span>
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">categories</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">collections</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">components</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="alert.html">alert.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">context</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">fixtures</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">helper</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">markdown</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="md-helper.html">md-helper.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">one</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">pages</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="complex.html">complex.html</a>
+                            </li>
+                            <li>
+                              <a href="context.html">context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">three</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">two</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="collections-categories.html">collections-categories.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li>
+                              <a href="example.html">example.html</a>
+                            </li>
+                            <li>
+                              <a href="yfm-context.html">yfm-context.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    <strong>No tags defined on this page.</strong>
-  
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">15</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">alert</span>
-    
-      <span class="label label-success">bootstrap</span>
-    
-      <span class="label label-success">collections</span>
-    
-      <span class="label label-success">complex</span>
-    
-      <span class="label label-success">example</span>
-    
-      <span class="label label-success">examples</span>
-    
-      <span class="label label-success">markdown</span>
-    
-      <span class="label label-success">md</span>
-    
-      <span class="label label-success">one</span>
-    
-      <span class="label label-success">pages</span>
-    
-      <span class="label label-success">tags</span>
-    
-      <span class="label label-success">test</span>
-    
-      <span class="label label-success">tests</span>
-    
-      <span class="label label-success">three</span>
-    
-      <span class="label label-success">two</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">alert</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">bootstrap</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="alert.html">alert.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">collections</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">complex</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="example.html">example.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">examples</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">markdown</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">md</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">one</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">pages</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-pages.html">collections-pages.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tags</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-        <li>
-          <a href="collections.html">collections.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">test</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="md-helper.html">md-helper.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">tests</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="complex.html">complex.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">three</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-    <div>Related pages for: <span class="label label-success">two</span></div>
-    <ul class="links">
-    
-      
-        <li>
-          <a href="collections-tags.html">collections-tags.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">0</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <strong>No tags defined on this page.</strong>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">15</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">alert</span>
+                        <span class="label label-success">bootstrap</span>
+                        <span class="label label-success">collections</span>
+                        <span class="label label-success">complex</span>
+                        <span class="label label-success">example</span>
+                        <span class="label label-success">examples</span>
+                        <span class="label label-success">markdown</span>
+                        <span class="label label-success">md</span>
+                        <span class="label label-success">one</span>
+                        <span class="label label-success">pages</span>
+                        <span class="label label-success">tags</span>
+                        <span class="label label-success">test</span>
+                        <span class="label label-success">tests</span>
+                        <span class="label label-success">three</span>
+                        <span class="label label-success">two</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">alert</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">bootstrap</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="alert.html">alert.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">collections</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">complex</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="example.html">example.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">examples</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">markdown</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">md</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">one</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">pages</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-pages.html">collections-pages.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tags</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                          <li>
+                            <a href="collections.html">collections.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">test</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="md-helper.html">md-helper.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">tests</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="complex.html">complex.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">three</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                      <div>Related pages for: <span class="label label-success">two</span></div>
+                      <ul class="links">
+                          <li>
+                            <a href="collections-tags.html">collections-tags.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -711,37 +480,22 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
-              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
-            
-              <li><a href="alert.html">alert.html</a></li>
-            
-              <li><a href="collections-pages.html">collections-pages.html</a></li>
-            
-              <li><a href="collections-tags.html">collections-tags.html</a></li>
-            
-              <li><a href="collections.html">collections.html</a></li>
-            
-              <li><a href="complex.html">complex.html</a></li>
-            
-              <li><a href="context.html">context.html</a></li>
-            
-              <li><a href="collections-categories.html">collections-categories.html</a></li>
-            
               <li><a href="example.html">example.html</a></li>
-            
+              <li><a href="alert.html">alert.html</a></li>
+              <li><a href="collections-pages.html">collections-pages.html</a></li>
+              <li><a href="collections-tags.html">collections-tags.html</a></li>
+              <li><a href="collections.html">collections.html</a></li>
+              <li><a href="complex.html">complex.html</a></li>
+              <li><a href="context.html">context.html</a></li>
+              <li><a href="debug-helpers.html">debug-helpers.html</a></li>
+              <li><a href="collections-categories.html">collections-categories.html</a></li>
               <li><a href="gist-helper.html">gist-helper.html</a></li>
-            
               <li><a href="lodash.html">lodash.html</a></li>
-            
               <li><a href="md-helper.html">md-helper.html</a></li>
-            
+              <li><a href="no-yfm-data.html">no-yfm-data.html</a></li>
               <li><a href="no-yfm.html">no-yfm.html</a></li>
-            
               <li><a href="yfm-context.html">yfm-context.html</a></li>
-            
               <li><a href="yfm.html">yfm.html</a></li>
-            
             </ul>
 
             <hr>
@@ -750,310 +504,6 @@
               <h1>Page</h1>
               <h1>Each pages</h1>
               <ul>
-                <li><a href="debug-helpers.html" class="">debug-helpers</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/debug-helpers.hbs
-                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      debug-helpers.html
-                  this.pagename:      debug-helpers.html
-                  this.basename:      debug-helpers
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  debug-helpers.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/yfm.hbs
-                  page.dest:          test/actual/plugin_preprocess/yfm.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      yfm.html
-                  page.pagename:      yfm.html
-                  page.basename:      yfm
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  yfm.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/debug-helpers.hbs
-                  dest:               test/actual/plugin_preprocess/debug-helpers.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           debug-helpers.html
-                  pagename:           debug-helpers.html
-                  basename:           debug-helpers
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       debug-helpers.html
-                  -->
-                <li><a href="alert.html" class="">alert</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/alert.hbs
-                  this.dest:          test/actual/plugin_preprocess/alert.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      alert.html
-                  this.pagename:      alert.html
-                  this.basename:      alert
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  alert.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/yfm.hbs
-                  page.dest:          test/actual/plugin_preprocess/yfm.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      yfm.html
-                  page.pagename:      yfm.html
-                  page.basename:      yfm
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  yfm.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/alert.hbs
-                  dest:               test/actual/plugin_preprocess/alert.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           alert.html
-                  pagename:           alert.html
-                  basename:           alert
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       alert.html
-                  -->
-                <li><a href="collections-pages.html" class="">collections-pages</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-pages.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-pages.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-pages.html
-                  this.pagename:      collections-pages.html
-                  this.basename:      collections-pages
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-pages.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/yfm.hbs
-                  page.dest:          test/actual/plugin_preprocess/yfm.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      yfm.html
-                  page.pagename:      yfm.html
-                  page.basename:      yfm
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  yfm.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-pages.hbs
-                  dest:               test/actual/plugin_preprocess/collections-pages.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-pages.html
-                  pagename:           collections-pages.html
-                  basename:           collections-pages
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-pages.html
-                  -->
-                <li><a href="collections-tags.html" class="">collections-tags</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-tags.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-tags.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-tags.html
-                  this.pagename:      collections-tags.html
-                  this.basename:      collections-tags
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-tags.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/yfm.hbs
-                  page.dest:          test/actual/plugin_preprocess/yfm.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      yfm.html
-                  page.pagename:      yfm.html
-                  page.basename:      yfm
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  yfm.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-tags.hbs
-                  dest:               test/actual/plugin_preprocess/collections-tags.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-tags.html
-                  pagename:           collections-tags.html
-                  basename:           collections-tags
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-tags.html
-                  -->
-                <li><a href="collections.html" class="">collections</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections.html
-                  this.pagename:      collections.html
-                  this.basename:      collections
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/yfm.hbs
-                  page.dest:          test/actual/plugin_preprocess/yfm.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      yfm.html
-                  page.pagename:      yfm.html
-                  page.basename:      yfm
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  yfm.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections.hbs
-                  dest:               test/actual/plugin_preprocess/collections.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections.html
-                  pagename:           collections.html
-                  basename:           collections
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections.html
-                  -->
-                <li><a href="complex.html" class="">complex</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/complex.hbs
-                  this.dest:          test/actual/plugin_preprocess/complex.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      complex.html
-                  this.pagename:      complex.html
-                  this.basename:      complex
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  complex.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/yfm.hbs
-                  page.dest:          test/actual/plugin_preprocess/yfm.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      yfm.html
-                  page.pagename:      yfm.html
-                  page.basename:      yfm
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  yfm.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/complex.hbs
-                  dest:               test/actual/plugin_preprocess/complex.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           complex.html
-                  pagename:           complex.html
-                  basename:           complex
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       complex.html
-                  -->
-                <li><a href="context.html" class="">context</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/context.hbs
-                  this.dest:          test/actual/plugin_preprocess/context.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      context.html
-                  this.pagename:      context.html
-                  this.basename:      context
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  context.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/yfm.hbs
-                  page.dest:          test/actual/plugin_preprocess/yfm.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      yfm.html
-                  page.pagename:      yfm.html
-                  page.basename:      yfm
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  yfm.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/context.hbs
-                  dest:               test/actual/plugin_preprocess/context.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           context.html
-                  pagename:           context.html
-                  basename:           context
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       context.html
-                  -->
-                <li><a href="collections-categories.html" class="">collections-categories</a></li>
-                  <!--
-                  "this"
-                  ===============================
-                  this.src:           test/fixtures/pages/collections-categories.hbs
-                  this.dest:          test/actual/plugin_preprocess/collections-categories.html
-                  this.dirname:       test/actual/plugin_preprocess
-                  this.filename:      collections-categories.html
-                  this.pagename:      collections-categories.html
-                  this.basename:      collections-categories
-                  this.ext:           .html
-                  this.isCurrentPage:      
-                  this.relativeLink:  collections-categories.html
-
-                  "page"
-                  ===============================
-                  page.src:           test/fixtures/pages/yfm.hbs
-                  page.dest:          test/actual/plugin_preprocess/yfm.html
-                  page.dirname:       test/actual/plugin_preprocess
-                  page.filename:      yfm.html
-                  page.pagename:      yfm.html
-                  page.basename:      yfm
-                  page.ext:           .html
-                  page.isCurrentPage:      
-                  page.relativeLink:  yfm.html
-
-                  "root"
-                  ===============================
-                  src:                test/fixtures/pages/collections-categories.hbs
-                  dest:               test/actual/plugin_preprocess/collections-categories.html
-                  dirname:            test/actual/plugin_preprocess
-                  filename:           collections-categories.html
-                  pagename:           collections-categories.html
-                  basename:           collections-categories
-                  ext:                .html
-                  isCurrentPage:           
-                  relativeLink:       collections-categories.html
-                  -->
                 <li><a href="example.html" class="">example</a></li>
                   <!--
                   "this"
@@ -1065,7 +515,7 @@
                   this.pagename:      example.html
                   this.basename:      example
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  example.html
 
                   "page"
@@ -1077,7 +527,7 @@
                   page.pagename:      yfm.html
                   page.basename:      yfm
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  yfm.html
 
                   "root"
@@ -1089,10 +539,314 @@
                   pagename:           example.html
                   basename:           example
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       example.html
                   -->
-                <li><a href="gist-helper.html" class="">gist-helper</a></li>
+<li><a href="alert.html" class="">alert</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/alert.hbs
+                  this.dest:          test/actual/plugin_preprocess/alert.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      alert.html
+                  this.pagename:      alert.html
+                  this.basename:      alert
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  alert.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/yfm.hbs
+                  page.dest:          test/actual/plugin_preprocess/yfm.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      yfm.html
+                  page.pagename:      yfm.html
+                  page.basename:      yfm
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  yfm.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/alert.hbs
+                  dest:               test/actual/plugin_preprocess/alert.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           alert.html
+                  pagename:           alert.html
+                  basename:           alert
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       alert.html
+                  -->
+<li><a href="collections-pages.html" class="">collections-pages</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-pages.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-pages.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-pages.html
+                  this.pagename:      collections-pages.html
+                  this.basename:      collections-pages
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-pages.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/yfm.hbs
+                  page.dest:          test/actual/plugin_preprocess/yfm.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      yfm.html
+                  page.pagename:      yfm.html
+                  page.basename:      yfm
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  yfm.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-pages.hbs
+                  dest:               test/actual/plugin_preprocess/collections-pages.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-pages.html
+                  pagename:           collections-pages.html
+                  basename:           collections-pages
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-pages.html
+                  -->
+<li><a href="collections-tags.html" class="">collections-tags</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-tags.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-tags.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-tags.html
+                  this.pagename:      collections-tags.html
+                  this.basename:      collections-tags
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-tags.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/yfm.hbs
+                  page.dest:          test/actual/plugin_preprocess/yfm.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      yfm.html
+                  page.pagename:      yfm.html
+                  page.basename:      yfm
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  yfm.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-tags.hbs
+                  dest:               test/actual/plugin_preprocess/collections-tags.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-tags.html
+                  pagename:           collections-tags.html
+                  basename:           collections-tags
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-tags.html
+                  -->
+<li><a href="collections.html" class="">collections</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections.html
+                  this.pagename:      collections.html
+                  this.basename:      collections
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/yfm.hbs
+                  page.dest:          test/actual/plugin_preprocess/yfm.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      yfm.html
+                  page.pagename:      yfm.html
+                  page.basename:      yfm
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  yfm.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections.hbs
+                  dest:               test/actual/plugin_preprocess/collections.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections.html
+                  pagename:           collections.html
+                  basename:           collections
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections.html
+                  -->
+<li><a href="complex.html" class="">complex</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/complex.hbs
+                  this.dest:          test/actual/plugin_preprocess/complex.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      complex.html
+                  this.pagename:      complex.html
+                  this.basename:      complex
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  complex.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/yfm.hbs
+                  page.dest:          test/actual/plugin_preprocess/yfm.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      yfm.html
+                  page.pagename:      yfm.html
+                  page.basename:      yfm
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  yfm.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/complex.hbs
+                  dest:               test/actual/plugin_preprocess/complex.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           complex.html
+                  pagename:           complex.html
+                  basename:           complex
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       complex.html
+                  -->
+<li><a href="context.html" class="">context</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/context.hbs
+                  this.dest:          test/actual/plugin_preprocess/context.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      context.html
+                  this.pagename:      context.html
+                  this.basename:      context
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  context.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/yfm.hbs
+                  page.dest:          test/actual/plugin_preprocess/yfm.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      yfm.html
+                  page.pagename:      yfm.html
+                  page.basename:      yfm
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  yfm.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/context.hbs
+                  dest:               test/actual/plugin_preprocess/context.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           context.html
+                  pagename:           context.html
+                  basename:           context
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       context.html
+                  -->
+<li><a href="debug-helpers.html" class="">debug-helpers</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/debug-helpers.hbs
+                  this.dest:          test/actual/plugin_preprocess/debug-helpers.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      debug-helpers.html
+                  this.pagename:      debug-helpers.html
+                  this.basename:      debug-helpers
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  debug-helpers.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/yfm.hbs
+                  page.dest:          test/actual/plugin_preprocess/yfm.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      yfm.html
+                  page.pagename:      yfm.html
+                  page.basename:      yfm
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  yfm.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/debug-helpers.hbs
+                  dest:               test/actual/plugin_preprocess/debug-helpers.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           debug-helpers.html
+                  pagename:           debug-helpers.html
+                  basename:           debug-helpers
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       debug-helpers.html
+                  -->
+<li><a href="collections-categories.html" class="">collections-categories</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/collections-categories.hbs
+                  this.dest:          test/actual/plugin_preprocess/collections-categories.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      collections-categories.html
+                  this.pagename:      collections-categories.html
+                  this.basename:      collections-categories
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  collections-categories.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/yfm.hbs
+                  page.dest:          test/actual/plugin_preprocess/yfm.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      yfm.html
+                  page.pagename:      yfm.html
+                  page.basename:      yfm
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  yfm.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/collections-categories.hbs
+                  dest:               test/actual/plugin_preprocess/collections-categories.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           collections-categories.html
+                  pagename:           collections-categories.html
+                  basename:           collections-categories
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       collections-categories.html
+                  -->
+<li><a href="gist-helper.html" class="">gist-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1103,7 +857,7 @@
                   this.pagename:      gist-helper.html
                   this.basename:      gist-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  gist-helper.html
 
                   "page"
@@ -1115,7 +869,7 @@
                   page.pagename:      yfm.html
                   page.basename:      yfm
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  yfm.html
 
                   "root"
@@ -1127,10 +881,10 @@
                   pagename:           gist-helper.html
                   basename:           gist-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       gist-helper.html
                   -->
-                <li><a href="lodash.html" class="">lodash</a></li>
+<li><a href="lodash.html" class="">lodash</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1141,7 +895,7 @@
                   this.pagename:      lodash.html
                   this.basename:      lodash
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  lodash.html
 
                   "page"
@@ -1153,7 +907,7 @@
                   page.pagename:      yfm.html
                   page.basename:      yfm
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  yfm.html
 
                   "root"
@@ -1165,10 +919,10 @@
                   pagename:           lodash.html
                   basename:           lodash
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       lodash.html
                   -->
-                <li><a href="md-helper.html" class="">md-helper</a></li>
+<li><a href="md-helper.html" class="">md-helper</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1179,7 +933,7 @@
                   this.pagename:      md-helper.html
                   this.basename:      md-helper
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  md-helper.html
 
                   "page"
@@ -1191,7 +945,7 @@
                   page.pagename:      yfm.html
                   page.basename:      yfm
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  yfm.html
 
                   "root"
@@ -1203,10 +957,48 @@
                   pagename:           md-helper.html
                   basename:           md-helper
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       md-helper.html
                   -->
-                <li><a href="no-yfm.html" class="">no-yfm</a></li>
+<li><a href="no-yfm-data.html" class="">no-yfm-data</a></li>
+                  <!--
+                  "this"
+                  ===============================
+                  this.src:           test/fixtures/pages/no-yfm-data.hbs
+                  this.dest:          test/actual/plugin_preprocess/no-yfm-data.html
+                  this.dirname:       test/actual/plugin_preprocess
+                  this.filename:      no-yfm-data.html
+                  this.pagename:      no-yfm-data.html
+                  this.basename:      no-yfm-data
+                  this.ext:           .html
+                  this.isCurrentPage:      false
+                  this.relativeLink:  no-yfm-data.html
+
+                  "page"
+                  ===============================
+                  page.src:           test/fixtures/pages/yfm.hbs
+                  page.dest:          test/actual/plugin_preprocess/yfm.html
+                  page.dirname:       test/actual/plugin_preprocess
+                  page.filename:      yfm.html
+                  page.pagename:      yfm.html
+                  page.basename:      yfm
+                  page.ext:           .html
+                  page.isCurrentPage:      false
+                  page.relativeLink:  yfm.html
+
+                  "root"
+                  ===============================
+                  src:                test/fixtures/pages/no-yfm-data.hbs
+                  dest:               test/actual/plugin_preprocess/no-yfm-data.html
+                  dirname:            test/actual/plugin_preprocess
+                  filename:           no-yfm-data.html
+                  pagename:           no-yfm-data.html
+                  basename:           no-yfm-data
+                  ext:                .html
+                  isCurrentPage:           false
+                  relativeLink:       no-yfm-data.html
+                  -->
+<li><a href="no-yfm.html" class="">no-yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1217,7 +1009,7 @@
                   this.pagename:      no-yfm.html
                   this.basename:      no-yfm
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  no-yfm.html
 
                   "page"
@@ -1229,7 +1021,7 @@
                   page.pagename:      yfm.html
                   page.basename:      yfm
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  yfm.html
 
                   "root"
@@ -1241,10 +1033,10 @@
                   pagename:           no-yfm.html
                   basename:           no-yfm
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       no-yfm.html
                   -->
-                <li><a href="yfm-context.html" class="">yfm-context</a></li>
+<li><a href="yfm-context.html" class="">yfm-context</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1255,7 +1047,7 @@
                   this.pagename:      yfm-context.html
                   this.basename:      yfm-context
                   this.ext:           .html
-                  this.isCurrentPage:      
+                  this.isCurrentPage:      false
                   this.relativeLink:  yfm-context.html
 
                   "page"
@@ -1267,7 +1059,7 @@
                   page.pagename:      yfm.html
                   page.basename:      yfm
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  yfm.html
 
                   "root"
@@ -1279,10 +1071,10 @@
                   pagename:           yfm-context.html
                   basename:           yfm-context
                   ext:                .html
-                  isCurrentPage:           
+                  isCurrentPage:           false
                   relativeLink:       yfm-context.html
                   -->
-                <li><a href="yfm.html" class="active">yfm</a></li>
+<li><a href="yfm.html" class="active">yfm</a></li>
                   <!--
                   "this"
                   ===============================
@@ -1305,7 +1097,7 @@
                   page.pagename:      yfm.html
                   page.basename:      yfm
                   page.ext:           .html
-                  page.isCurrentPage:      
+                  page.isCurrentPage:      false
                   page.relativeLink:  yfm.html
 
                   "root"
@@ -1320,7 +1112,6 @@
                   isCurrentPage:           true
                   relativeLink:       yfm.html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -1355,6 +1146,7 @@
       "test/fixtures/pages/gist-helper.hbs",
       "test/fixtures/pages/lodash.hbs",
       "test/fixtures/pages/md-helper.hbs",
+      "test/fixtures/pages/no-yfm-data.hbs",
       "test/fixtures/pages/no-yfm.hbs",
       "test/fixtures/pages/yfm-context.hbs",
       "test/fixtures/pages/yfm.hbs"
@@ -1370,7 +1162,7 @@
   "filename": "yfm.html",
   "first": false,
   "foo": "bar",
-  "index": 14,
+  "index": 15,
   "isCurrentPage": false,
   "items": [
     "alpha",
@@ -1378,11 +1170,11 @@
   ],
   "last": true,
   "middle": false,
-  "number": 15,
+  "number": 16,
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n\n<div class=\"alert alert-info\">This is an alert</div>\n\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relative ../page.dest dest}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\" class=\"{{#isCurrentPage}}active{{/isCurrentPage}}\">{{basename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:           {{this.src}}\n                  this.dest:          {{this.dest}}\n                  this.dirname:       {{this.dirname}}\n                  this.filename:      {{this.filename}}\n                  this.pagename:      {{this.pagename}}\n                  this.basename:      {{this.basename}}\n                  this.ext:           {{this.ext}}\n                  this.isCurrentPage:      {{this.isCurrentPage}}\n                  this.relativeLink:  {{this.relativeLink}}\n\n                  \"page\"\n                  ===============================\n                  page.src:           {{../page.src}}\n                  page.dest:          {{../page.dest}}\n                  page.dirname:       {{../page.dirname}}\n                  page.filename:      {{../page.filename}}\n                  page.pagename:      {{../page.pagename}}\n                  page.basename:      {{../page.basename}}\n                  page.ext:           {{../page.ext}}\n                  page.isCurrentPage:      {{../page.isCurrentPage}}\n                  page.relativeLink:  {{../page.relativeLink}}\n\n                  \"root\"\n                  ===============================\n                  src:                {{src}}\n                  dest:               {{dest}}\n                  dirname:            {{dirname}}\n                  filename:           {{filename}}\n                  pagename:           {{pagename}}\n                  basename:           {{basename}}\n                  ext:                {{ext}}\n                  isCurrentPage:           {{isCurrentPage}}\n                  relativeLink:       {{relativeLink}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "yfm.html",
   "pagename": "yfm.html",
-  "prev": 13,
+  "prev": 14,
   "relativeLink": "yfm.html",
   "src": "test/fixtures/pages/yfm.hbs",
   "title": "YFM"

--- a/test/actual/single_page.html
+++ b/test/actual/single_page.html
@@ -20,33 +20,25 @@
 
       <ul class="pager">
 
-  
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">First</a>
     </li>
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">&larr; Previous</a>
     </li>
-  
 
-  
 
-  
     <li class="active pager-middle">
       <a href="single_page.html">1</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
-  
 
 </ul><style>
 .unselectable {
@@ -66,33 +58,25 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
     <li class="prev disabled">
       <a unselectable="on" class="unselectable">First</a>
     </li>
     <li class="prev disabled">
       <a unselectable="on" class="unselectable">&larr; Previous</a>
     </li>
-  
 
-  
 
-  
     <li class="active">
       <a href="single_page.html">1</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
-  
 
 </ul>
           </div>
@@ -113,131 +97,90 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
                   
-<!-- Categories -->
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>categories on this page: <span class="badge badge-info">2</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>All categories: <span class="badge badge-info">2</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-info">yaml</span>
-    
-      <span class="label label-info">yfm</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-info">
-  <div class="panel-heading">
-    <h4>Pages related to each category</h4>
-  </div>
-  <div class="panel-body">
-    
-      <div>Related pages for: <span class="label label-info">yaml</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="single_page.html">single_page.html</a>
-          </li>
-        
-        
-      </ul>
-    
-      <div>Related pages for: <span class="label label-info">yfm</span></div>
-      <ul class="links">
-      
-        
-          <li class="active">
-            <a href="single_page.html">single_page.html</a>
-          </li>
-        
-        
-      </ul>
-    
-  </div>
-</div>
-
-                
+                  <!-- Categories -->
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>categories on this page: <span class="badge badge-info">2</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>All categories: <span class="badge badge-info">2</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-info">yaml</span>
+                        <span class="label label-info">yfm</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-info">
+                    <div class="panel-heading">
+                      <h4>Pages related to each category</h4>
+                    </div>
+                    <div class="panel-body">
+                        <div>Related pages for: <span class="label label-info">yaml</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="single_page.html">single_page.html</a>
+                            </li>
+                        </ul>
+                        <div>Related pages for: <span class="label label-info">yfm</span></div>
+                        <ul class="links">
+                            <li class="active">
+                              <a href="single_page.html">single_page.html</a>
+                            </li>
+                        </ul>
+                    </div>
+                  </div>
               </div>
               <div class="col-md-6">
-                
                   
-<!-- Tags Collection -->
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">example</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>All tags: <span class="badge badge-success">1</span></h4>
-  </div>
-  <div class="panel-body">
-  
-    
-      <span class="label label-success">example</span>
-    
-    
-  </div>
-</div>
-
-<hr>
-
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h4>Pages related to each tag</h4>
-  </div>
-  <div class="panel-body">
-  
-    <div>Related pages for: <span class="label label-success">example</span></div>
-    <ul class="links">
-    
-      
-        <li class="active">
-          <a href="single_page.html">single_page.html</a>
-        </li>
-      
-      
-    </ul>
-  
-  </div>
-</div>
-
-                
+                  <!-- Tags Collection -->
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Tags on this page: <span class="badge badge-success">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">example</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>All tags: <span class="badge badge-success">1</span></h4>
+                    </div>
+                    <div class="panel-body">
+                        <span class="label label-success">example</span>
+                    </div>
+                  </div>
+                  
+                  <hr>
+                  
+                  <div class="panel panel-success">
+                    <div class="panel-heading">
+                      <h4>Pages related to each tag</h4>
+                    </div>
+                    <div class="panel-body">
+                      <div>Related pages for: <span class="label label-success">example</span></div>
+                      <ul class="links">
+                          <li class="active">
+                            <a href="single_page.html">single_page.html</a>
+                          </li>
+                      </ul>
+                    </div>
+                  </div>
               </div>
             </div>
 
@@ -250,7 +193,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
 <hr>
 
 <div>Title from YFM of &quot;example.hbs&quot;</div>
-<div></div>
+<div>This is text from example.json.</div>
 
 <hr>
 
@@ -261,9 +204,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="single_page.html">single_page.html</a></li>
-            
             </ul>
 
             <hr>
@@ -338,7 +279,6 @@ This example shows that the properties from "example.json" and "example.hbs" are
                   basename:      example
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -384,6 +324,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
   "filename": "single_page.html",
   "first": true,
   "index": 0,
+  "info": "Congratulations! This is data from example.yml.",
   "items": [
     "omega",
     "gamma"
@@ -398,6 +339,7 @@ This example shows that the properties from "example.json" and "example.hbs" are
   "tags": [
     "example"
   ],
+  "text": "This is text from example.json.",
   "title": "Title from YFM of \"example.hbs\""
 }
 </code></pre>

--- a/test/actual/yfm/associative-arrays.html
+++ b/test/actual/yfm/associative-arrays.html
@@ -20,69 +20,52 @@
 
       <ul class="pager">
 
-  
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">First</a>
     </li>
     <li class="previous disabled">
       <a unselectable="on" class="unselectable">&larr; Previous</a>
     </li>
-  
 
-  
 
-  
     <li class="active pager-middle">
       <a href="associative-arrays.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="block-literals.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="comments.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="data-files.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="data-types.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="document.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lists.html">7</a>
     </li>
-  
     <li class="pager-middle">
       <a href="relational-trees.html">8</a>
     </li>
-  
     <li class="pager-middle">
       <a href="underscore.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="variables.html">10</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="variables.html">Last</a>
     </li>
     <li class="next">
       <a href="block-literals.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -102,69 +85,52 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
     <li class="prev disabled">
       <a unselectable="on" class="unselectable">First</a>
     </li>
     <li class="prev disabled">
       <a unselectable="on" class="unselectable">&larr; Previous</a>
     </li>
-  
 
-  
 
-  
     <li class="active">
       <a href="associative-arrays.html">1</a>
     </li>
-  
     <li>
       <a href="block-literals.html">2</a>
     </li>
-  
     <li>
       <a href="comments.html">3</a>
     </li>
-  
     <li>
       <a href="data-files.html">4</a>
     </li>
-  
     <li>
       <a href="data-types.html">5</a>
     </li>
-  
     <li>
       <a href="document.html">6</a>
     </li>
-  
     <li>
       <a href="lists.html">7</a>
     </li>
-  
     <li>
       <a href="relational-trees.html">8</a>
     </li>
-  
     <li>
       <a href="underscore.html">9</a>
     </li>
-  
     <li>
       <a href="variables.html">10</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="block-literals.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="variables.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -185,10 +151,8 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
               </div>
               <div class="col-md-6">
-                
               </div>
             </div>
 
@@ -202,14 +166,10 @@
 <div class="examples">
   <h4>Associative arrays</h4>
   <dl class="dl-horizontal">
-    
       <dt>Name:</dt> <dd>John Smith</dd>
       <dt>Age:</dt>  <dd>33</dd>
-    
-    
       <dt>Name:</dt> <dd>Grace Jones</dd>
       <dt>Age:</dt>  <dd>21</dd>
-    
   </dl>
 </div>
 
@@ -217,27 +177,16 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="associative-arrays.html">associative-arrays.html</a></li>
-            
               <li><a href="block-literals.html">block-literals.html</a></li>
-            
               <li><a href="comments.html">comments.html</a></li>
-            
               <li><a href="data-files.html">data-files.html</a></li>
-            
               <li><a href="data-types.html">data-types.html</a></li>
-            
               <li><a href="document.html">document.html</a></li>
-            
               <li><a href="lists.html">lists.html</a></li>
-            
               <li><a href="relational-trees.html">relational-trees.html</a></li>
-            
               <li><a href="underscore.html">underscore.html</a></li>
-            
               <li><a href="variables.html">variables.html</a></li>
-            
             </ul>
 
             <hr>
@@ -312,7 +261,7 @@
                   basename:      associative-arrays
                   ext:           .html
                   -->
-                <li><a href="block-literals.html">block-literals.html</a></li>
+<li><a href="block-literals.html">block-literals.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -344,7 +293,7 @@
                   basename:      block-literals
                   ext:           .html
                   -->
-                <li><a href="comments.html">comments.html</a></li>
+<li><a href="comments.html">comments.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -376,7 +325,7 @@
                   basename:      comments
                   ext:           .html
                   -->
-                <li><a href="data-files.html">data-files.html</a></li>
+<li><a href="data-files.html">data-files.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -408,7 +357,7 @@
                   basename:      data-files
                   ext:           .html
                   -->
-                <li><a href="data-types.html">data-types.html</a></li>
+<li><a href="data-types.html">data-types.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -440,7 +389,7 @@
                   basename:      data-types
                   ext:           .html
                   -->
-                <li><a href="document.html">document.html</a></li>
+<li><a href="document.html">document.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -472,7 +421,7 @@
                   basename:      document
                   ext:           .html
                   -->
-                <li><a href="lists.html">lists.html</a></li>
+<li><a href="lists.html">lists.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -504,7 +453,7 @@
                   basename:      lists
                   ext:           .html
                   -->
-                <li><a href="relational-trees.html">relational-trees.html</a></li>
+<li><a href="relational-trees.html">relational-trees.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -536,7 +485,7 @@
                   basename:      relational-trees
                   ext:           .html
                   -->
-                <li><a href="underscore.html">underscore.html</a></li>
+<li><a href="underscore.html">underscore.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -568,7 +517,7 @@
                   basename:      underscore
                   ext:           .html
                   -->
-                <li><a href="variables.html">variables.html</a></li>
+<li><a href="variables.html">variables.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -600,7 +549,6 @@
                   basename:      variables
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>

--- a/test/actual/yfm/block-literals.html
+++ b/test/actual/yfm/block-literals.html
@@ -20,69 +20,52 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="associative-arrays.html">First</a>
     </li>
     <li class="previous">
       <a href="associative-arrays.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="associative-arrays.html">1</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="block-literals.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="comments.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="data-files.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="data-types.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="document.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lists.html">7</a>
     </li>
-  
     <li class="pager-middle">
       <a href="relational-trees.html">8</a>
     </li>
-  
     <li class="pager-middle">
       <a href="underscore.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="variables.html">10</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="variables.html">Last</a>
     </li>
     <li class="next">
       <a href="comments.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -102,69 +85,52 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="associative-arrays.html">First</a>
     </li>
     <li class="prev">
       <a href="associative-arrays.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="associative-arrays.html">1</a>
     </li>
-  
     <li class="active">
       <a href="block-literals.html">2</a>
     </li>
-  
     <li>
       <a href="comments.html">3</a>
     </li>
-  
     <li>
       <a href="data-files.html">4</a>
     </li>
-  
     <li>
       <a href="data-types.html">5</a>
     </li>
-  
     <li>
       <a href="document.html">6</a>
     </li>
-  
     <li>
       <a href="lists.html">7</a>
     </li>
-  
     <li>
       <a href="relational-trees.html">8</a>
     </li>
-  
     <li>
       <a href="underscore.html">9</a>
     </li>
-  
     <li>
       <a href="variables.html">10</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="comments.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="variables.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -185,10 +151,8 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
               </div>
               <div class="col-md-6">
-                
               </div>
             </div>
 
@@ -217,27 +181,16 @@ old pond . . . a frog leaps in water’s sound
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="associative-arrays.html">associative-arrays.html</a></li>
-            
               <li><a href="block-literals.html">block-literals.html</a></li>
-            
               <li><a href="comments.html">comments.html</a></li>
-            
               <li><a href="data-files.html">data-files.html</a></li>
-            
               <li><a href="data-types.html">data-types.html</a></li>
-            
               <li><a href="document.html">document.html</a></li>
-            
               <li><a href="lists.html">lists.html</a></li>
-            
               <li><a href="relational-trees.html">relational-trees.html</a></li>
-            
               <li><a href="underscore.html">underscore.html</a></li>
-            
               <li><a href="variables.html">variables.html</a></li>
-            
             </ul>
 
             <hr>
@@ -312,7 +265,7 @@ old pond . . . a frog leaps in water’s sound
                   basename:      associative-arrays
                   ext:           .html
                   -->
-                <li><a href="block-literals.html">block-literals.html</a></li>
+<li><a href="block-literals.html">block-literals.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -344,7 +297,7 @@ old pond . . . a frog leaps in water’s sound
                   basename:      block-literals
                   ext:           .html
                   -->
-                <li><a href="comments.html">comments.html</a></li>
+<li><a href="comments.html">comments.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -376,7 +329,7 @@ old pond . . . a frog leaps in water’s sound
                   basename:      comments
                   ext:           .html
                   -->
-                <li><a href="data-files.html">data-files.html</a></li>
+<li><a href="data-files.html">data-files.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -408,7 +361,7 @@ old pond . . . a frog leaps in water’s sound
                   basename:      data-files
                   ext:           .html
                   -->
-                <li><a href="data-types.html">data-types.html</a></li>
+<li><a href="data-types.html">data-types.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -440,7 +393,7 @@ old pond . . . a frog leaps in water’s sound
                   basename:      data-types
                   ext:           .html
                   -->
-                <li><a href="document.html">document.html</a></li>
+<li><a href="document.html">document.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -472,7 +425,7 @@ old pond . . . a frog leaps in water’s sound
                   basename:      document
                   ext:           .html
                   -->
-                <li><a href="lists.html">lists.html</a></li>
+<li><a href="lists.html">lists.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -504,7 +457,7 @@ old pond . . . a frog leaps in water’s sound
                   basename:      lists
                   ext:           .html
                   -->
-                <li><a href="relational-trees.html">relational-trees.html</a></li>
+<li><a href="relational-trees.html">relational-trees.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -536,7 +489,7 @@ old pond . . . a frog leaps in water’s sound
                   basename:      relational-trees
                   ext:           .html
                   -->
-                <li><a href="underscore.html">underscore.html</a></li>
+<li><a href="underscore.html">underscore.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -568,7 +521,7 @@ old pond . . . a frog leaps in water’s sound
                   basename:      underscore
                   ext:           .html
                   -->
-                <li><a href="variables.html">variables.html</a></li>
+<li><a href="variables.html">variables.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -600,7 +553,6 @@ old pond . . . a frog leaps in water’s sound
                   basename:      variables
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>

--- a/test/actual/yfm/comments.html
+++ b/test/actual/yfm/comments.html
@@ -20,69 +20,52 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="associative-arrays.html">First</a>
     </li>
     <li class="previous">
       <a href="block-literals.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="associative-arrays.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="block-literals.html">2</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="comments.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="data-files.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="data-types.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="document.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lists.html">7</a>
     </li>
-  
     <li class="pager-middle">
       <a href="relational-trees.html">8</a>
     </li>
-  
     <li class="pager-middle">
       <a href="underscore.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="variables.html">10</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="variables.html">Last</a>
     </li>
     <li class="next">
       <a href="data-files.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -102,69 +85,52 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="associative-arrays.html">First</a>
     </li>
     <li class="prev">
       <a href="block-literals.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="associative-arrays.html">1</a>
     </li>
-  
     <li>
       <a href="block-literals.html">2</a>
     </li>
-  
     <li class="active">
       <a href="comments.html">3</a>
     </li>
-  
     <li>
       <a href="data-files.html">4</a>
     </li>
-  
     <li>
       <a href="data-types.html">5</a>
     </li>
-  
     <li>
       <a href="document.html">6</a>
     </li>
-  
     <li>
       <a href="lists.html">7</a>
     </li>
-  
     <li>
       <a href="relational-trees.html">8</a>
     </li>
-  
     <li>
       <a href="underscore.html">9</a>
     </li>
-  
     <li>
       <a href="variables.html">10</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="data-files.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="variables.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -185,10 +151,8 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
               </div>
               <div class="col-md-6">
-                
               </div>
             </div>
 
@@ -205,27 +169,16 @@ Nothing.
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="associative-arrays.html">associative-arrays.html</a></li>
-            
               <li><a href="block-literals.html">block-literals.html</a></li>
-            
               <li><a href="comments.html">comments.html</a></li>
-            
               <li><a href="data-files.html">data-files.html</a></li>
-            
               <li><a href="data-types.html">data-types.html</a></li>
-            
               <li><a href="document.html">document.html</a></li>
-            
               <li><a href="lists.html">lists.html</a></li>
-            
               <li><a href="relational-trees.html">relational-trees.html</a></li>
-            
               <li><a href="underscore.html">underscore.html</a></li>
-            
               <li><a href="variables.html">variables.html</a></li>
-            
             </ul>
 
             <hr>
@@ -300,7 +253,7 @@ Nothing.
                   basename:      associative-arrays
                   ext:           .html
                   -->
-                <li><a href="block-literals.html">block-literals.html</a></li>
+<li><a href="block-literals.html">block-literals.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -332,7 +285,7 @@ Nothing.
                   basename:      block-literals
                   ext:           .html
                   -->
-                <li><a href="comments.html">comments.html</a></li>
+<li><a href="comments.html">comments.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -364,7 +317,7 @@ Nothing.
                   basename:      comments
                   ext:           .html
                   -->
-                <li><a href="data-files.html">data-files.html</a></li>
+<li><a href="data-files.html">data-files.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -396,7 +349,7 @@ Nothing.
                   basename:      data-files
                   ext:           .html
                   -->
-                <li><a href="data-types.html">data-types.html</a></li>
+<li><a href="data-types.html">data-types.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -428,7 +381,7 @@ Nothing.
                   basename:      data-types
                   ext:           .html
                   -->
-                <li><a href="document.html">document.html</a></li>
+<li><a href="document.html">document.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -460,7 +413,7 @@ Nothing.
                   basename:      document
                   ext:           .html
                   -->
-                <li><a href="lists.html">lists.html</a></li>
+<li><a href="lists.html">lists.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -492,7 +445,7 @@ Nothing.
                   basename:      lists
                   ext:           .html
                   -->
-                <li><a href="relational-trees.html">relational-trees.html</a></li>
+<li><a href="relational-trees.html">relational-trees.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -524,7 +477,7 @@ Nothing.
                   basename:      relational-trees
                   ext:           .html
                   -->
-                <li><a href="underscore.html">underscore.html</a></li>
+<li><a href="underscore.html">underscore.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -556,7 +509,7 @@ Nothing.
                   basename:      underscore
                   ext:           .html
                   -->
-                <li><a href="variables.html">variables.html</a></li>
+<li><a href="variables.html">variables.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -588,7 +541,6 @@ Nothing.
                   basename:      variables
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>

--- a/test/actual/yfm/data-files.html
+++ b/test/actual/yfm/data-files.html
@@ -20,69 +20,52 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="associative-arrays.html">First</a>
     </li>
     <li class="previous">
       <a href="comments.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="associative-arrays.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="block-literals.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="comments.html">3</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="data-files.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="data-types.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="document.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lists.html">7</a>
     </li>
-  
     <li class="pager-middle">
       <a href="relational-trees.html">8</a>
     </li>
-  
     <li class="pager-middle">
       <a href="underscore.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="variables.html">10</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="variables.html">Last</a>
     </li>
     <li class="next">
       <a href="data-types.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -102,69 +85,52 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="associative-arrays.html">First</a>
     </li>
     <li class="prev">
       <a href="comments.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="associative-arrays.html">1</a>
     </li>
-  
     <li>
       <a href="block-literals.html">2</a>
     </li>
-  
     <li>
       <a href="comments.html">3</a>
     </li>
-  
     <li class="active">
       <a href="data-files.html">4</a>
     </li>
-  
     <li>
       <a href="data-types.html">5</a>
     </li>
-  
     <li>
       <a href="document.html">6</a>
     </li>
-  
     <li>
       <a href="lists.html">7</a>
     </li>
-  
     <li>
       <a href="relational-trees.html">8</a>
     </li>
-  
     <li>
       <a href="underscore.html">9</a>
     </li>
-  
     <li>
       <a href="variables.html">10</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="data-types.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="variables.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -185,10 +151,8 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
               </div>
               <div class="col-md-6">
-                
               </div>
             </div>
 
@@ -234,27 +198,16 @@ When a data file is created with the name "data", it gives you access to the roo
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="associative-arrays.html">associative-arrays.html</a></li>
-            
               <li><a href="block-literals.html">block-literals.html</a></li>
-            
               <li><a href="comments.html">comments.html</a></li>
-            
               <li><a href="data-files.html">data-files.html</a></li>
-            
               <li><a href="data-types.html">data-types.html</a></li>
-            
               <li><a href="document.html">document.html</a></li>
-            
               <li><a href="lists.html">lists.html</a></li>
-            
               <li><a href="relational-trees.html">relational-trees.html</a></li>
-            
               <li><a href="underscore.html">underscore.html</a></li>
-            
               <li><a href="variables.html">variables.html</a></li>
-            
             </ul>
 
             <hr>
@@ -329,7 +282,7 @@ When a data file is created with the name "data", it gives you access to the roo
                   basename:      associative-arrays
                   ext:           .html
                   -->
-                <li><a href="block-literals.html">block-literals.html</a></li>
+<li><a href="block-literals.html">block-literals.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -361,7 +314,7 @@ When a data file is created with the name "data", it gives you access to the roo
                   basename:      block-literals
                   ext:           .html
                   -->
-                <li><a href="comments.html">comments.html</a></li>
+<li><a href="comments.html">comments.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -393,7 +346,7 @@ When a data file is created with the name "data", it gives you access to the roo
                   basename:      comments
                   ext:           .html
                   -->
-                <li><a href="data-files.html">data-files.html</a></li>
+<li><a href="data-files.html">data-files.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -425,7 +378,7 @@ When a data file is created with the name "data", it gives you access to the roo
                   basename:      data-files
                   ext:           .html
                   -->
-                <li><a href="data-types.html">data-types.html</a></li>
+<li><a href="data-types.html">data-types.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -457,7 +410,7 @@ When a data file is created with the name "data", it gives you access to the roo
                   basename:      data-types
                   ext:           .html
                   -->
-                <li><a href="document.html">document.html</a></li>
+<li><a href="document.html">document.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -489,7 +442,7 @@ When a data file is created with the name "data", it gives you access to the roo
                   basename:      document
                   ext:           .html
                   -->
-                <li><a href="lists.html">lists.html</a></li>
+<li><a href="lists.html">lists.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -521,7 +474,7 @@ When a data file is created with the name "data", it gives you access to the roo
                   basename:      lists
                   ext:           .html
                   -->
-                <li><a href="relational-trees.html">relational-trees.html</a></li>
+<li><a href="relational-trees.html">relational-trees.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -553,7 +506,7 @@ When a data file is created with the name "data", it gives you access to the roo
                   basename:      relational-trees
                   ext:           .html
                   -->
-                <li><a href="underscore.html">underscore.html</a></li>
+<li><a href="underscore.html">underscore.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -585,7 +538,7 @@ When a data file is created with the name "data", it gives you access to the roo
                   basename:      underscore
                   ext:           .html
                   -->
-                <li><a href="variables.html">variables.html</a></li>
+<li><a href="variables.html">variables.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -617,7 +570,6 @@ When a data file is created with the name "data", it gives you access to the roo
                   basename:      variables
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>

--- a/test/actual/yfm/data-types.html
+++ b/test/actual/yfm/data-types.html
@@ -20,69 +20,52 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="associative-arrays.html">First</a>
     </li>
     <li class="previous">
       <a href="data-files.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="associative-arrays.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="block-literals.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="comments.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="data-files.html">4</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="data-types.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="document.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lists.html">7</a>
     </li>
-  
     <li class="pager-middle">
       <a href="relational-trees.html">8</a>
     </li>
-  
     <li class="pager-middle">
       <a href="underscore.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="variables.html">10</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="variables.html">Last</a>
     </li>
     <li class="next">
       <a href="document.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -102,69 +85,52 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="associative-arrays.html">First</a>
     </li>
     <li class="prev">
       <a href="data-files.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="associative-arrays.html">1</a>
     </li>
-  
     <li>
       <a href="block-literals.html">2</a>
     </li>
-  
     <li>
       <a href="comments.html">3</a>
     </li>
-  
     <li>
       <a href="data-files.html">4</a>
     </li>
-  
     <li class="active">
       <a href="data-types.html">5</a>
     </li>
-  
     <li>
       <a href="document.html">6</a>
     </li>
-  
     <li>
       <a href="lists.html">7</a>
     </li>
-  
     <li>
       <a href="relational-trees.html">8</a>
     </li>
-  
     <li>
       <a href="underscore.html">9</a>
     </li>
-  
     <li>
       <a href="variables.html">10</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="document.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="variables.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -185,10 +151,8 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
               </div>
               <div class="col-md-6">
-                
               </div>
             </div>
 
@@ -202,7 +166,6 @@
 <div class="examples">
   <h4>Casting data types</h4>
   <dl class="dl-horizontal">
-    
       <dt>a.</dt> <dd>123</dd>
       <dt>b.</dt> <dd>123</dd>
       <dt>c.</dt> <dd>123</dd>
@@ -211,7 +174,6 @@
       <dt>f.</dt> <dd>Yes</dd>
       <dt>g.</dt> <dd>Yes</dd>
       <dt>h.</dt> <dd>Yes we have No bananas</dd>
-    
   </dl>
 </div>
 
@@ -219,27 +181,16 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="associative-arrays.html">associative-arrays.html</a></li>
-            
               <li><a href="block-literals.html">block-literals.html</a></li>
-            
               <li><a href="comments.html">comments.html</a></li>
-            
               <li><a href="data-files.html">data-files.html</a></li>
-            
               <li><a href="data-types.html">data-types.html</a></li>
-            
               <li><a href="document.html">document.html</a></li>
-            
               <li><a href="lists.html">lists.html</a></li>
-            
               <li><a href="relational-trees.html">relational-trees.html</a></li>
-            
               <li><a href="underscore.html">underscore.html</a></li>
-            
               <li><a href="variables.html">variables.html</a></li>
-            
             </ul>
 
             <hr>
@@ -314,7 +265,7 @@
                   basename:      associative-arrays
                   ext:           .html
                   -->
-                <li><a href="block-literals.html">block-literals.html</a></li>
+<li><a href="block-literals.html">block-literals.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -346,7 +297,7 @@
                   basename:      block-literals
                   ext:           .html
                   -->
-                <li><a href="comments.html">comments.html</a></li>
+<li><a href="comments.html">comments.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -378,7 +329,7 @@
                   basename:      comments
                   ext:           .html
                   -->
-                <li><a href="data-files.html">data-files.html</a></li>
+<li><a href="data-files.html">data-files.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -410,7 +361,7 @@
                   basename:      data-files
                   ext:           .html
                   -->
-                <li><a href="data-types.html">data-types.html</a></li>
+<li><a href="data-types.html">data-types.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -442,7 +393,7 @@
                   basename:      data-types
                   ext:           .html
                   -->
-                <li><a href="document.html">document.html</a></li>
+<li><a href="document.html">document.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -474,7 +425,7 @@
                   basename:      document
                   ext:           .html
                   -->
-                <li><a href="lists.html">lists.html</a></li>
+<li><a href="lists.html">lists.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -506,7 +457,7 @@
                   basename:      lists
                   ext:           .html
                   -->
-                <li><a href="relational-trees.html">relational-trees.html</a></li>
+<li><a href="relational-trees.html">relational-trees.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -538,7 +489,7 @@
                   basename:      relational-trees
                   ext:           .html
                   -->
-                <li><a href="underscore.html">underscore.html</a></li>
+<li><a href="underscore.html">underscore.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -570,7 +521,7 @@
                   basename:      underscore
                   ext:           .html
                   -->
-                <li><a href="variables.html">variables.html</a></li>
+<li><a href="variables.html">variables.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -602,7 +553,6 @@
                   basename:      variables
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>

--- a/test/actual/yfm/document.html
+++ b/test/actual/yfm/document.html
@@ -20,69 +20,52 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="associative-arrays.html">First</a>
     </li>
     <li class="previous">
       <a href="data-types.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="associative-arrays.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="block-literals.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="comments.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="data-files.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="data-types.html">5</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="document.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lists.html">7</a>
     </li>
-  
     <li class="pager-middle">
       <a href="relational-trees.html">8</a>
     </li>
-  
     <li class="pager-middle">
       <a href="underscore.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="variables.html">10</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="variables.html">Last</a>
     </li>
     <li class="next">
       <a href="lists.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -102,69 +85,52 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="associative-arrays.html">First</a>
     </li>
     <li class="prev">
       <a href="data-types.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="associative-arrays.html">1</a>
     </li>
-  
     <li>
       <a href="block-literals.html">2</a>
     </li>
-  
     <li>
       <a href="comments.html">3</a>
     </li>
-  
     <li>
       <a href="data-files.html">4</a>
     </li>
-  
     <li>
       <a href="data-types.html">5</a>
     </li>
-  
     <li class="active">
       <a href="document.html">6</a>
     </li>
-  
     <li>
       <a href="lists.html">7</a>
     </li>
-  
     <li>
       <a href="relational-trees.html">8</a>
     </li>
-  
     <li>
       <a href="underscore.html">9</a>
     </li>
-  
     <li>
       <a href="variables.html">10</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="lists.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="variables.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -185,10 +151,8 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
               </div>
               <div class="col-md-6">
-                
               </div>
             </div>
 
@@ -209,7 +173,7 @@
     <dd>Oz-Ware Purchase Invoice</dd>
 
     <dt>Date:</dt>
-    <dd>2007-08-05</dd>
+    <dd>2007-08-06</dd>
 
     <dt>First Name:</dt>
     <dd>Dorothy</dd>
@@ -227,7 +191,6 @@
   <h4 style="background: #eee; display: block">Order Information</h4>
   <dl class="dl-horizontal">
     <dt>Items:</dt>
-    
     <dd>
       <strong class="muted" style="border-bottom: 1px solid #ddd; display: block">Item #0</strong>
       <dl class="dl-horizontal">
@@ -241,7 +204,6 @@
         <dd> 4 </dd>
       </dl>
     </dd>
-    
     <dd>
       <strong class="muted" style="border-bottom: 1px solid #ddd; display: block">Item #1</strong>
       <dl class="dl-horizontal">
@@ -255,7 +217,6 @@
         <dd> 1 </dd>
       </dl>
     </dd>
-    
   </dl>
 </div>
 <hr>
@@ -301,27 +262,16 @@ Suite 16
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="associative-arrays.html">associative-arrays.html</a></li>
-            
               <li><a href="block-literals.html">block-literals.html</a></li>
-            
               <li><a href="comments.html">comments.html</a></li>
-            
               <li><a href="data-files.html">data-files.html</a></li>
-            
               <li><a href="data-types.html">data-types.html</a></li>
-            
               <li><a href="document.html">document.html</a></li>
-            
               <li><a href="lists.html">lists.html</a></li>
-            
               <li><a href="relational-trees.html">relational-trees.html</a></li>
-            
               <li><a href="underscore.html">underscore.html</a></li>
-            
               <li><a href="variables.html">variables.html</a></li>
-            
             </ul>
 
             <hr>
@@ -396,7 +346,7 @@ Suite 16
                   basename:      associative-arrays
                   ext:           .html
                   -->
-                <li><a href="block-literals.html">block-literals.html</a></li>
+<li><a href="block-literals.html">block-literals.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -428,7 +378,7 @@ Suite 16
                   basename:      block-literals
                   ext:           .html
                   -->
-                <li><a href="comments.html">comments.html</a></li>
+<li><a href="comments.html">comments.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -460,7 +410,7 @@ Suite 16
                   basename:      comments
                   ext:           .html
                   -->
-                <li><a href="data-files.html">data-files.html</a></li>
+<li><a href="data-files.html">data-files.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -492,7 +442,7 @@ Suite 16
                   basename:      data-files
                   ext:           .html
                   -->
-                <li><a href="data-types.html">data-types.html</a></li>
+<li><a href="data-types.html">data-types.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -524,7 +474,7 @@ Suite 16
                   basename:      data-types
                   ext:           .html
                   -->
-                <li><a href="document.html">document.html</a></li>
+<li><a href="document.html">document.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -556,7 +506,7 @@ Suite 16
                   basename:      document
                   ext:           .html
                   -->
-                <li><a href="lists.html">lists.html</a></li>
+<li><a href="lists.html">lists.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -588,7 +538,7 @@ Suite 16
                   basename:      lists
                   ext:           .html
                   -->
-                <li><a href="relational-trees.html">relational-trees.html</a></li>
+<li><a href="relational-trees.html">relational-trees.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -620,7 +570,7 @@ Suite 16
                   basename:      relational-trees
                   ext:           .html
                   -->
-                <li><a href="underscore.html">underscore.html</a></li>
+<li><a href="underscore.html">underscore.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -652,7 +602,7 @@ Suite 16
                   basename:      underscore
                   ext:           .html
                   -->
-                <li><a href="variables.html">variables.html</a></li>
+<li><a href="variables.html">variables.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -684,7 +634,6 @@ Suite 16
                   basename:      variables
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>
@@ -705,7 +654,7 @@ Suite 16
   "data": {
     "receipt": "Oz-Ware Purchase Invoice",
     "date": "2007-08-06T00:00:00.000Z",
-    "prettyDate": "2007-08-05",
+    "prettyDate": "2007-08-06",
     "customer": {
       "given": "Dorothy",
       "family": "Gale"
@@ -789,7 +738,7 @@ Suite 16
   "page": "<!DOCTYPE html>\n  <html lang=\"en\">\n  <head>\n    <meta charset=\"UTF-8\">\n    <title>Layout filename: '{{layout}}'</title>\n    <link rel=\"stylesheet\" href=\"http://getbootstrap.com/dist/css/bootstrap.min.css\">\n    <link rel=\"stylesheet\" href=\"{{assets}}/validation.css\">\n  </head>\n  <body style=\"padding-top: 60px;\">\n    <div class=\"container\">\n\n      <!-- validate assets path -->\n      <section id=\"validate\"></section>\n      <div class=\"docs-section\">\n        <div class=\"docs-header\" id=\"content\">\n          <h4><strong class=\"text-muted\">{{page.src}}</strong> &#x2192; <strong class=\"text-success\">{{page.dest}}</strong></h4>\n        </div>\n        <hr>\n      </div>\n\n      {{pager pagination}}\n      <hr>\n\n      <div class=\"row\">\n        <!-- Column: sidebar -->\n        <div class=\"col-md-3\">\n          <div class=\"bs-sidebar hidden-print\" role=\"complementary\">\n            <!-- pagination -->\n            {{nav pagination}}\n          </div>\n        </div>\n        <!-- Column: content -->\n        <div class=\"col-md-9\" role=\"main\">\n          <div class=\"docs-section\">\n            <div class=\"docs-header\" id=\"content\">\n              <h4><strong>Page layout:</strong> {{default originalLayout '(no layout defined)'}}</h4>\n              <h4><strong>Page src:</strong> {{page.src}}</h4>\n              <h4><strong>Page dest:</strong> {{page.dest}}</h4>\n              <h4><strong>Dest filename:</strong> {{page.filename}}</h4>\n              <h4><strong>Dest basename:</strong> {{page.basename}}</h4>\n              <h4><strong>Page title:</strong> {{default title '(no title defined)'}}</h4>\n            </div>\n\n            <hr>\n            <div class=\"row\">\n              <div class=\"col-md-6\">\n                <!-- Categories Collection -->\n                {{#if categories}}\n                  {{> collections-categories }}\n                {{/if}}\n              </div>\n              <div class=\"col-md-6\">\n                {{#if tags}}\n                  {{> collections-tags }}\n                {{/if}}\n              </div>\n            </div>\n\n            <hr>\n\n            \n<div class=\"page-header\">\n  <h4>{{{title}}}</h4>\n</div>\n\n\n<!-- Customer Information\n============================================ -->\n<div class=\"customer-information\">\n  <h4 style=\"background: #eee; display: block\">Customer Information</h4>\n  <dl class=\"dl-horizontal\">\n    <dt>Receipt:</dt>\n    <dd>{{receipt}}</dd>\n\n    <dt>Date:</dt>\n    <dd>{{prettyDate}}</dd>\n\n    <dt>First Name:</dt>\n    <dd>{{customer.given}}</dd>\n\n    <dt>Last Name:</dt>\n    <dd>{{customer.family}}</dd>\n  </dl>\n</div>\n\n<hr>\n\n<!-- Order Information\n============================================ -->\n<div class=\"customer-information\">\n  <h4 style=\"background: #eee; display: block\">Order Information</h4>\n  <dl class=\"dl-horizontal\">\n    <dt>Items:</dt>\n    {{#each items}}\n    <dd>\n      <strong class=\"muted\" style=\"border-bottom: 1px solid #ddd; display: block\">Item #{{@index}}</strong>\n      <dl class=\"dl-horizontal\">\n        <dt>Part No: </dt>\n        <dd> {{part_no}} </dd>\n        <dt>Description: </dt>\n        <dd> {{descrip}} </dd>\n        <dt>Price: </dt>\n        <dd> ${{price}} </dd>\n        <dt>Qty: </dt>\n        <dd> {{quantity}} </dd>\n      </dl>\n    </dd>\n    {{/each}}\n  </dl>\n</div>\n<hr>\n\n<!-- Bill To\n============================================ -->\n<div class=\"bill-to\">\n  <h4 style=\"background: #eee; display: block\">Address Information</h4>\n  <strong>Bill To:</strong>\n  <dl class=\"dl-horizontal\">\n    <dt>Billing Street: </dt>\n    <dd> {{bill-to.street}} </dd>\n    <dt>Billing City: </dt>\n    <dd> {{bill-to.city}} </dd>\n    <dt>Billing State: </dt>\n    <dd> {{bill-to.state}} </dd>\n  </dl>\n  <strong>Ship To:</strong>\n  <dl class=\"dl-horizontal\">\n    <dt>Shipping Street: </dt>\n    <dd> {{ship-to.street}} </dd>\n    <dt>Shipping City: </dt>\n    <dd> {{ship-to.city}} </dd>\n    <dt>Shipping State: </dt>\n    <dd> {{ship-to.state}} </dd>\n    </dd>\n  </dl>\n</div>\n\n<!-- Special Instructions\n============================================ -->\n<div class=\"special-instructions\" style=\"margin-bottom: 120px;\">\n  <h4 style=\"background: #eee; display: block\">Delivery Instructions</h4>\n  <p>{{{specialDelivery}}}</p>\n</div>\n\n            <div class=\"docs-header\" id=\"content\">\n              <h1>Content</h1>\n            </div>\n            <ul>\n            {{#each pages}}\n              <li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n            {{/each}}\n            </ul>\n\n            <hr>\n            <div style=\"display: none\">\n\n              <h1>Page</h1>\n              <!--\n              \"this\"\n              ===============================\n              this.src:      {{this.src}}\n              this.dest:     {{this.dest}}\n              this.layout:   {{this.layout}}\n              this.dirname:  {{this.dirname}}\n              this.filename: {{this.filename}}\n              this.pagename: {{this.pagename}}\n              this.basename: {{this.basename}}\n              this.ext:      {{this.ext}}\n\n              \"page\"\n              ===============================\n              page.src:        {{page.src}}\n              page.dest:       {{page.dest}}\n              page.layout:     {{page.layout}}\n              page.dirname:    {{page.dirname}}\n              page.filename:   {{page.filename}}\n              page.pagename:   {{page.pagename}}\n              page.basename:   {{page.basename}}\n              page.ext:        {{page.ext}}\n\n              \"root\"\n              ===============================\n              src:           {{src}}\n              dest:          {{dest}}\n              layout:        {{layout}}\n              dirname:       {{dirname}}\n              filename:      {{filename}}\n              pagename:      {{pagename}}\n              basename:      {{basename}}\n              ext:           {{ext}}\n              -->\n              <h1>Each pages</h1>\n              <ul>\n                {{#each pages}}<li><a href=\"{{relativeLink}}\">{{filename}}</a></li>\n                  <!--\n                  \"this\"\n                  ===============================\n                  this.src:      {{this.src}}\n                  this.dest:     {{this.dest}}\n                  this.dirname:  {{this.dirname}}\n                  this.filename: {{this.filename}}\n                  this.pagename: {{this.pagename}}\n                  this.basename: {{this.basename}}\n                  this.ext:      {{this.ext}}\n\n                  \"page\"\n                  ===============================\n                  page.src:      {{../page.src}}\n                  page.dest:     {{../page.dest}}\n                  page.dirname:  {{../page.dirname}}\n                  page.filename: {{../page.filename}}\n                  page.pagename: {{../page.pagename}}\n                  page.basename: {{../page.basename}}\n                  page.ext:      {{../page.ext}}\n\n                  \"root\"\n                  ===============================\n                  src:           {{src}}\n                  dest:          {{dest}}\n                  dirname:       {{dirname}}\n                  filename:      {{filename}}\n                  pagename:      {{pagename}}\n                  basename:      {{basename}}\n                  ext:           {{ext}}\n                  -->\n                {{/each}}\n              </ul>\n\n              <h1>Debug Info</h1>\n              {{{inspect page 'json'}}}\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    <script src=\"{{assets}}/validation.js\"></script>\n  </body>\n</html>\n",
   "pageName": "document.html",
   "pagename": "document.html",
-  "prettyDate": "2007-08-05",
+  "prettyDate": "2007-08-06",
   "prev": 4,
   "receipt": "Oz-Ware Purchase Invoice",
   "relativeLink": "document.html",

--- a/test/actual/yfm/lists.html
+++ b/test/actual/yfm/lists.html
@@ -20,69 +20,52 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="associative-arrays.html">First</a>
     </li>
     <li class="previous">
       <a href="document.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="associative-arrays.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="block-literals.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="comments.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="data-files.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="data-types.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="document.html">6</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="lists.html">7</a>
     </li>
-  
     <li class="pager-middle">
       <a href="relational-trees.html">8</a>
     </li>
-  
     <li class="pager-middle">
       <a href="underscore.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="variables.html">10</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="variables.html">Last</a>
     </li>
     <li class="next">
       <a href="relational-trees.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -102,69 +85,52 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="associative-arrays.html">First</a>
     </li>
     <li class="prev">
       <a href="document.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="associative-arrays.html">1</a>
     </li>
-  
     <li>
       <a href="block-literals.html">2</a>
     </li>
-  
     <li>
       <a href="comments.html">3</a>
     </li>
-  
     <li>
       <a href="data-files.html">4</a>
     </li>
-  
     <li>
       <a href="data-types.html">5</a>
     </li>
-  
     <li>
       <a href="document.html">6</a>
     </li>
-  
     <li class="active">
       <a href="lists.html">7</a>
     </li>
-  
     <li>
       <a href="relational-trees.html">8</a>
     </li>
-  
     <li>
       <a href="underscore.html">9</a>
     </li>
-  
     <li>
       <a href="variables.html">10</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="relational-trees.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="variables.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -185,10 +151,8 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
               </div>
               <div class="col-md-6">
-                
               </div>
             </div>
 
@@ -203,9 +167,8 @@
   <h4>Attributes</h4>
   <ul>
   <li>attr1</li>
-  <li>attr2</li>
-  <li>attr3</li>
-  
+<li>attr2</li>
+<li>attr3</li>
   </ul>
 </div>
 
@@ -215,8 +178,7 @@
   <h4>Methods</h4>
   <ul>
   <li>getter</li>
-  <li>setter</li>
-  
+<li>setter</li>
   </ul>
 </div>
 
@@ -226,26 +188,17 @@
   <h3>Lists</h3>
   <h4>Movies</h4>
   <dl class="dl-horizontal">
-    
       <dt>Movie:</dt> <dd>Casablanca</dd>
-    
       <dt>Movie:</dt> <dd>North by Northwest</dd>
-    
       <dt>Movie:</dt> <dd>The Man Who Wasn&#x27;t There</dd>
-    
   </dl>
 
   <h4>Groceries</h4>
   <dl class="dl-horizontal">
-    
       <dt>Item:</dt> <dd>milk</dd>
-    
       <dt>Item:</dt> <dd>pumpkin pie</dd>
-    
       <dt>Item:</dt> <dd>eggs</dd>
-    
       <dt>Item:</dt> <dd>juice</dd>
-    
   </dl>
 </div>
 
@@ -255,13 +208,10 @@
   <h3>Hierarchical combinations of elements</h3>
   <h4>Lists of associative arrays</h4>
   <dl class="dl-horizontal">
-    
       <dt>Name:</dt> <dd>John Smith</dd>
       <dt>Age:</dt>  <dd>33</dd>
-    
       <dt>Name:</dt> <dd>Mary Smith</dd>
       <dt>Age:</dt>  <dd>27</dd>
-    
   </dl>
 
   <h4>Associative arrays of lists</h4>
@@ -277,27 +227,16 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="associative-arrays.html">associative-arrays.html</a></li>
-            
               <li><a href="block-literals.html">block-literals.html</a></li>
-            
               <li><a href="comments.html">comments.html</a></li>
-            
               <li><a href="data-files.html">data-files.html</a></li>
-            
               <li><a href="data-types.html">data-types.html</a></li>
-            
               <li><a href="document.html">document.html</a></li>
-            
               <li><a href="lists.html">lists.html</a></li>
-            
               <li><a href="relational-trees.html">relational-trees.html</a></li>
-            
               <li><a href="underscore.html">underscore.html</a></li>
-            
               <li><a href="variables.html">variables.html</a></li>
-            
             </ul>
 
             <hr>
@@ -372,7 +311,7 @@
                   basename:      associative-arrays
                   ext:           .html
                   -->
-                <li><a href="block-literals.html">block-literals.html</a></li>
+<li><a href="block-literals.html">block-literals.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -404,7 +343,7 @@
                   basename:      block-literals
                   ext:           .html
                   -->
-                <li><a href="comments.html">comments.html</a></li>
+<li><a href="comments.html">comments.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -436,7 +375,7 @@
                   basename:      comments
                   ext:           .html
                   -->
-                <li><a href="data-files.html">data-files.html</a></li>
+<li><a href="data-files.html">data-files.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -468,7 +407,7 @@
                   basename:      data-files
                   ext:           .html
                   -->
-                <li><a href="data-types.html">data-types.html</a></li>
+<li><a href="data-types.html">data-types.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -500,7 +439,7 @@
                   basename:      data-types
                   ext:           .html
                   -->
-                <li><a href="document.html">document.html</a></li>
+<li><a href="document.html">document.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -532,7 +471,7 @@
                   basename:      document
                   ext:           .html
                   -->
-                <li><a href="lists.html">lists.html</a></li>
+<li><a href="lists.html">lists.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -564,7 +503,7 @@
                   basename:      lists
                   ext:           .html
                   -->
-                <li><a href="relational-trees.html">relational-trees.html</a></li>
+<li><a href="relational-trees.html">relational-trees.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -596,7 +535,7 @@
                   basename:      relational-trees
                   ext:           .html
                   -->
-                <li><a href="underscore.html">underscore.html</a></li>
+<li><a href="underscore.html">underscore.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -628,7 +567,7 @@
                   basename:      underscore
                   ext:           .html
                   -->
-                <li><a href="variables.html">variables.html</a></li>
+<li><a href="variables.html">variables.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -660,7 +599,6 @@
                   basename:      variables
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>

--- a/test/actual/yfm/relational-trees.html
+++ b/test/actual/yfm/relational-trees.html
@@ -20,69 +20,52 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="associative-arrays.html">First</a>
     </li>
     <li class="previous">
       <a href="lists.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="associative-arrays.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="block-literals.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="comments.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="data-files.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="data-types.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="document.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lists.html">7</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="relational-trees.html">8</a>
     </li>
-  
     <li class="pager-middle">
       <a href="underscore.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="variables.html">10</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="variables.html">Last</a>
     </li>
     <li class="next">
       <a href="underscore.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -102,69 +85,52 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="associative-arrays.html">First</a>
     </li>
     <li class="prev">
       <a href="lists.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="associative-arrays.html">1</a>
     </li>
-  
     <li>
       <a href="block-literals.html">2</a>
     </li>
-  
     <li>
       <a href="comments.html">3</a>
     </li>
-  
     <li>
       <a href="data-files.html">4</a>
     </li>
-  
     <li>
       <a href="data-types.html">5</a>
     </li>
-  
     <li>
       <a href="document.html">6</a>
     </li>
-  
     <li>
       <a href="lists.html">7</a>
     </li>
-  
     <li class="active">
       <a href="relational-trees.html">8</a>
     </li>
-  
     <li>
       <a href="underscore.html">9</a>
     </li>
-  
     <li>
       <a href="variables.html">10</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="underscore.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="variables.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -185,10 +151,8 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
               </div>
               <div class="col-md-6">
-                
               </div>
             </div>
 
@@ -202,115 +166,72 @@
 <div class="examples">
   <h4>Associative arrays</h4>
   <dl class="dl-horizontal">
-    
-      
         <dt>instrument</dt> 
         <dd>Lasik 2000</dd>
-      
         <dt>pulseEnergy</dt> 
         <dd>5.4</dd>
-      
         <dt>pulseDuration</dt> 
         <dd>12</dd>
-      
         <dt>repetition</dt> 
         <dd>1000</dd>
-      
         <dt>spotSize</dt> 
         <dd>1mm</dd>
-      
       <hr>
-    
-      
         <dt>instrument</dt> 
         <dd>Lasik 2000</dd>
-      
         <dt>pulseEnergy</dt> 
         <dd>5</dd>
-      
         <dt>pulseDuration</dt> 
         <dd>10</dd>
-      
         <dt>repetition</dt> 
         <dd>500</dd>
-      
         <dt>spotSize</dt> 
         <dd>2mm</dd>
-      
       <hr>
-    
-      
         <dt>instrument</dt> 
         <dd>Lasik 2000</dd>
-      
         <dt>pulseEnergy</dt> 
         <dd>5.4</dd>
-      
         <dt>pulseDuration</dt> 
         <dd>12</dd>
-      
         <dt>repetition</dt> 
         <dd>1000</dd>
-      
         <dt>spotSize</dt> 
         <dd>1mm</dd>
-      
       <hr>
-    
-      
         <dt>instrument</dt> 
         <dd>Lasik 2000</dd>
-      
         <dt>pulseEnergy</dt> 
         <dd>5</dd>
-      
         <dt>pulseDuration</dt> 
         <dd>10</dd>
-      
         <dt>repetition</dt> 
         <dd>500</dd>
-      
         <dt>spotSize</dt> 
         <dd>2mm</dd>
-      
       <hr>
-    
-      
         <dt>instrument</dt> 
         <dd>Lasik 2000</dd>
-      
         <dt>pulseEnergy</dt> 
         <dd>5.4</dd>
-      
         <dt>pulseDuration</dt> 
         <dd>12</dd>
-      
         <dt>repetition</dt> 
         <dd>1000</dd>
-      
         <dt>spotSize</dt> 
         <dd>1mm</dd>
-      
       <hr>
-    
-      
         <dt>instrument</dt> 
         <dd>Lasik 2000</dd>
-      
         <dt>pulseEnergy</dt> 
         <dd>5</dd>
-      
         <dt>pulseDuration</dt> 
         <dd>10</dd>
-      
         <dt>repetition</dt> 
         <dd>500</dd>
-      
         <dt>spotSize</dt> 
         <dd>2mm</dd>
-      
       <hr>
-    
   </dl>
 </div>
 
@@ -318,27 +239,16 @@
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="associative-arrays.html">associative-arrays.html</a></li>
-            
               <li><a href="block-literals.html">block-literals.html</a></li>
-            
               <li><a href="comments.html">comments.html</a></li>
-            
               <li><a href="data-files.html">data-files.html</a></li>
-            
               <li><a href="data-types.html">data-types.html</a></li>
-            
               <li><a href="document.html">document.html</a></li>
-            
               <li><a href="lists.html">lists.html</a></li>
-            
               <li><a href="relational-trees.html">relational-trees.html</a></li>
-            
               <li><a href="underscore.html">underscore.html</a></li>
-            
               <li><a href="variables.html">variables.html</a></li>
-            
             </ul>
 
             <hr>
@@ -413,7 +323,7 @@
                   basename:      associative-arrays
                   ext:           .html
                   -->
-                <li><a href="block-literals.html">block-literals.html</a></li>
+<li><a href="block-literals.html">block-literals.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -445,7 +355,7 @@
                   basename:      block-literals
                   ext:           .html
                   -->
-                <li><a href="comments.html">comments.html</a></li>
+<li><a href="comments.html">comments.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -477,7 +387,7 @@
                   basename:      comments
                   ext:           .html
                   -->
-                <li><a href="data-files.html">data-files.html</a></li>
+<li><a href="data-files.html">data-files.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -509,7 +419,7 @@
                   basename:      data-files
                   ext:           .html
                   -->
-                <li><a href="data-types.html">data-types.html</a></li>
+<li><a href="data-types.html">data-types.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -541,7 +451,7 @@
                   basename:      data-types
                   ext:           .html
                   -->
-                <li><a href="document.html">document.html</a></li>
+<li><a href="document.html">document.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -573,7 +483,7 @@
                   basename:      document
                   ext:           .html
                   -->
-                <li><a href="lists.html">lists.html</a></li>
+<li><a href="lists.html">lists.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -605,7 +515,7 @@
                   basename:      lists
                   ext:           .html
                   -->
-                <li><a href="relational-trees.html">relational-trees.html</a></li>
+<li><a href="relational-trees.html">relational-trees.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -637,7 +547,7 @@
                   basename:      relational-trees
                   ext:           .html
                   -->
-                <li><a href="underscore.html">underscore.html</a></li>
+<li><a href="underscore.html">underscore.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -669,7 +579,7 @@
                   basename:      underscore
                   ext:           .html
                   -->
-                <li><a href="variables.html">variables.html</a></li>
+<li><a href="variables.html">variables.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -701,7 +611,6 @@
                   basename:      variables
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>

--- a/test/actual/yfm/underscore.html
+++ b/test/actual/yfm/underscore.html
@@ -20,69 +20,52 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="associative-arrays.html">First</a>
     </li>
     <li class="previous">
       <a href="relational-trees.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="associative-arrays.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="block-literals.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="comments.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="data-files.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="data-types.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="document.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lists.html">7</a>
     </li>
-  
     <li class="pager-middle">
       <a href="relational-trees.html">8</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="underscore.html">9</a>
     </li>
-  
     <li class="pager-middle">
       <a href="variables.html">10</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="variables.html">Last</a>
     </li>
     <li class="next">
       <a href="variables.html">Next &rarr;</a>
     </li>
-  
 
-  
 
 </ul><style>
 .unselectable {
@@ -102,69 +85,52 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="associative-arrays.html">First</a>
     </li>
     <li class="prev">
       <a href="relational-trees.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="associative-arrays.html">1</a>
     </li>
-  
     <li>
       <a href="block-literals.html">2</a>
     </li>
-  
     <li>
       <a href="comments.html">3</a>
     </li>
-  
     <li>
       <a href="data-files.html">4</a>
     </li>
-  
     <li>
       <a href="data-types.html">5</a>
     </li>
-  
     <li>
       <a href="document.html">6</a>
     </li>
-  
     <li>
       <a href="lists.html">7</a>
     </li>
-  
     <li>
       <a href="relational-trees.html">8</a>
     </li>
-  
     <li class="active">
       <a href="underscore.html">9</a>
     </li>
-  
     <li>
       <a href="variables.html">10</a>
     </li>
-  
 
-  
     <li class="next">
       <a href="variables.html">Next &rarr;</a>
     </li>
     <li class="next">
       <a href="variables.html">Last</a>
     </li>
-  
 
-  
 
 </ul>
           </div>
@@ -185,10 +151,8 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
               </div>
               <div class="col-md-6">
-                
               </div>
             </div>
 
@@ -244,27 +208,16 @@ When a data file is created with the name "data", it gives you access to the roo
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="associative-arrays.html">associative-arrays.html</a></li>
-            
               <li><a href="block-literals.html">block-literals.html</a></li>
-            
               <li><a href="comments.html">comments.html</a></li>
-            
               <li><a href="data-files.html">data-files.html</a></li>
-            
               <li><a href="data-types.html">data-types.html</a></li>
-            
               <li><a href="document.html">document.html</a></li>
-            
               <li><a href="lists.html">lists.html</a></li>
-            
               <li><a href="relational-trees.html">relational-trees.html</a></li>
-            
               <li><a href="underscore.html">underscore.html</a></li>
-            
               <li><a href="variables.html">variables.html</a></li>
-            
             </ul>
 
             <hr>
@@ -339,7 +292,7 @@ When a data file is created with the name "data", it gives you access to the roo
                   basename:      associative-arrays
                   ext:           .html
                   -->
-                <li><a href="block-literals.html">block-literals.html</a></li>
+<li><a href="block-literals.html">block-literals.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -371,7 +324,7 @@ When a data file is created with the name "data", it gives you access to the roo
                   basename:      block-literals
                   ext:           .html
                   -->
-                <li><a href="comments.html">comments.html</a></li>
+<li><a href="comments.html">comments.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -403,7 +356,7 @@ When a data file is created with the name "data", it gives you access to the roo
                   basename:      comments
                   ext:           .html
                   -->
-                <li><a href="data-files.html">data-files.html</a></li>
+<li><a href="data-files.html">data-files.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -435,7 +388,7 @@ When a data file is created with the name "data", it gives you access to the roo
                   basename:      data-files
                   ext:           .html
                   -->
-                <li><a href="data-types.html">data-types.html</a></li>
+<li><a href="data-types.html">data-types.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -467,7 +420,7 @@ When a data file is created with the name "data", it gives you access to the roo
                   basename:      data-types
                   ext:           .html
                   -->
-                <li><a href="document.html">document.html</a></li>
+<li><a href="document.html">document.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -499,7 +452,7 @@ When a data file is created with the name "data", it gives you access to the roo
                   basename:      document
                   ext:           .html
                   -->
-                <li><a href="lists.html">lists.html</a></li>
+<li><a href="lists.html">lists.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -531,7 +484,7 @@ When a data file is created with the name "data", it gives you access to the roo
                   basename:      lists
                   ext:           .html
                   -->
-                <li><a href="relational-trees.html">relational-trees.html</a></li>
+<li><a href="relational-trees.html">relational-trees.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -563,7 +516,7 @@ When a data file is created with the name "data", it gives you access to the roo
                   basename:      relational-trees
                   ext:           .html
                   -->
-                <li><a href="underscore.html">underscore.html</a></li>
+<li><a href="underscore.html">underscore.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -595,7 +548,7 @@ When a data file is created with the name "data", it gives you access to the roo
                   basename:      underscore
                   ext:           .html
                   -->
-                <li><a href="variables.html">variables.html</a></li>
+<li><a href="variables.html">variables.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -627,7 +580,6 @@ When a data file is created with the name "data", it gives you access to the roo
                   basename:      variables
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>

--- a/test/actual/yfm/variables.html
+++ b/test/actual/yfm/variables.html
@@ -20,69 +20,52 @@
 
       <ul class="pager">
 
-  
 
-  
     <li class="previous">
       <a href="associative-arrays.html">First</a>
     </li>
     <li class="previous">
       <a href="underscore.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li class="pager-middle">
       <a href="associative-arrays.html">1</a>
     </li>
-  
     <li class="pager-middle">
       <a href="block-literals.html">2</a>
     </li>
-  
     <li class="pager-middle">
       <a href="comments.html">3</a>
     </li>
-  
     <li class="pager-middle">
       <a href="data-files.html">4</a>
     </li>
-  
     <li class="pager-middle">
       <a href="data-types.html">5</a>
     </li>
-  
     <li class="pager-middle">
       <a href="document.html">6</a>
     </li>
-  
     <li class="pager-middle">
       <a href="lists.html">7</a>
     </li>
-  
     <li class="pager-middle">
       <a href="relational-trees.html">8</a>
     </li>
-  
     <li class="pager-middle">
       <a href="underscore.html">9</a>
     </li>
-  
     <li class="active pager-middle">
       <a href="variables.html">10</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
-  
 
 </ul><style>
 .unselectable {
@@ -102,69 +85,52 @@
             <!-- pagination -->
             <ul class="nav nav-pills nav-stacked">
 
-  
 
-  
     <li class="prev">
       <a href="associative-arrays.html">First</a>
     </li>
     <li class="prev">
       <a href="underscore.html">&larr; Previous</a>
     </li>
-  
 
-  
     <li>
       <a href="associative-arrays.html">1</a>
     </li>
-  
     <li>
       <a href="block-literals.html">2</a>
     </li>
-  
     <li>
       <a href="comments.html">3</a>
     </li>
-  
     <li>
       <a href="data-files.html">4</a>
     </li>
-  
     <li>
       <a href="data-types.html">5</a>
     </li>
-  
     <li>
       <a href="document.html">6</a>
     </li>
-  
     <li>
       <a href="lists.html">7</a>
     </li>
-  
     <li>
       <a href="relational-trees.html">8</a>
     </li>
-  
     <li>
       <a href="underscore.html">9</a>
     </li>
-  
     <li class="active">
       <a href="variables.html">10</a>
     </li>
-  
 
-  
 
-  
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Next &rarr;</a>
     </li>
     <li class="next disabled">
       <a unselectable="on" class="unselectable">Last</a>
     </li>
-  
 
 </ul>
           </div>
@@ -185,10 +151,8 @@
             <div class="row">
               <div class="col-md-6">
                 <!-- Categories Collection -->
-                
               </div>
               <div class="col-md-6">
-                
               </div>
             </div>
 
@@ -212,32 +176,20 @@ other_thing: *NAME</code></pre>
 <p>Parses to:</p>
 <pre><code class="language-json">{"<span class="attribute">other_thing</span>": <span class="value"><span class="string">"foobar"</span></span>, "<span class="attribute">some_thing</span>": <span class="value"><span class="string">"foobar"</span></span>}</code></pre>
 
-
             <div class="docs-header" id="content">
               <h1>Content</h1>
             </div>
             <ul>
-            
               <li><a href="associative-arrays.html">associative-arrays.html</a></li>
-            
               <li><a href="block-literals.html">block-literals.html</a></li>
-            
               <li><a href="comments.html">comments.html</a></li>
-            
               <li><a href="data-files.html">data-files.html</a></li>
-            
               <li><a href="data-types.html">data-types.html</a></li>
-            
               <li><a href="document.html">document.html</a></li>
-            
               <li><a href="lists.html">lists.html</a></li>
-            
               <li><a href="relational-trees.html">relational-trees.html</a></li>
-            
               <li><a href="underscore.html">underscore.html</a></li>
-            
               <li><a href="variables.html">variables.html</a></li>
-            
             </ul>
 
             <hr>
@@ -312,7 +264,7 @@ other_thing: *NAME</code></pre>
                   basename:      associative-arrays
                   ext:           .html
                   -->
-                <li><a href="block-literals.html">block-literals.html</a></li>
+<li><a href="block-literals.html">block-literals.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -344,7 +296,7 @@ other_thing: *NAME</code></pre>
                   basename:      block-literals
                   ext:           .html
                   -->
-                <li><a href="comments.html">comments.html</a></li>
+<li><a href="comments.html">comments.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -376,7 +328,7 @@ other_thing: *NAME</code></pre>
                   basename:      comments
                   ext:           .html
                   -->
-                <li><a href="data-files.html">data-files.html</a></li>
+<li><a href="data-files.html">data-files.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -408,7 +360,7 @@ other_thing: *NAME</code></pre>
                   basename:      data-files
                   ext:           .html
                   -->
-                <li><a href="data-types.html">data-types.html</a></li>
+<li><a href="data-types.html">data-types.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -440,7 +392,7 @@ other_thing: *NAME</code></pre>
                   basename:      data-types
                   ext:           .html
                   -->
-                <li><a href="document.html">document.html</a></li>
+<li><a href="document.html">document.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -472,7 +424,7 @@ other_thing: *NAME</code></pre>
                   basename:      document
                   ext:           .html
                   -->
-                <li><a href="lists.html">lists.html</a></li>
+<li><a href="lists.html">lists.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -504,7 +456,7 @@ other_thing: *NAME</code></pre>
                   basename:      lists
                   ext:           .html
                   -->
-                <li><a href="relational-trees.html">relational-trees.html</a></li>
+<li><a href="relational-trees.html">relational-trees.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -536,7 +488,7 @@ other_thing: *NAME</code></pre>
                   basename:      relational-trees
                   ext:           .html
                   -->
-                <li><a href="underscore.html">underscore.html</a></li>
+<li><a href="underscore.html">underscore.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -568,7 +520,7 @@ other_thing: *NAME</code></pre>
                   basename:      underscore
                   ext:           .html
                   -->
-                <li><a href="variables.html">variables.html</a></li>
+<li><a href="variables.html">variables.html</a></li>
                   <!--
                   "this"
                   ===============================
@@ -600,7 +552,6 @@ other_thing: *NAME</code></pre>
                   basename:      variables
                   ext:           .html
                   -->
-                
               </ul>
 
               <h1>Debug Info</h1>

--- a/test/fixtures/pages/no-yfm-data.hbs
+++ b/test/fixtures/pages/no-yfm-data.hbs
@@ -1,0 +1,8 @@
+There is no YAML front matter in this page.
+
+<ul>
+  <li>{{one}}</li>
+  <li>{{two}}</li>
+  <li>{{three}}</li>
+  <li>{{global1}}</li>
+</ul>


### PR DESCRIPTION
This pull request fixes the issue described in #28 

With this changes it's possible to pass data (as an object) globally. The data object will be merged with the options.data from the task definition (can also be an object or paths to JSON/YFM files).

I added sample data to the global options  and created "noyfmdata" and "noyfmdatafile" tasks. Both won't work with the current implementation.