### PR TITLE
Fixed: Warning: flatten is not a function Use --force to continue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "gray-matter": "^0.4.2",
     "inflection": "^1.3.6",
     "lodash": "^2.4.1",
-    "resolve-dep": "^0.5.3"
+    "resolve-dep": "^0.6.0"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
The reason for this version change is due to how a sub-sub-dependency has changed.

`resolve-dep:  0.5.3` has a has a dependency of `arrayify-compact` which in turn has a dependency on `arrayify-compact: ^0.1.0` which in turn has a dependency on `array-flatten: >= 0.0.2`.

array-flatten published a new major version today breaking our build.

`resolve-dep:  0.6.0` has a dependency of `arrayify-compact: ^0.2.0` which in turn has a dependency on `arr-flatten: ^1.0.1` which solves the build issue I was getting.